### PR TITLE
Add external image data access layer

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageAlbumDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageAlbumDao.java
@@ -1,0 +1,65 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import io.legohunter.data.mybatis.mapper.ExternalImageAlbumMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ExternalImageAlbumDao {
+    private final ExternalImageAlbumMapper externalImageAlbumMapper;
+
+    public Set<ExternalImageAlbum> findAll() {
+        return externalImageAlbumMapper.findAll();
+    }
+
+    public Optional<ExternalImageAlbum> findByExternalImageAlbumId(Long externalImageAlbumId) {
+        return externalImageAlbumMapper.findByExternalImageAlbumId(externalImageAlbumId);
+    }
+
+    public Optional<ExternalImageAlbum> findByExternalServiceIdAndItemInventoryId(Integer externalServiceId, Integer itemInventoryId) {
+        return externalImageAlbumMapper.findByExternalServiceIdAndItemInventoryId(externalServiceId, itemInventoryId);
+    }
+
+    public Optional<ExternalImageAlbum> findByExternalServiceIdAndExternalAlbumId(Integer externalServiceId, String externalAlbumId) {
+        return externalImageAlbumMapper.findByExternalServiceIdAndExternalAlbumId(externalServiceId, externalAlbumId);
+    }
+
+    public Set<ExternalImageAlbum> findBySyncStatus(ExternalSyncStatus syncStatus) {
+        return externalImageAlbumMapper.findBySyncStatus(syncStatus);
+    }
+
+    public ExternalImageAlbum insert(ExternalImageAlbum externalImageAlbum) {
+        externalImageAlbumMapper.insert(externalImageAlbum);
+        return externalImageAlbum;
+    }
+
+    public int update(ExternalImageAlbum externalImageAlbum) {
+        return externalImageAlbumMapper.update(externalImageAlbum);
+    }
+
+    public ExternalImageAlbum upsert(ExternalImageAlbum externalImageAlbum) {
+        externalImageAlbumMapper.upsert(externalImageAlbum);
+        return externalImageAlbum;
+    }
+
+    public int deleteByExternalImageAlbumId(Long externalImageAlbumId) {
+        return externalImageAlbumMapper.deleteByExternalImageAlbumId(externalImageAlbumId);
+    }
+
+    public int deleteByExternalServiceIdAndItemInventoryId(Integer externalServiceId, Integer itemInventoryId) {
+        return externalImageAlbumMapper.deleteByExternalServiceIdAndItemInventoryId(externalServiceId, itemInventoryId);
+    }
+
+    public ExternalImageAlbum findOrCreateForItem(ExternalImageAlbum externalImageAlbum) {
+        return findByExternalServiceIdAndItemInventoryId(
+                externalImageAlbum.getExternalServiceId(),
+                externalImageAlbum.getItemInventoryId()
+        ).orElseGet(() -> insert(externalImageAlbum));
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageAlbumImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageAlbumImageDao.java
@@ -1,0 +1,74 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ExternalImageAlbumImage;
+import io.legohunter.data.mybatis.mapper.ExternalImageAlbumImageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ExternalImageAlbumImageDao {
+    private final ExternalImageAlbumImageMapper externalImageAlbumImageMapper;
+
+    public Set<ExternalImageAlbumImage> findAll() {
+        return externalImageAlbumImageMapper.findAll();
+    }
+
+    public Optional<ExternalImageAlbumImage> findByExternalImageAlbumIdAndExternalImageId(Long externalImageAlbumId, Long externalImageId) {
+        return externalImageAlbumImageMapper.findByExternalImageAlbumIdAndExternalImageId(externalImageAlbumId, externalImageId);
+    }
+
+    public Set<ExternalImageAlbumImage> findByExternalImageAlbumId(Long externalImageAlbumId) {
+        return externalImageAlbumImageMapper.findByExternalImageAlbumId(externalImageAlbumId);
+    }
+
+    public Set<ExternalImageAlbumImage> findByExternalImageId(Long externalImageId) {
+        return externalImageAlbumImageMapper.findByExternalImageId(externalImageId);
+    }
+
+    public Optional<ExternalImageAlbumImage> findPrimaryByExternalImageAlbumId(Long externalImageAlbumId) {
+        return externalImageAlbumImageMapper.findPrimaryByExternalImageAlbumId(externalImageAlbumId);
+    }
+
+    public ExternalImageAlbumImage insert(ExternalImageAlbumImage externalImageAlbumImage) {
+        externalImageAlbumImageMapper.insert(externalImageAlbumImage);
+        return externalImageAlbumImage;
+    }
+
+    public int update(ExternalImageAlbumImage externalImageAlbumImage) {
+        return externalImageAlbumImageMapper.update(externalImageAlbumImage);
+    }
+
+    public ExternalImageAlbumImage upsert(ExternalImageAlbumImage externalImageAlbumImage) {
+        externalImageAlbumImageMapper.upsert(externalImageAlbumImage);
+        return externalImageAlbumImage;
+    }
+
+    public int clearPrimaryForExternalImageAlbum(Long externalImageAlbumId) {
+        return externalImageAlbumImageMapper.clearPrimaryForExternalImageAlbum(externalImageAlbumId);
+    }
+
+    public int deleteByExternalImageAlbumIdAndExternalImageId(Long externalImageAlbumId, Long externalImageId) {
+        return externalImageAlbumImageMapper.deleteByExternalImageAlbumIdAndExternalImageId(externalImageAlbumId, externalImageId);
+    }
+
+    public int deleteByExternalImageAlbumId(Long externalImageAlbumId) {
+        return externalImageAlbumImageMapper.deleteByExternalImageAlbumId(externalImageAlbumId);
+    }
+
+    public int deleteByExternalImageId(Long externalImageId) {
+        return externalImageAlbumImageMapper.deleteByExternalImageId(externalImageId);
+    }
+
+    public void setPrimaryImage(Long externalImageAlbumId, Long externalImageId) {
+        clearPrimaryForExternalImageAlbum(externalImageAlbumId);
+        upsert(ExternalImageAlbumImage.builder()
+                .externalImageAlbumId(externalImageAlbumId)
+                .externalImageId(externalImageId)
+                .primary(true)
+                .build());
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
@@ -1,0 +1,69 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ExternalImageDao {
+    private final ExternalImageMapper externalImageMapper;
+
+    public Set<ExternalImage> findAll() {
+        return externalImageMapper.findAll();
+    }
+
+    public Optional<ExternalImage> findByExternalImageId(Long externalImageId) {
+        return externalImageMapper.findByExternalImageId(externalImageId);
+    }
+
+    public Optional<ExternalImage> findByExternalServiceIdAndItemInventoryPhotoId(Integer externalServiceId, Integer itemInventoryPhotoId) {
+        return externalImageMapper.findByExternalServiceIdAndItemInventoryPhotoId(externalServiceId, itemInventoryPhotoId);
+    }
+
+    public Optional<ExternalImage> findByExternalServiceIdAndExternalServiceImageId(Integer externalServiceId, String externalServiceImageId) {
+        return externalImageMapper.findByExternalServiceIdAndExternalServiceImageId(externalServiceId, externalServiceImageId);
+    }
+
+    public Set<ExternalImage> findByItemInventoryPhotoId(Integer itemInventoryPhotoId) {
+        return externalImageMapper.findByItemInventoryPhotoId(itemInventoryPhotoId);
+    }
+
+    public Set<ExternalImage> findBySyncStatus(ExternalSyncStatus syncStatus) {
+        return externalImageMapper.findBySyncStatus(syncStatus);
+    }
+
+    public ExternalImage insert(ExternalImage externalImage) {
+        externalImageMapper.insert(externalImage);
+        return externalImage;
+    }
+
+    public int update(ExternalImage externalImage) {
+        return externalImageMapper.update(externalImage);
+    }
+
+    public ExternalImage upsert(ExternalImage externalImage) {
+        externalImageMapper.upsert(externalImage);
+        return externalImage;
+    }
+
+    public int deleteByExternalImageId(Long externalImageId) {
+        return externalImageMapper.deleteByExternalImageId(externalImageId);
+    }
+
+    public int deleteByExternalServiceIdAndItemInventoryPhotoId(Integer externalServiceId, Integer itemInventoryPhotoId) {
+        return externalImageMapper.deleteByExternalServiceIdAndItemInventoryPhotoId(externalServiceId, itemInventoryPhotoId);
+    }
+
+    public boolean hasUploadedMd5(Integer externalServiceId, Integer itemInventoryPhotoId, String md5) {
+        return findByExternalServiceIdAndItemInventoryPhotoId(externalServiceId, itemInventoryPhotoId)
+                .map(ExternalImage::getMd5AtUpload)
+                .filter(md5::equals)
+                .isPresent();
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoTest.java
@@ -1,0 +1,231 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.config.LegoDataDaoConfiguration;
+import io.legohunter.data.config.MyBatisV2Configuration;
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.dto.ExternalImageAlbumImage;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ExternalServiceType;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryPhoto;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import io.legohunter.data.enums.PhotoStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@Import({MyBatisV2Configuration.class, LegoDataDaoConfiguration.class})
+@Sql(scripts = "/scripts/db/h2/current_schema.ddl")
+class ExternalImageDaoTest {
+
+    @Autowired ExternalImageAlbumDao externalImageAlbumDao;
+    @Autowired ExternalImageDao externalImageDao;
+    @Autowired ExternalImageAlbumImageDao externalImageAlbumImageDao;
+    @Autowired ExternalServiceTypeDao externalServiceTypeDao;
+    @Autowired ExternalServiceDao externalServiceDao;
+    @Autowired ItemInventoryDao itemInventoryDao;
+    @Autowired ItemInventoryPhotoDao itemInventoryPhotoDao;
+
+    @Test
+    void externalImageAlbumDaoExposesCrudUpsertAndFindOrCreateOperations() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-dao-album");
+        ExternalImageAlbum album = externalImageAlbum(itemInventory.getItemInventoryId(), "album-dao");
+
+        assertThat(externalImageAlbumDao.insert(album).getExternalImageAlbumId()).isNotNull();
+        assertThat(externalImageAlbumDao.findAll()).hasSize(1);
+        assertThat(externalImageAlbumDao.findByExternalImageAlbumId(album.getExternalImageAlbumId())).isPresent();
+        assertThat(externalImageAlbumDao.findByExternalServiceIdAndItemInventoryId(10, itemInventory.getItemInventoryId())).isPresent();
+        assertThat(externalImageAlbumDao.findByExternalServiceIdAndExternalAlbumId(10, "album-dao")).isPresent();
+        assertThat(externalImageAlbumDao.findBySyncStatus(ExternalSyncStatus.PENDING)).hasSize(1);
+
+        album.setShortUrl("https://short.example/updated");
+        album.setSyncStatus(ExternalSyncStatus.SYNCED);
+        assertThat(externalImageAlbumDao.update(album)).isOne();
+        assertThat(externalImageAlbumDao.findByExternalImageAlbumId(album.getExternalImageAlbumId()))
+                .hasValueSatisfying(found -> assertThat(found.getShortUrl()).isEqualTo("https://short.example/updated"));
+
+        externalImageAlbumDao.upsert(ExternalImageAlbum.builder()
+                .externalServiceId(10)
+                .itemInventoryId(itemInventory.getItemInventoryId())
+                .externalAlbumId("album-dao-upsert")
+                .title("Upserted")
+                .albumUrl("https://photos.example/upsert")
+                .shortUrl("https://short.example/upsert")
+                .syncStatus(ExternalSyncStatus.FAILED)
+                .build());
+        assertThat(externalImageAlbumDao.findByExternalServiceIdAndItemInventoryId(10, itemInventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalAlbumId()).isEqualTo("album-dao-upsert"));
+
+        ExternalImageAlbum existing = externalImageAlbumDao.findOrCreateForItem(externalImageAlbum(itemInventory.getItemInventoryId(), "ignored"));
+        assertThat(existing.getExternalImageAlbumId()).isEqualTo(album.getExternalImageAlbumId());
+
+        ItemInventory secondItemInventory = insertItemInventory("uuid-dao-album-new");
+        ExternalImageAlbum created = externalImageAlbumDao.findOrCreateForItem(externalImageAlbum(secondItemInventory.getItemInventoryId(), "album-created"));
+        assertThat(created.getExternalImageAlbumId()).isNotNull();
+
+        assertThat(externalImageAlbumDao.deleteByExternalServiceIdAndItemInventoryId(10, secondItemInventory.getItemInventoryId())).isOne();
+        assertThat(externalImageAlbumDao.deleteByExternalImageAlbumId(album.getExternalImageAlbumId())).isOne();
+    }
+
+    @Test
+    void externalImageDaoExposesCrudUpsertAndMd5ComparisonOperations() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-dao-image");
+        ItemInventoryPhoto photo = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        ExternalImage image = externalImage(photo.getItemInventoryPhotoId(), "image-dao", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        assertThat(externalImageDao.insert(image).getExternalImageId()).isNotNull();
+        assertThat(externalImageDao.findAll()).hasSize(1);
+        assertThat(externalImageDao.findByExternalImageId(image.getExternalImageId())).isPresent();
+        assertThat(externalImageDao.findByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId())).isPresent();
+        assertThat(externalImageDao.findByExternalServiceIdAndExternalServiceImageId(10, "image-dao")).isPresent();
+        assertThat(externalImageDao.findByItemInventoryPhotoId(photo.getItemInventoryPhotoId())).hasSize(1);
+        assertThat(externalImageDao.findBySyncStatus(ExternalSyncStatus.PENDING)).hasSize(1);
+        assertThat(externalImageDao.hasUploadedMd5(10, photo.getItemInventoryPhotoId(), "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")).isTrue();
+        assertThat(externalImageDao.hasUploadedMd5(10, photo.getItemInventoryPhotoId(), "ffffffffffffffffffffffffffffffff")).isFalse();
+
+        image.setMd5AtUpload("ffffffffffffffffffffffffffffffff");
+        image.setSyncStatus(ExternalSyncStatus.SYNCED);
+        assertThat(externalImageDao.update(image)).isOne();
+        assertThat(externalImageDao.findByExternalImageId(image.getExternalImageId()))
+                .hasValueSatisfying(found -> assertThat(found.getMd5AtUpload()).isEqualTo("ffffffffffffffffffffffffffffffff"));
+
+        externalImageDao.upsert(ExternalImage.builder()
+                .externalServiceId(10)
+                .itemInventoryPhotoId(photo.getItemInventoryPhotoId())
+                .externalServiceImageId("image-dao-upsert")
+                .title("Upserted")
+                .imageUrl("https://photos.example/images/upsert")
+                .md5AtUpload("11111111111111111111111111111111")
+                .syncStatus(ExternalSyncStatus.FAILED)
+                .build());
+        assertThat(externalImageDao.findByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalServiceImageId()).isEqualTo("image-dao-upsert"));
+
+        assertThat(externalImageDao.deleteByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId())).isOne();
+        externalImageDao.insert(image);
+        assertThat(externalImageDao.deleteByExternalImageId(image.getExternalImageId())).isOne();
+    }
+
+    @Test
+    void externalImageAlbumImageDaoExposesCrudUpsertPrimaryAndDeleteOperations() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-dao-membership");
+        ItemInventoryPhoto firstPhoto = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "12121212121212121212121212121212");
+        ItemInventoryPhoto secondPhoto = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "34343434343434343434343434343434");
+        ExternalImageAlbum album = externalImageAlbumDao.insert(externalImageAlbum(itemInventory.getItemInventoryId(), "album-membership-dao"));
+        ExternalImage firstImage = externalImageDao.insert(externalImage(firstPhoto.getItemInventoryPhotoId(), "image-first-dao", "12121212121212121212121212121212"));
+        ExternalImage secondImage = externalImageDao.insert(externalImage(secondPhoto.getItemInventoryPhotoId(), "image-second-dao", "34343434343434343434343434343434"));
+        ExternalImageAlbumImage firstMembership = externalImageAlbumImage(album.getExternalImageAlbumId(), firstImage.getExternalImageId(), 1, true);
+
+        externalImageAlbumImageDao.insert(firstMembership);
+        assertThat(externalImageAlbumImageDao.findAll()).hasSize(1);
+        assertThat(externalImageAlbumImageDao.findByExternalImageAlbumIdAndExternalImageId(album.getExternalImageAlbumId(), firstImage.getExternalImageId())).isPresent();
+        assertThat(externalImageAlbumImageDao.findByExternalImageAlbumId(album.getExternalImageAlbumId())).hasSize(1);
+        assertThat(externalImageAlbumImageDao.findByExternalImageId(firstImage.getExternalImageId())).hasSize(1);
+        assertThat(externalImageAlbumImageDao.findPrimaryByExternalImageAlbumId(album.getExternalImageAlbumId())).isPresent();
+
+        firstMembership.setPrimary(false);
+        firstMembership.setSortOrder(2);
+        assertThat(externalImageAlbumImageDao.update(firstMembership)).isOne();
+        assertThat(externalImageAlbumImageDao.clearPrimaryForExternalImageAlbum(album.getExternalImageAlbumId())).isOne();
+
+        ExternalImageAlbumImage secondMembership = externalImageAlbumImage(album.getExternalImageAlbumId(), secondImage.getExternalImageId(), 3, false);
+        externalImageAlbumImageDao.upsert(secondMembership);
+        externalImageAlbumImageDao.setPrimaryImage(album.getExternalImageAlbumId(), secondImage.getExternalImageId());
+        assertThat(externalImageAlbumImageDao.findPrimaryByExternalImageAlbumId(album.getExternalImageAlbumId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalImageId()).isEqualTo(secondImage.getExternalImageId()));
+
+        assertThat(externalImageAlbumImageDao.deleteByExternalImageAlbumIdAndExternalImageId(album.getExternalImageAlbumId(), firstImage.getExternalImageId())).isOne();
+        assertThat(externalImageAlbumImageDao.deleteByExternalImageId(secondImage.getExternalImageId())).isOne();
+        externalImageAlbumImageDao.insert(secondMembership);
+        assertThat(externalImageAlbumImageDao.deleteByExternalImageAlbumId(album.getExternalImageAlbumId())).isOne();
+    }
+
+    private void insertImageHostingService() {
+        externalServiceTypeDao.insert(ExternalServiceType.builder()
+                .externalServiceTypeId(5)
+                .externalServiceTypeName("IMAGE_HOSTING")
+                .externalServiceTypeDescription("Image Hosting Service")
+                .build());
+        ExternalService service = new ExternalService();
+        service.setExternalServiceId(10);
+        service.setExternalServiceName("Flickr");
+        service.setExternalServiceUrl("https://www.flickr.com");
+        service.setExternalServiceTypeId(5);
+        externalServiceDao.insert(service);
+    }
+
+    private ItemInventory insertItemInventory(String uuid) {
+        ItemInventory itemInventory = new ItemInventory();
+        itemInventory.setUuid(uuid);
+        itemInventory.setDescription("Inventory " + uuid);
+        itemInventory.setActive(true);
+        itemInventory.setForSale(false);
+        itemInventoryDao.insert(itemInventory);
+        return itemInventory;
+    }
+
+    private ItemInventoryPhoto insertItemInventoryPhoto(Integer itemInventoryId, String md5) {
+        return itemInventoryPhotoDao.insertPhoto(
+                itemInventoryId,
+                md5,
+                md5 + ".jpg",
+                "lego-photos-sandbox",
+                "3001/uuid/" + md5 + ".jpg",
+                1000L,
+                false,
+                PhotoStatus.PROCESSED
+        );
+    }
+
+    private ExternalImageAlbum externalImageAlbum(Integer itemInventoryId, String externalAlbumId) {
+        return ExternalImageAlbum.builder()
+                .externalServiceId(10)
+                .itemInventoryId(itemInventoryId)
+                .externalAlbumId(externalAlbumId)
+                .title("3001-1 [uuid]")
+                .albumUrl("https://photos.example/albums/" + externalAlbumId)
+                .shortUrl("https://short.example/" + externalAlbumId)
+                .syncStatus(ExternalSyncStatus.PENDING)
+                .build();
+    }
+
+    private ExternalImage externalImage(Integer itemInventoryPhotoId, String externalServiceImageId, String md5) {
+        return ExternalImage.builder()
+                .externalServiceId(10)
+                .itemInventoryPhotoId(itemInventoryPhotoId)
+                .externalServiceImageId(externalServiceImageId)
+                .title("3001-1 [uuid]")
+                .imageUrl("https://photos.example/images/" + externalServiceImageId)
+                .md5AtUpload(md5)
+                .syncStatus(ExternalSyncStatus.PENDING)
+                .build();
+    }
+
+    private ExternalImageAlbumImage externalImageAlbumImage(Long externalImageAlbumId, Long externalImageId, int sortOrder, boolean primary) {
+        return ExternalImageAlbumImage.builder()
+                .externalImageAlbumId(externalImageAlbumId)
+                .externalImageId(externalImageId)
+                .sortOrder(sortOrder)
+                .primary(primary)
+                .build();
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    @PropertySource("application.properties")
+    static class DaoConfiguration {
+    }
+}

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -1,6 +1,9 @@
 DROP TABLE IF EXISTS bricklink_item_inventory;
 DROP TABLE IF EXISTS external_item_inventory;
 DROP TABLE IF EXISTS external_service_item;
+DROP TABLE IF EXISTS external_image_album_image;
+DROP TABLE IF EXISTS external_image;
+DROP TABLE IF EXISTS external_image_album;
 DROP TABLE IF EXISTS item_inventory_photo;
 DROP TABLE IF EXISTS transaction_item_cost;
 DROP TABLE IF EXISTS transaction_cost;
@@ -187,6 +190,51 @@ CREATE TABLE item_inventory_photo (
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
     uploaded_at TIMESTAMP
+);
+
+CREATE TABLE external_image_album (
+    external_image_album_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_id INT NOT NULL,
+    external_album_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    album_url VARCHAR(1024),
+    short_url VARCHAR(1024),
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_id),
+    UNIQUE (external_service_id, external_album_id)
+);
+
+CREATE TABLE external_image (
+    external_image_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_photo_id INT NOT NULL,
+    external_service_image_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    image_url VARCHAR(1024),
+    md5_at_upload CHAR(32) NOT NULL,
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    uploaded_at TIMESTAMP,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_photo_id),
+    UNIQUE (external_service_id, external_service_image_id)
+);
+
+CREATE TABLE external_image_album_image (
+    external_image_album_id BIGINT NOT NULL,
+    external_image_id BIGINT NOT NULL,
+    sort_order INT,
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (external_image_album_id, external_image_id)
 );
 
 CREATE TABLE party (

--- a/lego-data-dao/src/test/resources/scripts/db/h2/external_image_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/external_image_schema.ddl
@@ -1,0 +1,97 @@
+DROP TABLE IF EXISTS external_image_album_image;
+DROP TABLE IF EXISTS external_image;
+DROP TABLE IF EXISTS external_image_album;
+DROP TABLE IF EXISTS item_inventory_photo;
+DROP TABLE IF EXISTS item_inventory;
+DROP TABLE IF EXISTS external_service;
+DROP TABLE IF EXISTS external_service_type;
+
+CREATE TABLE external_service_type (
+    external_service_type_id INT PRIMARY KEY,
+    external_service_type_name VARCHAR(255) UNIQUE,
+    external_service_type_description VARCHAR(1024)
+);
+
+CREATE TABLE external_service (
+    external_service_id INT PRIMARY KEY,
+    external_service_name VARCHAR(255) UNIQUE,
+    external_service_url VARCHAR(1024),
+    external_service_type_id INT
+);
+
+CREATE TABLE item_inventory (
+    item_inventory_id INT AUTO_INCREMENT PRIMARY KEY,
+    uuid VARCHAR(64) UNIQUE,
+    box_number INT,
+    description VARCHAR(2048),
+    active BOOLEAN,
+    for_sale BOOLEAN,
+    new_or_used VARCHAR(32),
+    completeness VARCHAR(64),
+    item_condition_id INT,
+    box_condition_id INT,
+    instructions_condition_id INT,
+    sealed BOOLEAN,
+    built_once BOOLEAN
+);
+
+CREATE TABLE item_inventory_photo (
+    item_inventory_photo_id INT AUTO_INCREMENT PRIMARY KEY,
+    item_inventory_id INT,
+    s3_bucket VARCHAR(255),
+    s3_key VARCHAR(1024),
+    md5 VARCHAR(64) UNIQUE,
+    file_name VARCHAR(255),
+    file_size BIGINT,
+    is_primary BOOLEAN,
+    caption VARCHAR(2048),
+    status VARCHAR(32),
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    uploaded_at TIMESTAMP
+);
+
+CREATE TABLE external_image_album (
+    external_image_album_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_id INT NOT NULL,
+    external_album_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    album_url VARCHAR(1024),
+    short_url VARCHAR(1024),
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_id),
+    UNIQUE (external_service_id, external_album_id)
+);
+
+CREATE TABLE external_image (
+    external_image_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_photo_id INT NOT NULL,
+    external_service_image_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    image_url VARCHAR(1024),
+    md5_at_upload CHAR(32) NOT NULL,
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    uploaded_at TIMESTAMP,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_photo_id),
+    UNIQUE (external_service_id, external_service_image_id)
+);
+
+CREATE TABLE external_image_album_image (
+    external_image_album_id BIGINT NOT NULL,
+    external_image_id BIGINT NOT NULL,
+    sort_order INT,
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (external_image_album_id, external_image_id)
+);

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImage.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImage.java
@@ -1,0 +1,25 @@
+package io.legohunter.data.dto;
+
+import io.legohunter.data.enums.ExternalSyncStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+public class ExternalImage {
+    private Long externalImageId;
+    private Integer externalServiceId;
+    private Integer itemInventoryPhotoId;
+    private String externalServiceImageId;
+    private String title;
+    private String imageUrl;
+    private String md5AtUpload;
+    private ExternalSyncStatus syncStatus;
+    private String errorMessage;
+    private ZonedDateTime uploadedAt;
+    private ZonedDateTime lastSyncedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImageAlbum.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImageAlbum.java
@@ -1,0 +1,24 @@
+package io.legohunter.data.dto;
+
+import io.legohunter.data.enums.ExternalSyncStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+public class ExternalImageAlbum {
+    private Long externalImageAlbumId;
+    private Integer externalServiceId;
+    private Integer itemInventoryId;
+    private String externalAlbumId;
+    private String title;
+    private String albumUrl;
+    private String shortUrl;
+    private ExternalSyncStatus syncStatus;
+    private String errorMessage;
+    private ZonedDateTime lastSyncedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImageAlbumImage.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalImageAlbumImage.java
@@ -1,0 +1,17 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+public class ExternalImageAlbumImage {
+    private Long externalImageAlbumId;
+    private Long externalImageId;
+    private Integer sortOrder;
+    private Boolean primary;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/enums/ExternalSyncStatus.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/enums/ExternalSyncStatus.java
@@ -1,0 +1,8 @@
+package io.legohunter.data.enums;
+
+public enum ExternalSyncStatus {
+    PENDING,
+    SYNCED,
+    FAILED,
+    DELETE_PENDING
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapper.java
@@ -1,0 +1,127 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImageAlbumImage;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ExternalImageAlbumImageMapper {
+    String ALL_COLUMNS = """
+            external_image_album_id,
+            external_image_id,
+            sort_order,
+            is_primary,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album_image")
+    @ResultMap("externalImageAlbumImageResultMap")
+    Set<ExternalImageAlbumImage> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image_album_image
+            WHERE external_image_album_id = #{externalImageAlbumId}
+              AND external_image_id = #{externalImageId}
+            """)
+    @ResultMap("externalImageAlbumImageResultMap")
+    Optional<ExternalImageAlbumImage> findByExternalImageAlbumIdAndExternalImageId(Long externalImageAlbumId, Long externalImageId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album_image WHERE external_image_album_id = #{externalImageAlbumId}")
+    @ResultMap("externalImageAlbumImageResultMap")
+    Set<ExternalImageAlbumImage> findByExternalImageAlbumId(Long externalImageAlbumId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album_image WHERE external_image_id = #{externalImageId}")
+    @ResultMap("externalImageAlbumImageResultMap")
+    Set<ExternalImageAlbumImage> findByExternalImageId(Long externalImageId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image_album_image
+            WHERE external_image_album_id = #{externalImageAlbumId}
+              AND is_primary = TRUE
+            """)
+    @ResultMap("externalImageAlbumImageResultMap")
+    Optional<ExternalImageAlbumImage> findPrimaryByExternalImageAlbumId(Long externalImageAlbumId);
+
+    @Insert("""
+            INSERT INTO external_image_album_image (
+                external_image_album_id,
+                external_image_id,
+                sort_order,
+                is_primary,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalImageAlbumId},
+                #{externalImageId},
+                #{sortOrder},
+                #{primary},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    void insert(ExternalImageAlbumImage externalImageAlbumImage);
+
+    @Update("""
+            UPDATE external_image_album_image
+            SET
+                sort_order = #{sortOrder},
+                is_primary = #{primary},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE external_image_album_id = #{externalImageAlbumId}
+              AND external_image_id = #{externalImageId}
+            """)
+    int update(ExternalImageAlbumImage externalImageAlbumImage);
+
+    @Insert("""
+            INSERT INTO external_image_album_image (
+                external_image_album_id,
+                external_image_id,
+                sort_order,
+                is_primary,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalImageAlbumId},
+                #{externalImageId},
+                #{sortOrder},
+                #{primary},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                sort_order = VALUES(sort_order),
+                is_primary = VALUES(is_primary),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    void upsert(ExternalImageAlbumImage externalImageAlbumImage);
+
+    @Update("""
+            UPDATE external_image_album_image
+            SET
+                is_primary = FALSE,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE external_image_album_id = #{externalImageAlbumId}
+            """)
+    int clearPrimaryForExternalImageAlbum(Long externalImageAlbumId);
+
+    @Delete("""
+            DELETE FROM external_image_album_image
+            WHERE external_image_album_id = #{externalImageAlbumId}
+              AND external_image_id = #{externalImageId}
+            """)
+    int deleteByExternalImageAlbumIdAndExternalImageId(Long externalImageAlbumId, Long externalImageId);
+
+    @Delete("DELETE FROM external_image_album_image WHERE external_image_album_id = #{externalImageAlbumId}")
+    int deleteByExternalImageAlbumId(Long externalImageAlbumId);
+
+    @Delete("DELETE FROM external_image_album_image WHERE external_image_id = #{externalImageId}")
+    int deleteByExternalImageId(Long externalImageId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapper.java
@@ -1,0 +1,156 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ExternalImageAlbumMapper {
+    String ALL_COLUMNS = """
+            external_image_album_id,
+            external_service_id,
+            item_inventory_id,
+            external_album_id,
+            title,
+            album_url,
+            short_url,
+            sync_status,
+            error_message,
+            last_synced_at,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album")
+    @ResultMap("externalImageAlbumResultMap")
+    Set<ExternalImageAlbum> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album WHERE external_image_album_id = #{externalImageAlbumId}")
+    @ResultMap("externalImageAlbumResultMap")
+    Optional<ExternalImageAlbum> findByExternalImageAlbumId(Long externalImageAlbumId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image_album
+            WHERE external_service_id = #{externalServiceId}
+              AND item_inventory_id = #{itemInventoryId}
+            """)
+    @ResultMap("externalImageAlbumResultMap")
+    Optional<ExternalImageAlbum> findByExternalServiceIdAndItemInventoryId(Integer externalServiceId, Integer itemInventoryId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image_album
+            WHERE external_service_id = #{externalServiceId}
+              AND external_album_id = #{externalAlbumId}
+            """)
+    @ResultMap("externalImageAlbumResultMap")
+    Optional<ExternalImageAlbum> findByExternalServiceIdAndExternalAlbumId(Integer externalServiceId, String externalAlbumId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image_album WHERE sync_status = #{syncStatus.name}")
+    @ResultMap("externalImageAlbumResultMap")
+    Set<ExternalImageAlbum> findBySyncStatus(ExternalSyncStatus syncStatus);
+
+    @Insert("""
+            INSERT INTO external_image_album (
+                external_service_id,
+                item_inventory_id,
+                external_album_id,
+                title,
+                album_url,
+                short_url,
+                sync_status,
+                error_message,
+                last_synced_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalServiceId},
+                #{itemInventoryId},
+                #{externalAlbumId},
+                #{title},
+                #{albumUrl},
+                #{shortUrl},
+                #{syncStatus},
+                #{errorMessage},
+                #{lastSyncedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "externalImageAlbumId")
+    void insert(ExternalImageAlbum externalImageAlbum);
+
+    @Update("""
+            UPDATE external_image_album
+            SET
+                external_service_id = #{externalServiceId},
+                item_inventory_id = #{itemInventoryId},
+                external_album_id = #{externalAlbumId},
+                title = #{title},
+                album_url = #{albumUrl},
+                short_url = #{shortUrl},
+                sync_status = #{syncStatus},
+                error_message = #{errorMessage},
+                last_synced_at = #{lastSyncedAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE external_image_album_id = #{externalImageAlbumId}
+            """)
+    int update(ExternalImageAlbum externalImageAlbum);
+
+    @Insert("""
+            INSERT INTO external_image_album (
+                external_service_id,
+                item_inventory_id,
+                external_album_id,
+                title,
+                album_url,
+                short_url,
+                sync_status,
+                error_message,
+                last_synced_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalServiceId},
+                #{itemInventoryId},
+                #{externalAlbumId},
+                #{title},
+                #{albumUrl},
+                #{shortUrl},
+                #{syncStatus},
+                #{errorMessage},
+                #{lastSyncedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                external_album_id = VALUES(external_album_id),
+                title = VALUES(title),
+                album_url = VALUES(album_url),
+                short_url = VALUES(short_url),
+                sync_status = VALUES(sync_status),
+                error_message = VALUES(error_message),
+                last_synced_at = VALUES(last_synced_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "externalImageAlbumId")
+    void upsert(ExternalImageAlbum externalImageAlbum);
+
+    @Delete("DELETE FROM external_image_album WHERE external_image_album_id = #{externalImageAlbumId}")
+    int deleteByExternalImageAlbumId(Long externalImageAlbumId);
+
+    @Delete("""
+            DELETE FROM external_image_album
+            WHERE external_service_id = #{externalServiceId}
+              AND item_inventory_id = #{itemInventoryId}
+            """)
+    int deleteByExternalServiceIdAndItemInventoryId(Integer externalServiceId, Integer itemInventoryId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
@@ -1,0 +1,167 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ExternalImageMapper {
+    String ALL_COLUMNS = """
+            external_image_id,
+            external_service_id,
+            item_inventory_photo_id,
+            external_service_image_id,
+            title,
+            image_url,
+            md5_at_upload,
+            sync_status,
+            error_message,
+            uploaded_at,
+            last_synced_at,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image")
+    @ResultMap("externalImageResultMap")
+    Set<ExternalImage> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image WHERE external_image_id = #{externalImageId}")
+    @ResultMap("externalImageResultMap")
+    Optional<ExternalImage> findByExternalImageId(Long externalImageId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image
+            WHERE external_service_id = #{externalServiceId}
+              AND item_inventory_photo_id = #{itemInventoryPhotoId}
+            """)
+    @ResultMap("externalImageResultMap")
+    Optional<ExternalImage> findByExternalServiceIdAndItemInventoryPhotoId(Integer externalServiceId, Integer itemInventoryPhotoId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM external_image
+            WHERE external_service_id = #{externalServiceId}
+              AND external_service_image_id = #{externalServiceImageId}
+            """)
+    @ResultMap("externalImageResultMap")
+    Optional<ExternalImage> findByExternalServiceIdAndExternalServiceImageId(Integer externalServiceId, String externalServiceImageId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image WHERE item_inventory_photo_id = #{itemInventoryPhotoId}")
+    @ResultMap("externalImageResultMap")
+    Set<ExternalImage> findByItemInventoryPhotoId(Integer itemInventoryPhotoId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM external_image WHERE sync_status = #{syncStatus.name}")
+    @ResultMap("externalImageResultMap")
+    Set<ExternalImage> findBySyncStatus(ExternalSyncStatus syncStatus);
+
+    @Insert("""
+            INSERT INTO external_image (
+                external_service_id,
+                item_inventory_photo_id,
+                external_service_image_id,
+                title,
+                image_url,
+                md5_at_upload,
+                sync_status,
+                error_message,
+                uploaded_at,
+                last_synced_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalServiceId},
+                #{itemInventoryPhotoId},
+                #{externalServiceImageId},
+                #{title},
+                #{imageUrl},
+                #{md5AtUpload},
+                #{syncStatus},
+                #{errorMessage},
+                #{uploadedAt},
+                #{lastSyncedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "externalImageId")
+    void insert(ExternalImage externalImage);
+
+    @Update("""
+            UPDATE external_image
+            SET
+                external_service_id = #{externalServiceId},
+                item_inventory_photo_id = #{itemInventoryPhotoId},
+                external_service_image_id = #{externalServiceImageId},
+                title = #{title},
+                image_url = #{imageUrl},
+                md5_at_upload = #{md5AtUpload},
+                sync_status = #{syncStatus},
+                error_message = #{errorMessage},
+                uploaded_at = #{uploadedAt},
+                last_synced_at = #{lastSyncedAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE external_image_id = #{externalImageId}
+            """)
+    int update(ExternalImage externalImage);
+
+    @Insert("""
+            INSERT INTO external_image (
+                external_service_id,
+                item_inventory_photo_id,
+                external_service_image_id,
+                title,
+                image_url,
+                md5_at_upload,
+                sync_status,
+                error_message,
+                uploaded_at,
+                last_synced_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{externalServiceId},
+                #{itemInventoryPhotoId},
+                #{externalServiceImageId},
+                #{title},
+                #{imageUrl},
+                #{md5AtUpload},
+                #{syncStatus},
+                #{errorMessage},
+                #{uploadedAt},
+                #{lastSyncedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                external_service_image_id = VALUES(external_service_image_id),
+                title = VALUES(title),
+                image_url = VALUES(image_url),
+                md5_at_upload = VALUES(md5_at_upload),
+                sync_status = VALUES(sync_status),
+                error_message = VALUES(error_message),
+                uploaded_at = VALUES(uploaded_at),
+                last_synced_at = VALUES(last_synced_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "externalImageId")
+    void upsert(ExternalImage externalImage);
+
+    @Delete("DELETE FROM external_image WHERE external_image_id = #{externalImageId}")
+    int deleteByExternalImageId(Long externalImageId);
+
+    @Delete("""
+            DELETE FROM external_image
+            WHERE external_service_id = #{externalServiceId}
+              AND item_inventory_photo_id = #{itemInventoryPhotoId}
+            """)
+    int deleteByExternalServiceIdAndItemInventoryPhotoId(Integer externalServiceId, Integer itemInventoryPhotoId);
+}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapper.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ExternalImageAlbumImageMapper">
+  <resultMap type="io.legohunter.data.dto.ExternalImageAlbumImage" id="externalImageAlbumImageResultMap">
+    <result column="external_image_album_id" property="externalImageAlbumId"/>
+    <result column="external_image_id"       property="externalImageId"/>
+    <result column="sort_order"              property="sortOrder"/>
+    <result column="is_primary"              property="primary"/>
+    <result column="created_at"              property="createdAt"/>
+    <result column="updated_at"              property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapper.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ExternalImageAlbumMapper">
+  <resultMap type="io.legohunter.data.dto.ExternalImageAlbum" id="externalImageAlbumResultMap">
+    <result column="external_image_album_id" property="externalImageAlbumId"/>
+    <result column="external_service_id"     property="externalServiceId"/>
+    <result column="item_inventory_id"       property="itemInventoryId"/>
+    <result column="external_album_id"       property="externalAlbumId"/>
+    <result column="title"                   property="title"/>
+    <result column="album_url"               property="albumUrl"/>
+    <result column="short_url"               property="shortUrl"/>
+    <result column="sync_status"             property="syncStatus"/>
+    <result column="error_message"           property="errorMessage"/>
+    <result column="last_synced_at"          property="lastSyncedAt"/>
+    <result column="created_at"              property="createdAt"/>
+    <result column="updated_at"              property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalImageMapper.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ExternalImageMapper">
+  <resultMap type="io.legohunter.data.dto.ExternalImage" id="externalImageResultMap">
+    <result column="external_image_id"         property="externalImageId"/>
+    <result column="external_service_id"      property="externalServiceId"/>
+    <result column="item_inventory_photo_id"  property="itemInventoryPhotoId"/>
+    <result column="external_service_image_id" property="externalServiceImageId"/>
+    <result column="title"                    property="title"/>
+    <result column="image_url"                property="imageUrl"/>
+    <result column="md5_at_upload"            property="md5AtUpload"/>
+    <result column="sync_status"              property="syncStatus"/>
+    <result column="error_message"            property="errorMessage"/>
+    <result column="uploaded_at"              property="uploadedAt"/>
+    <result column="last_synced_at"           property="lastSyncedAt"/>
+    <result column="created_at"               property="createdAt"/>
+    <result column="updated_at"               property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumImageMapperTest.java
@@ -1,0 +1,91 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.dto.ExternalImageAlbumImage;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ExternalServiceType;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryPhoto;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class ExternalImageAlbumImageMapperTest extends MapperTestSupport {
+
+    @Test
+    void insertFindsUpdatesUpsertsPrimaryAndDeletesAlbumImageMembership() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-external-membership");
+        ItemInventoryPhoto firstPhoto = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "cccccccccccccccccccccccccccccccc");
+        ItemInventoryPhoto secondPhoto = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "dddddddddddddddddddddddddddddddd");
+        ExternalImageAlbum album = externalImageAlbum(10, itemInventory.getItemInventoryId(), "album-membership");
+        externalImageAlbumMapper.insert(album);
+        ExternalImage firstImage = externalImage(10, firstPhoto.getItemInventoryPhotoId(), "image-first", "cccccccccccccccccccccccccccccccc");
+        ExternalImage secondImage = externalImage(10, secondPhoto.getItemInventoryPhotoId(), "image-second", "dddddddddddddddddddddddddddddddd");
+        externalImageMapper.insert(firstImage);
+        externalImageMapper.insert(secondImage);
+
+        ExternalImageAlbumImage firstMembership = externalImageAlbumImage(
+                album.getExternalImageAlbumId(),
+                firstImage.getExternalImageId(),
+                1,
+                true);
+        externalImageAlbumImageMapper.insert(firstMembership);
+
+        assertThat(externalImageAlbumImageMapper.findAll()).hasSize(1);
+        assertThat(externalImageAlbumImageMapper.findByExternalImageAlbumIdAndExternalImageId(
+                album.getExternalImageAlbumId(), firstImage.getExternalImageId()))
+                .hasValueSatisfying(found -> assertThat(found.getPrimary()).isTrue());
+        assertThat(externalImageAlbumImageMapper.findByExternalImageAlbumId(album.getExternalImageAlbumId())).hasSize(1);
+        assertThat(externalImageAlbumImageMapper.findByExternalImageId(firstImage.getExternalImageId())).hasSize(1);
+        assertThat(externalImageAlbumImageMapper.findPrimaryByExternalImageAlbumId(album.getExternalImageAlbumId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalImageId()).isEqualTo(firstImage.getExternalImageId()));
+
+        firstMembership.setSortOrder(2);
+        firstMembership.setPrimary(false);
+        assertThat(externalImageAlbumImageMapper.update(firstMembership)).isOne();
+        assertThat(externalImageAlbumImageMapper.findPrimaryByExternalImageAlbumId(album.getExternalImageAlbumId())).isEmpty();
+
+        ExternalImageAlbumImage secondMembership = externalImageAlbumImage(
+                album.getExternalImageAlbumId(),
+                secondImage.getExternalImageId(),
+                1,
+                true);
+        externalImageAlbumImageMapper.upsert(secondMembership);
+        assertThat(externalImageAlbumImageMapper.findByExternalImageAlbumId(album.getExternalImageAlbumId())).hasSize(2);
+        assertThat(externalImageAlbumImageMapper.clearPrimaryForExternalImageAlbum(album.getExternalImageAlbumId())).isEqualTo(2);
+        assertThat(externalImageAlbumImageMapper.findPrimaryByExternalImageAlbumId(album.getExternalImageAlbumId())).isEmpty();
+
+        secondMembership.setPrimary(true);
+        secondMembership.setSortOrder(3);
+        externalImageAlbumImageMapper.upsert(secondMembership);
+        assertThat(externalImageAlbumImageMapper.findByExternalImageAlbumIdAndExternalImageId(
+                album.getExternalImageAlbumId(), secondImage.getExternalImageId()))
+                .hasValueSatisfying(found -> assertThat(found.getSortOrder()).isEqualTo(3));
+
+        assertThat(externalImageAlbumImageMapper.deleteByExternalImageAlbumIdAndExternalImageId(
+                album.getExternalImageAlbumId(), firstImage.getExternalImageId())).isOne();
+        assertThat(externalImageAlbumImageMapper.deleteByExternalImageId(secondImage.getExternalImageId())).isOne();
+        assertThat(externalImageAlbumImageMapper.findAll()).isEmpty();
+
+        externalImageAlbumImageMapper.insert(secondMembership);
+        assertThat(externalImageAlbumImageMapper.deleteByExternalImageAlbumId(album.getExternalImageAlbumId())).isOne();
+    }
+
+    private void insertImageHostingService() {
+        externalServiceTypeMapper.insertExternalServiceType(ExternalServiceType.builder()
+                .externalServiceTypeId(5)
+                .externalServiceTypeName("IMAGE_HOSTING")
+                .externalServiceTypeDescription("Image Hosting Service")
+                .build());
+        ExternalService service = new ExternalService();
+        service.setExternalServiceId(10);
+        service.setExternalServiceName("Flickr");
+        service.setExternalServiceUrl("https://www.flickr.com");
+        service.setExternalServiceTypeId(5);
+        externalServiceMapper.insertExternalService(service);
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageAlbumMapperTest.java
@@ -1,0 +1,76 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ExternalServiceType;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class ExternalImageAlbumMapperTest extends MapperTestSupport {
+
+    @Test
+    void insertFindsUpdatesUpsertsAndDeletesExternalImageAlbum() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-external-album");
+        ExternalImageAlbum album = externalImageAlbum(10, itemInventory.getItemInventoryId(), "album-1");
+
+        externalImageAlbumMapper.insert(album);
+        assertThat(album.getExternalImageAlbumId()).isNotNull();
+
+        assertThat(externalImageAlbumMapper.findAll()).hasSize(1);
+        assertThat(externalImageAlbumMapper.findByExternalImageAlbumId(album.getExternalImageAlbumId()))
+                .hasValueSatisfying(found -> assertThat(found.getShortUrl()).isEqualTo("https://short.example/album-1"));
+        assertThat(externalImageAlbumMapper.findByExternalServiceIdAndItemInventoryId(10, itemInventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalAlbumId()).isEqualTo("album-1"));
+        assertThat(externalImageAlbumMapper.findByExternalServiceIdAndExternalAlbumId(10, "album-1"))
+                .hasValueSatisfying(found -> assertThat(found.getTitle()).isEqualTo("3001-1 [uuid]"));
+        assertThat(externalImageAlbumMapper.findBySyncStatus(ExternalSyncStatus.PENDING)).hasSize(1);
+
+        album.setTitle("3001-1 [uuid-updated]");
+        album.setSyncStatus(ExternalSyncStatus.SYNCED);
+        assertThat(externalImageAlbumMapper.update(album)).isOne();
+        assertThat(externalImageAlbumMapper.findByExternalImageAlbumId(album.getExternalImageAlbumId()))
+                .hasValueSatisfying(found -> assertThat(found.getSyncStatus()).isEqualTo(ExternalSyncStatus.SYNCED));
+
+        externalImageAlbumMapper.upsert(ExternalImageAlbum.builder()
+                .externalServiceId(10)
+                .itemInventoryId(itemInventory.getItemInventoryId())
+                .externalAlbumId("album-1-upserted")
+                .title("Upserted")
+                .albumUrl("https://photos.example/albums/upserted")
+                .shortUrl("https://short.example/upserted")
+                .syncStatus(ExternalSyncStatus.FAILED)
+                .errorMessage("failed")
+                .build());
+
+        assertThat(externalImageAlbumMapper.findByExternalServiceIdAndItemInventoryId(10, itemInventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getExternalAlbumId()).isEqualTo("album-1-upserted");
+                    assertThat(found.getErrorMessage()).isEqualTo("failed");
+                });
+
+        assertThat(externalImageAlbumMapper.deleteByExternalServiceIdAndItemInventoryId(10, itemInventory.getItemInventoryId())).isOne();
+        assertThat(externalImageAlbumMapper.findAll()).isEmpty();
+
+        externalImageAlbumMapper.insert(album);
+        assertThat(externalImageAlbumMapper.deleteByExternalImageAlbumId(album.getExternalImageAlbumId())).isOne();
+    }
+
+    private void insertImageHostingService() {
+        externalServiceTypeMapper.insertExternalServiceType(ExternalServiceType.builder()
+                .externalServiceTypeId(5)
+                .externalServiceTypeName("IMAGE_HOSTING")
+                .externalServiceTypeDescription("Image Hosting Service")
+                .build());
+        ExternalService service = new ExternalService();
+        service.setExternalServiceId(10);
+        service.setExternalServiceName("Flickr");
+        service.setExternalServiceUrl("https://www.flickr.com");
+        service.setExternalServiceTypeId(5);
+        externalServiceMapper.insertExternalService(service);
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
@@ -1,0 +1,79 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ExternalServiceType;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryPhoto;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class ExternalImageMapperTest extends MapperTestSupport {
+
+    @Test
+    void insertFindsUpdatesUpsertsAndDeletesExternalImage() {
+        insertImageHostingService();
+        ItemInventory itemInventory = insertItemInventory("uuid-external-image");
+        ItemInventoryPhoto photo = insertItemInventoryPhoto(itemInventory.getItemInventoryId(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        ExternalImage image = externalImage(10, photo.getItemInventoryPhotoId(), "image-1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        externalImageMapper.insert(image);
+        assertThat(image.getExternalImageId()).isNotNull();
+
+        assertThat(externalImageMapper.findAll()).hasSize(1);
+        assertThat(externalImageMapper.findByExternalImageId(image.getExternalImageId()))
+                .hasValueSatisfying(found -> assertThat(found.getMd5AtUpload()).isEqualTo("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assertThat(externalImageMapper.findByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalServiceImageId()).isEqualTo("image-1"));
+        assertThat(externalImageMapper.findByExternalServiceIdAndExternalServiceImageId(10, "image-1"))
+                .hasValueSatisfying(found -> assertThat(found.getImageUrl()).isEqualTo("https://photos.example/images/image-1"));
+        assertThat(externalImageMapper.findByItemInventoryPhotoId(photo.getItemInventoryPhotoId())).hasSize(1);
+        assertThat(externalImageMapper.findBySyncStatus(ExternalSyncStatus.PENDING)).hasSize(1);
+
+        image.setTitle("Updated image title");
+        image.setSyncStatus(ExternalSyncStatus.SYNCED);
+        assertThat(externalImageMapper.update(image)).isOne();
+        assertThat(externalImageMapper.findByExternalImageId(image.getExternalImageId()))
+                .hasValueSatisfying(found -> assertThat(found.getSyncStatus()).isEqualTo(ExternalSyncStatus.SYNCED));
+
+        externalImageMapper.upsert(ExternalImage.builder()
+                .externalServiceId(10)
+                .itemInventoryPhotoId(photo.getItemInventoryPhotoId())
+                .externalServiceImageId("image-1-upserted")
+                .title("Upserted image")
+                .imageUrl("https://photos.example/images/upserted")
+                .md5AtUpload("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+                .syncStatus(ExternalSyncStatus.FAILED)
+                .errorMessage("failed")
+                .build());
+
+        assertThat(externalImageMapper.findByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getExternalServiceImageId()).isEqualTo("image-1-upserted");
+                    assertThat(found.getMd5AtUpload()).isEqualTo("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+                });
+
+        assertThat(externalImageMapper.deleteByExternalServiceIdAndItemInventoryPhotoId(10, photo.getItemInventoryPhotoId())).isOne();
+        assertThat(externalImageMapper.findAll()).isEmpty();
+
+        externalImageMapper.insert(image);
+        assertThat(externalImageMapper.deleteByExternalImageId(image.getExternalImageId())).isOne();
+    }
+
+    private void insertImageHostingService() {
+        externalServiceTypeMapper.insertExternalServiceType(ExternalServiceType.builder()
+                .externalServiceTypeId(5)
+                .externalServiceTypeName("IMAGE_HOSTING")
+                .externalServiceTypeDescription("Image Hosting Service")
+                .build());
+        ExternalService service = new ExternalService();
+        service.setExternalServiceId(10);
+        service.setExternalServiceName("Flickr");
+        service.setExternalServiceUrl("https://www.flickr.com");
+        service.setExternalServiceTypeId(5);
+        externalServiceMapper.insertExternalService(service);
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -4,13 +4,19 @@ import io.legohunter.data.dto.BricklinkItemInventory;
 import io.legohunter.data.dto.Category;
 import io.legohunter.data.dto.ExternalItem;
 import io.legohunter.data.dto.ExternalItemInventory;
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ExternalImageAlbum;
+import io.legohunter.data.dto.ExternalImageAlbumImage;
 import io.legohunter.data.dto.ExternalService;
 import io.legohunter.data.dto.ExternalServiceType;
 import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryPhoto;
 import io.legohunter.data.dto.Party;
 import io.legohunter.data.dto.TransactionPlatform;
 import io.legohunter.data.dto.TransactionType;
 import io.legohunter.data.dto.Transactions;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import io.legohunter.data.enums.PhotoStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
@@ -24,6 +30,9 @@ abstract class MapperTestSupport {
     @Autowired CostTypeMapper costTypeMapper;
     @Autowired ExternalItemMapper externalItemMapper;
     @Autowired ExternalItemInventoryMapper externalItemInventoryMapper;
+    @Autowired ExternalImageAlbumMapper externalImageAlbumMapper;
+    @Autowired ExternalImageMapper externalImageMapper;
+    @Autowired ExternalImageAlbumImageMapper externalImageAlbumImageMapper;
     @Autowired ExternalServiceItemMapper externalServiceItemMapper;
     @Autowired ExternalServiceMapper externalServiceMapper;
     @Autowired ExternalServiceTypeMapper externalServiceTypeMapper;
@@ -119,6 +128,54 @@ abstract class MapperTestSupport {
                 .build();
         externalItemInventoryMapper.insert(externalItemInventory);
         return externalItemInventory;
+    }
+
+    ExternalImageAlbum externalImageAlbum(Integer externalServiceId, Integer itemInventoryId, String externalAlbumId) {
+        return ExternalImageAlbum.builder()
+                .externalServiceId(externalServiceId)
+                .itemInventoryId(itemInventoryId)
+                .externalAlbumId(externalAlbumId)
+                .title("3001-1 [uuid]")
+                .albumUrl("https://photos.example/albums/" + externalAlbumId)
+                .shortUrl("https://short.example/" + externalAlbumId)
+                .syncStatus(ExternalSyncStatus.PENDING)
+                .build();
+    }
+
+    ExternalImage externalImage(Integer externalServiceId, Integer itemInventoryPhotoId, String externalServiceImageId, String md5) {
+        return ExternalImage.builder()
+                .externalServiceId(externalServiceId)
+                .itemInventoryPhotoId(itemInventoryPhotoId)
+                .externalServiceImageId(externalServiceImageId)
+                .title("3001-1 [uuid]")
+                .imageUrl("https://photos.example/images/" + externalServiceImageId)
+                .md5AtUpload(md5)
+                .syncStatus(ExternalSyncStatus.PENDING)
+                .build();
+    }
+
+    ExternalImageAlbumImage externalImageAlbumImage(Long externalImageAlbumId, Long externalImageId, int sortOrder, boolean primary) {
+        return ExternalImageAlbumImage.builder()
+                .externalImageAlbumId(externalImageAlbumId)
+                .externalImageId(externalImageId)
+                .sortOrder(sortOrder)
+                .primary(primary)
+                .build();
+    }
+
+    ItemInventoryPhoto insertItemInventoryPhoto(Integer itemInventoryId, String md5) {
+        ItemInventoryPhoto photo = ItemInventoryPhoto.builder()
+                .itemInventoryId(itemInventoryId)
+                .s3Bucket("lego-photos-sandbox")
+                .s3Key("3001/uuid/" + md5 + ".jpg")
+                .md5(md5)
+                .fileName(md5 + ".jpg")
+                .fileSize(1000L)
+                .primary(false)
+                .status(PhotoStatus.PROCESSED)
+                .build();
+        itemInventoryPhotoMapper.insert(photo);
+        return photo;
     }
 
     BricklinkItemInventory bricklinkItemInventory(Integer externalItemId, Integer itemInventoryId) {

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -1,6 +1,9 @@
 DROP TABLE IF EXISTS bricklink_item_inventory;
 DROP TABLE IF EXISTS external_item_inventory;
 DROP TABLE IF EXISTS external_service_item;
+DROP TABLE IF EXISTS external_image_album_image;
+DROP TABLE IF EXISTS external_image;
+DROP TABLE IF EXISTS external_image_album;
 DROP TABLE IF EXISTS item_inventory_photo;
 DROP TABLE IF EXISTS transaction_item_cost;
 DROP TABLE IF EXISTS transaction_cost;
@@ -187,6 +190,51 @@ CREATE TABLE item_inventory_photo (
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
     uploaded_at TIMESTAMP
+);
+
+CREATE TABLE external_image_album (
+    external_image_album_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_id INT NOT NULL,
+    external_album_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    album_url VARCHAR(1024),
+    short_url VARCHAR(1024),
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_id),
+    UNIQUE (external_service_id, external_album_id)
+);
+
+CREATE TABLE external_image (
+    external_image_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_photo_id INT NOT NULL,
+    external_service_image_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    image_url VARCHAR(1024),
+    md5_at_upload CHAR(32) NOT NULL,
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    uploaded_at TIMESTAMP,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_photo_id),
+    UNIQUE (external_service_id, external_service_image_id)
+);
+
+CREATE TABLE external_image_album_image (
+    external_image_album_id BIGINT NOT NULL,
+    external_image_id BIGINT NOT NULL,
+    sort_order INT,
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (external_image_album_id, external_image_id)
 );
 
 CREATE TABLE party (

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/external_image_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/external_image_schema.ddl
@@ -1,0 +1,97 @@
+DROP TABLE IF EXISTS external_image_album_image;
+DROP TABLE IF EXISTS external_image;
+DROP TABLE IF EXISTS external_image_album;
+DROP TABLE IF EXISTS item_inventory_photo;
+DROP TABLE IF EXISTS item_inventory;
+DROP TABLE IF EXISTS external_service;
+DROP TABLE IF EXISTS external_service_type;
+
+CREATE TABLE external_service_type (
+    external_service_type_id INT PRIMARY KEY,
+    external_service_type_name VARCHAR(255) UNIQUE,
+    external_service_type_description VARCHAR(1024)
+);
+
+CREATE TABLE external_service (
+    external_service_id INT PRIMARY KEY,
+    external_service_name VARCHAR(255) UNIQUE,
+    external_service_url VARCHAR(1024),
+    external_service_type_id INT
+);
+
+CREATE TABLE item_inventory (
+    item_inventory_id INT AUTO_INCREMENT PRIMARY KEY,
+    uuid VARCHAR(64) UNIQUE,
+    box_number INT,
+    description VARCHAR(2048),
+    active BOOLEAN,
+    for_sale BOOLEAN,
+    new_or_used VARCHAR(32),
+    completeness VARCHAR(64),
+    item_condition_id INT,
+    box_condition_id INT,
+    instructions_condition_id INT,
+    sealed BOOLEAN,
+    built_once BOOLEAN
+);
+
+CREATE TABLE item_inventory_photo (
+    item_inventory_photo_id INT AUTO_INCREMENT PRIMARY KEY,
+    item_inventory_id INT,
+    s3_bucket VARCHAR(255),
+    s3_key VARCHAR(1024),
+    md5 VARCHAR(64) UNIQUE,
+    file_name VARCHAR(255),
+    file_size BIGINT,
+    is_primary BOOLEAN,
+    caption VARCHAR(2048),
+    status VARCHAR(32),
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    uploaded_at TIMESTAMP
+);
+
+CREATE TABLE external_image_album (
+    external_image_album_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_id INT NOT NULL,
+    external_album_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    album_url VARCHAR(1024),
+    short_url VARCHAR(1024),
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_id),
+    UNIQUE (external_service_id, external_album_id)
+);
+
+CREATE TABLE external_image (
+    external_image_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_service_id INT NOT NULL,
+    item_inventory_photo_id INT NOT NULL,
+    external_service_image_id VARCHAR(255),
+    title VARCHAR(500) NOT NULL,
+    image_url VARCHAR(1024),
+    md5_at_upload CHAR(32) NOT NULL,
+    sync_status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    error_message CLOB,
+    uploaded_at TIMESTAMP,
+    last_synced_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (external_service_id, item_inventory_photo_id),
+    UNIQUE (external_service_id, external_service_image_id)
+);
+
+CREATE TABLE external_image_album_image (
+    external_image_album_id BIGINT NOT NULL,
+    external_image_id BIGINT NOT NULL,
+    sort_order INT,
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (external_image_album_id, external_image_id)
+);


### PR DESCRIPTION
## Summary
- add DTOs, sync status enum, MyBatis mappers, XML result maps, and DAOs for external image album, image, and album-image membership tables
- add MySQL-style upserts for all three tables
- add H2 schema updates and mapper/DAO tests covering the new methods

## Validation
- mvn clean test