### PR TITLE
Align H2 current schema constraints

### DIFF
--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -45,7 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @Import({MyBatisV2Configuration.class, LegoDataDaoConfiguration.class})
-@Sql(scripts = "/scripts/db/h2/current_schema.ddl")
+@Sql(scripts = {
+        "/scripts/db/h2/current_schema.ddl",
+        "/scripts/db/h2/current_lookup_data.sql"
+})
 class CurrentDaoIntegrationTest {
 
     @Autowired CarrierDao carrierDao;
@@ -73,100 +76,108 @@ class CurrentDaoIntegrationTest {
     @Test
     void referenceDataDaosDelegateCrudOperations() {
         Carrier carrier = Carrier.builder()
-                .carrierCode("UPS")
-                .carrierName("UPS")
+                .carrierCode("TEST")
+                .carrierName("Test Carrier")
                 .trackingUrlPattern("https://track.example")
                 .build();
         carrierDao.insert(carrier);
-        carrier.setCarrierName("United Parcel Service");
+        carrier.setCarrierName("Updated Test Carrier");
         carrierDao.update(carrier);
-        assertThat(carrierDao.findCarrierByCode("UPS"))
-                .hasValueSatisfying(found -> assertThat(found.getCarrierName()).isEqualTo("United Parcel Service"));
-        assertThat(carrierDao.findAll()).hasSize(1);
+        assertThat(carrierDao.findCarrierByCode("TEST"))
+                .hasValueSatisfying(found -> assertThat(found.getCarrierName()).isEqualTo("Updated Test Carrier"));
+        assertThat(carrierDao.findAll()).extracting(Carrier::getCarrierCode)
+                .contains("DHL", "FEDEX", "UPS", "USPS", "TEST");
 
         Condition condition = Condition.builder()
-                .conditionId(1)
-                .conditionCode("G")
-                .conditionDescription("Good")
-                .conditionText("Good text")
+                .conditionId(100)
+                .conditionCode("UT")
+                .conditionDescription("Unit Test")
+                .conditionText("Unit test text")
                 .build();
         conditionDao.insert(condition);
         condition.setConditionText("Updated text");
         conditionDao.update(condition);
-        assertThat(conditionDao.findConditionById(1))
+        assertThat(conditionDao.findConditionById(100))
                 .hasValueSatisfying(found -> assertThat(found.getConditionText()).isEqualTo("Updated text"));
-        assertThat(conditionDao.findByConditionCode("G")).isPresent();
-        assertThat(conditionDao.findAll()).hasSize(1);
+        assertThat(conditionDao.findByConditionCode("UT")).isPresent();
+        assertThat(conditionDao.findAll()).extracting(Condition::getConditionCode)
+                .contains("M", "E", "VG", "G", "UT");
 
         CostType costType = CostType.builder()
-                .costTypeCode("SHIP")
-                .costTypeName("Shipping")
-                .costTypeDescription("Shipping")
+                .costTypeCode("UNITTEST")
+                .costTypeName("Unit Test")
+                .costTypeDescription("Unit test cost")
                 .build();
         costTypeDao.insert(costType);
-        costType.setCostTypeDescription("Postage");
+        costType.setCostTypeDescription("Updated unit test cost");
         costTypeDao.update(costType);
-        assertThat(costTypeDao.findCostTypeByCode("SHIP"))
-                .hasValueSatisfying(found -> assertThat(found.getCostTypeDescription()).isEqualTo("Postage"));
-        assertThat(costTypeDao.findAll()).hasSize(1);
+        assertThat(costTypeDao.findCostTypeByCode("UNITTEST"))
+                .hasValueSatisfying(found -> assertThat(found.getCostTypeDescription()).isEqualTo("Updated unit test cost"));
+        assertThat(costTypeDao.findAll()).extracting(CostType::getCostTypeCode)
+                .contains("DISCOUNT", "FEE", "INSURANCE", "PRICE", "SHIPPING", "TAX", "UNITTEST");
 
         TransactionType transactionType = TransactionType.builder()
-                .transactionTypeCode("BUY")
-                .transactionTypeDescription("Buy")
+                .transactionTypeCode("UT")
+                .transactionTypeDescription("Unit Test")
                 .conversionFactor(1)
                 .build();
         transactionTypeDao.insert(transactionType);
         transactionType.setConversionFactor(2);
         transactionTypeDao.udpate(transactionType);
-        assertThat(transactionTypeDao.findTransactionTypeByCode("BUY"))
+        assertThat(transactionTypeDao.findTransactionTypeByCode("UT"))
                 .hasValueSatisfying(found -> assertThat(found.getConversionFactor()).isEqualTo(2));
-        assertThat(transactionTypeDao.findAll()).hasSize(1);
+        assertThat(transactionTypeDao.findAll()).extracting(TransactionType::getTransactionTypeCode)
+                .contains("A", "B", "F", "G", "P", "RM", "S", "TG", "TR", "YS", "UT");
 
         TransactionPlatform transactionPlatform = TransactionPlatform.builder()
-                .transactionPlatformId(1)
-                .transactionPlatformName("BrickLink")
+                .transactionPlatformId(100)
+                .transactionPlatformName("Unit Test Platform")
                 .build();
         transactionPlatformDao.insert(transactionPlatform);
-        transactionPlatform.setTransactionPlatformName("BrickLink Marketplace");
+        transactionPlatform.setTransactionPlatformName("Updated Unit Test Platform");
         transactionPlatformDao.update(transactionPlatform);
-        assertThat(transactionPlatformDao.findTransactionPlatformById(1)).isPresent();
-        assertThat(transactionPlatformDao.findTransactionPlatformByName("BrickLink Marketplace")).isPresent();
-        assertThat(transactionPlatformDao.findAll()).hasSize(1);
+        assertThat(transactionPlatformDao.findTransactionPlatformById(100)).isPresent();
+        assertThat(transactionPlatformDao.findTransactionPlatformByName("Updated Unit Test Platform")).isPresent();
+        assertThat(transactionPlatformDao.findAll()).extracting(TransactionPlatform::getTransactionPlatformName)
+                .contains("Bricklink", "eBay", "Private", "CataWiki", "Lauritz", "Updated Unit Test Platform");
 
         PaymentPlatform paymentPlatform = PaymentPlatform.builder()
-                .paymentPlatformId(1)
-                .paymentPlatformName("PayPal")
-                .paymentPlatformUrl("https://paypal.example")
+                .paymentPlatformId(100)
+                .paymentPlatformName("Unit Test Pay")
+                .paymentPlatformUrl("https://pay.example")
                 .build();
         paymentPlatformDao.insert(paymentPlatform);
-        paymentPlatform.setPaymentPlatformUrl("https://paypal.test");
+        paymentPlatform.setPaymentPlatformUrl("https://pay.test");
         paymentPlatformDao.update(paymentPlatform);
-        assertThat(paymentPlatformDao.findPaymentPlatformById(1))
-                .hasValueSatisfying(found -> assertThat(found.getPaymentPlatformUrl()).isEqualTo("https://paypal.test"));
-        assertThat(paymentPlatformDao.findPaymentPlatformByName("PayPal")).isPresent();
-        assertThat(paymentPlatformDao.findAll()).hasSize(1);
+        assertThat(paymentPlatformDao.findPaymentPlatformById(100))
+                .hasValueSatisfying(found -> assertThat(found.getPaymentPlatformUrl()).isEqualTo("https://pay.test"));
+        assertThat(paymentPlatformDao.findPaymentPlatformByName("Unit Test Pay")).isPresent();
+        assertThat(paymentPlatformDao.findAll()).extracting(PaymentPlatform::getPaymentPlatformName)
+                .contains("PayPal", "Credit Card", "Unit Test Pay");
     }
 
     @Test
     void catalogDaosDelegateCrudAndUpsertOperations() {
         seedExternalCatalog();
 
-        assertThat(externalServiceTypeDao.findExternalServiceTypeById(1)).isPresent();
-        assertThat(externalServiceTypeDao.findExternalServiceTypeByName("Marketplace")).isPresent();
-        assertThat(externalServiceTypeDao.findAll()).hasSize(1);
+        assertThat(externalServiceTypeDao.findExternalServiceTypeById(2)).isPresent();
+        assertThat(externalServiceTypeDao.findExternalServiceTypeByName("MARKETPLACE")).isPresent();
+        assertThat(externalServiceTypeDao.findAll()).extracting(ExternalServiceType::getExternalServiceTypeName)
+                .contains("LEGO", "MARKETPLACE", "AUCTION", "THIRDPARTY");
 
         ExternalServiceType type = ExternalServiceType.builder()
-                .externalServiceTypeId(1)
-                .externalServiceTypeName("Marketplace")
+                .externalServiceTypeId(2)
+                .externalServiceTypeName("MARKETPLACE")
                 .externalServiceTypeDescription("Updated")
                 .build();
         externalServiceTypeDao.update(type);
-        assertThat(externalServiceTypeDao.findExternalServiceTypeById(1))
+        assertThat(externalServiceTypeDao.findExternalServiceTypeById(2))
                 .hasValueSatisfying(found -> assertThat(found.getExternalServiceTypeDescription()).isEqualTo("Updated"));
 
         assertThat(externalServiceDao.findExternalServiceById(2)).isPresent();
         assertThat(externalServiceDao.findExternalServiceByName("BRICKLINK")).isPresent();
-        assertThat(externalServiceDao.findAll()).hasSize(1);
+        assertThat(externalServiceDao.findAll()).extracting(ExternalService::getExternalServiceName)
+                .contains("LEGO", "BRICKLINK", "EBAY", "Rebrickable");
         ExternalService service = externalService(2, "BRICKLINK");
         service.setExternalServiceUrl("https://updated.example");
         externalServiceDao.update(service);
@@ -177,12 +188,13 @@ class CurrentDaoIntegrationTest {
         categoryDao.insert(category);
         category.setCategoryName("Updated Parts");
         categoryDao.update(category);
-        categoryDao.upsert(category(2, 101, "Upserted Parts", 100));
+        categoryDao.upsert(category(2, 101, "Upserted Parts", 5));
         assertThat(categoryDao.findCategoryByExternalServiceAndCategoryId(2, 101))
-                .hasValueSatisfying(found -> assertThat(found.getParentId()).isEqualTo(100));
-        assertThat(categoryDao.findAll()).hasSize(2);
+                .hasValueSatisfying(found -> assertThat(found.getParentId()).isEqualTo(5));
+        assertThat(categoryDao.findAll()).extracting(Category::getExternalCategoryId)
+                .contains(5, 65, 789, 101);
 
-        ExternalItem externalItem = externalItem("3001-1", 123L, "Brick", 100, 2);
+        ExternalItem externalItem = externalItem("3001-1", 123L, "Brick", 5, 2);
         externalItemDao.insert(externalItem);
         externalItem.setName("Brick Updated");
         externalItemDao.update(externalItem);
@@ -191,7 +203,7 @@ class CurrentDaoIntegrationTest {
         assertThat(externalItemDao.findByExternalServiceAndUniqueId(2, 123)).isPresent();
         assertThat(externalItemDao.findByExternalServiceAndNumber(2, "3001-1")).isPresent();
         assertThat(externalItemDao.findAllByExternalService("BRICKLINK")).hasSize(1);
-        externalItemDao.upsert(externalItem("3001-1", 456L, "Brick Upserted", 100, 2));
+        externalItemDao.upsert(externalItem("3001-1", 456L, "Brick Upserted", 5, 2));
         assertThat(externalItemDao.findByExternalServiceAndNumber(2, "3001-1"))
                 .hasValueSatisfying(found -> assertThat(found.getName()).isEqualTo("Brick Upserted"));
 
@@ -293,7 +305,7 @@ class CurrentDaoIntegrationTest {
         assertThat(itemInventoryPhotoDao.findPrimaryByItemInventoryId(itemInventory.getItemInventoryId())).isPresent();
 
         seedExternalCatalog();
-        ExternalItem externalItem = externalItem("bii-1", 789L, "Bricklink item", 100, 2);
+        ExternalItem externalItem = externalItem("bii-1", 789L, "Bricklink item", 5, 2);
         externalItemDao.insert(externalItem);
         externalItemInventoryDao.insert(ExternalItemInventory.builder()
                 .externalItemId(externalItem.getExternalItemId())
@@ -340,10 +352,6 @@ class CurrentDaoIntegrationTest {
         assertThat(partyDao.findPartyById(9L)).isPresent();
         assertThat(partyDao.findAll()).hasSize(2);
 
-        transactionPlatformDao.insert(TransactionPlatform.builder()
-                .transactionPlatformId(1)
-                .transactionPlatformName("BrickLink")
-                .build());
         Transactions transaction = Transactions.builder()
                 .transactionDateTime(ZonedDateTime.parse("2026-01-01T00:00:00Z"))
                 .notes("Transaction")
@@ -439,13 +447,28 @@ class CurrentDaoIntegrationTest {
     }
 
     private void seedExternalCatalog() {
-        externalServiceTypeDao.insert(ExternalServiceType.builder()
-                .externalServiceTypeId(1)
-                .externalServiceTypeName("Marketplace")
-                .externalServiceTypeDescription("Marketplace APIs")
-                .build());
-        externalServiceDao.insert(externalService(2, "BRICKLINK"));
-        categoryDao.insert(category(2, 100, "Sets", null));
+        externalServiceTypeDao.findExternalServiceTypeById(2)
+                .orElseGet(() -> {
+                    ExternalServiceType serviceType = ExternalServiceType.builder()
+                            .externalServiceTypeId(2)
+                            .externalServiceTypeName("MARKETPLACE")
+                            .externalServiceTypeDescription("Marketplace")
+                            .build();
+                    externalServiceTypeDao.insert(serviceType);
+                    return serviceType;
+                });
+        externalServiceDao.findExternalServiceById(2)
+                .orElseGet(() -> {
+                    ExternalService service = externalService(2, "BRICKLINK");
+                    externalServiceDao.insert(service);
+                    return service;
+                });
+        categoryDao.findCategoryByExternalServiceAndCategoryId(2, 5)
+                .orElseGet(() -> {
+                    Category category = category(2, 5, "Brick", null);
+                    categoryDao.insert(category);
+                    return category;
+                });
     }
 
     private ExternalService externalService(Integer id, String name) {
@@ -453,7 +476,7 @@ class CurrentDaoIntegrationTest {
         service.setExternalServiceId(id);
         service.setExternalServiceName(name);
         service.setExternalServiceUrl("https://" + name.toLowerCase() + ".example");
-        service.setExternalServiceTypeId(1);
+        service.setExternalServiceTypeId(2);
         return service;
     }
 
@@ -480,6 +503,7 @@ class CurrentDaoIntegrationTest {
     }
 
     private ItemInventory itemInventory(String uuid) {
+        seedDefaultCondition();
         ItemInventory itemInventory = new ItemInventory();
         itemInventory.setUuid(uuid);
         itemInventory.setBoxNumber(1);
@@ -494,6 +518,20 @@ class CurrentDaoIntegrationTest {
         itemInventory.setSealed(false);
         itemInventory.setBuiltOnce(true);
         return itemInventory;
+    }
+
+    private void seedDefaultCondition() {
+        conditionDao.findConditionById(1)
+                .orElseGet(() -> {
+                    Condition condition = Condition.builder()
+                            .conditionId(1)
+                            .conditionCode("G")
+                            .conditionDescription("Good")
+                            .conditionText("Good")
+                            .build();
+                    conditionDao.insert(condition);
+                    return condition;
+                });
     }
 
     private BricklinkItemInventory bricklinkItemInventory(Integer externalItemId, Integer itemInventoryId) {

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_lookup_data.sql
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_lookup_data.sql
@@ -1,0 +1,73 @@
+INSERT INTO carrier (carrier_code, carrier_name, tracking_url_pattern) VALUES
+    ('DHL', 'Dalsey, Hillblom and Lynn', 'https://www.dhl.com/us-en/home/tracking.html?tracking-id=%s&submit=1'),
+    ('FEDEX', 'Federal Express', 'https://www.fedex.com/fedextrack/?action=track&trackingnumber=%s'),
+    ('UPS', 'United Parcel Service', 'http://wwwapps.ups.com/WebTracking/processRequest?HTMLVersion=5.0&Requester=NES&AgreeToTermsAndConditions=yes&loc=en_US&tracknum=%s'),
+    ('USPS', 'United States Postal Service', 'https://tools.usps.com/go/TrackConfirmAction.action?tLabels=%s');
+
+INSERT INTO `condition` (condition_id, condition_code, condition_description, condition_text) VALUES
+    (1, 'M', 'Mint', NULL),
+    (2, 'E', 'Excellent', NULL),
+    (3, 'VG', 'Very Good', NULL),
+    (4, 'G', 'Good', NULL),
+    (5, 'P', 'Poor', NULL),
+    (6, 'NA', 'Not Applicable', NULL),
+    (7, 'F', 'Fair', NULL),
+    (8, 'MS', 'Missing', NULL),
+    (9, 'CC', 'Color Copy', NULL),
+    (10, 'BW', 'Black & White Copy', NULL),
+    (11, 'SL', 'Sealed', 'Mint in sealed box');
+
+INSERT INTO cost_type (cost_type_code, cost_type_name, cost_type_description) VALUES
+    ('DISCOUNT', 'Discount', 'A Discount added to an item or entire order'),
+    ('FEE', 'Fee', 'A fee added to an item or entire order'),
+    ('INSURANCE', 'Insurance', 'The cost for insurance to ship an item or an entire order'),
+    ('PRICE', 'Price', 'The for-sale price or purchase cost of an item'),
+    ('SHIPPING', 'Shipping', 'The cost of shipping an item or an entire order'),
+    ('TAX', 'Tax', 'The sales tax amount added to an item or entire order');
+
+INSERT INTO transaction_type (transaction_type_code, transaction_type_description, conversion_factor) VALUES
+    ('A', 'Auction Purchase', 1),
+    ('B', 'Built from Loose Pieces', 1),
+    ('F', 'Find', 1),
+    ('G', 'Gift', 1),
+    ('P', 'Purchase', 1),
+    ('RM', 'Removed', -1),
+    ('S', 'Sale', -1),
+    ('TG', 'Trade Give', -1),
+    ('TR', 'Trade Receive', 1),
+    ('YS', 'Yard Sale/Flea Market Purchase', 1);
+
+INSERT INTO transaction_platform (transaction_platform_id, transaction_platform_name) VALUES
+    (1, 'Bricklink'),
+    (2, 'eBay'),
+    (3, 'Private'),
+    (4, 'CataWiki'),
+    (5, 'Lauritz');
+
+INSERT INTO payment_platform (payment_platform_id, payment_platform_name, payment_platform_url) VALUES
+    (1, 'PayPal', 'https://www.paypal.com/'),
+    (2, 'Credit Card', NULL);
+
+INSERT INTO external_service_type (external_service_type_id, external_service_type_name, external_service_type_description) VALUES
+    (1, 'LEGO', 'LEGO'),
+    (2, 'MARKETPLACE', 'Marketplace'),
+    (3, 'AUCTION', 'Auction'),
+    (4, 'THIRDPARTY', 'Third Party Producer');
+
+INSERT INTO external_service (external_service_id, external_service_name, external_service_url, external_service_type_id) VALUES
+    (1, 'LEGO', 'https://www.lego.com', 1),
+    (2, 'BRICKLINK', 'https://www.bricklink.com', 2),
+    (3, 'EBAY', 'https://www.ebay.com', 3),
+    (4, 'CATAWIKI', 'https://www.catawiki.com', 3),
+    (5, 'LAURITZ', 'https://www.lauritz.com', 3),
+    (6, 'QXL', 'https://www.qxl.dk', 3),
+    (7, 'PNW Steam Shop', 'https://www.pnwsteamshop.com', 4),
+    (8, 'Brick Model Railroader', 'https://brickmodelrailroader.com', 4),
+    (9, 'Rebrickable', 'https://rebrickable.com', 2);
+
+INSERT INTO category (external_service_id, external_category_id, category_name, parent_id) VALUES
+    (2, 5, 'Brick', NULL),
+    (2, 65, 'Star Wars', NULL),
+    (2, 789, 'The Hobbit and The Lord of the Rings', NULL),
+    (9, 1, 'Technic', NULL),
+    (9, 18, 'Star Wars', 1);

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -169,7 +169,7 @@ CREATE TABLE inventory_index (
     description VARCHAR(2048),
     active BOOLEAN,
     moved_to_box_id INT,
-    PRIMARY KEY (box_id, box_index, item_number)
+    PRIMARY KEY (box_id, box_index)
 );
 
 CREATE TABLE item (
@@ -189,7 +189,8 @@ CREATE TABLE item_inventory_photo (
     status VARCHAR(32),
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
-    uploaded_at TIMESTAMP
+    uploaded_at TIMESTAMP,
+    CONSTRAINT uq_item_service_key UNIQUE (s3_key)
 );
 
 CREATE TABLE external_image_album (
@@ -290,3 +291,138 @@ CREATE TABLE transaction_item_cost (
     amount DOUBLE,
     notes VARCHAR(2048)
 );
+
+ALTER TABLE external_service
+    ADD CONSTRAINT fk_external_service_external_service_type1
+    FOREIGN KEY (external_service_type_id) REFERENCES external_service_type (external_service_type_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE category
+    ADD CONSTRAINT fk_category_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item
+    ADD CONSTRAINT fk_external_item_category1
+    FOREIGN KEY (external_service_id, external_category_id) REFERENCES category (external_service_id, external_category_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory
+    ADD CONSTRAINT fk_item_inventory_condition1
+    FOREIGN KEY (item_condition_id) REFERENCES `condition` (condition_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory
+    ADD CONSTRAINT fk_item_inventory_condition2
+    FOREIGN KEY (instructions_condition_id) REFERENCES `condition` (condition_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_service_item
+    ADD CONSTRAINT fk_external_service_item_external_item1
+    FOREIGN KEY (external_item_id) REFERENCES external_item (external_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_service_item
+    ADD CONSTRAINT fk_external_service_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item_inventory
+    ADD CONSTRAINT fk_external_item_has_item_inventory_external_item1
+    FOREIGN KEY (external_item_id) REFERENCES external_item (external_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item_inventory
+    ADD CONSTRAINT fk_external_item_has_item_inventory_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE bricklink_item_inventory
+    ADD CONSTRAINT fk_bricklink_item_inventory_external_item_inventory1
+    FOREIGN KEY (external_item_id, item_inventory_id) REFERENCES external_item_inventory (external_item_id, item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory_photo
+    ADD CONSTRAINT fk_item_inventory_photo_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album
+    ADD CONSTRAINT fk_external_image_album_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album
+    ADD CONSTRAINT fk_external_image_album_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image
+    ADD CONSTRAINT fk_external_image_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image
+    ADD CONSTRAINT fk_external_image_item_inventory_photo1
+    FOREIGN KEY (item_inventory_photo_id) REFERENCES item_inventory_photo (item_inventory_photo_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album_image
+    ADD CONSTRAINT fk_external_image_album_image_album1
+    FOREIGN KEY (external_image_album_id) REFERENCES external_image_album (external_image_album_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album_image
+    ADD CONSTRAINT fk_external_image_album_image_image1
+    FOREIGN KEY (external_image_id) REFERENCES external_image (external_image_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_party1
+    FOREIGN KEY (from_party_id) REFERENCES party (party_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_party2
+    FOREIGN KEY (to_party_id) REFERENCES party (party_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_transaction_platform1
+    FOREIGN KEY (transaction_platform_id) REFERENCES transaction_platform (transaction_platform_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_transactions1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_transaction_type1
+    FOREIGN KEY (transaction_type_code) REFERENCES transaction_type (transaction_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_cost
+    ADD CONSTRAINT fk_transaction_cost_transactions1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_cost
+    ADD CONSTRAINT fk_transaction_cost_cost_type10
+    FOREIGN KEY (cost_type_code) REFERENCES cost_type (cost_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item_cost
+    ADD CONSTRAINT fk_transaction_item_cost_transaction_item1
+    FOREIGN KEY (transaction_item_id) REFERENCES transaction_item (transaction_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item_cost
+    ADD CONSTRAINT fk_transaction_cost_cost_type1
+    FOREIGN KEY (cost_type_code) REFERENCES cost_type (cost_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/CategoryMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/CategoryMapperTest.java
@@ -16,13 +16,13 @@ class CategoryMapperTest extends MapperTestSupport {
         categoryMapper.insert(category);
         category.setCategoryName("LEGO Parts");
         categoryMapper.update(category);
-        categoryMapper.upsert(category(2, 101, "Updated Parts", 100));
+        categoryMapper.upsert(category(2, 101, "Updated Parts", 5));
 
         assertThat(categoryMapper.findCategoryByExternalServiceAndCategoryId(2, 101))
                 .hasValueSatisfying(found -> {
                     assertThat(found.getCategoryName()).isEqualTo("Updated Parts");
-                    assertThat(found.getParentId()).isEqualTo(100);
+                    assertThat(found.getParentId()).isEqualTo(5);
                 });
-        assertThat(categoryMapper.findAll()).extracting(Category::getExternalCategoryId).containsExactlyInAnyOrder(100, 101);
+        assertThat(categoryMapper.findAll()).extracting(Category::getExternalCategoryId).containsExactlyInAnyOrder(5, 101);
     }
 }

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/CurrentLookupDataTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/CurrentLookupDataTest.java
@@ -1,0 +1,49 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.Carrier;
+import io.legohunter.data.dto.Category;
+import io.legohunter.data.dto.Condition;
+import io.legohunter.data.dto.CostType;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ExternalServiceType;
+import io.legohunter.data.dto.PaymentPlatform;
+import io.legohunter.data.dto.TransactionPlatform;
+import io.legohunter.data.dto.TransactionType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MapperTestConfiguration.class)
+@Sql(scripts = {
+        "/scripts/db/h2/current_schema.ddl",
+        "/scripts/db/h2/current_lookup_data.sql"
+})
+class CurrentLookupDataTest extends MapperTestSupport {
+
+    @Test
+    void loadsSandboxLookupReferenceData() {
+        assertThat(carrierMapper.findAll()).extracting(Carrier::getCarrierCode)
+                .containsExactlyInAnyOrder("DHL", "FEDEX", "UPS", "USPS");
+        assertThat(conditionMapper.findAll()).extracting(Condition::getConditionCode)
+                .containsExactlyInAnyOrder("M", "E", "VG", "G", "P", "NA", "F", "MS", "CC", "BW", "SL");
+        assertThat(costTypeMapper.findAll()).extracting(CostType::getCostTypeCode)
+                .containsExactlyInAnyOrder("DISCOUNT", "FEE", "INSURANCE", "PRICE", "SHIPPING", "TAX");
+        assertThat(transactionTypeMapper.findAll()).extracting(TransactionType::getTransactionTypeCode)
+                .containsExactlyInAnyOrder("A", "B", "F", "G", "P", "RM", "S", "TG", "TR", "YS");
+        assertThat(transactionPlatformMapper.findAll()).extracting(TransactionPlatform::getTransactionPlatformName)
+                .containsExactlyInAnyOrder("Bricklink", "eBay", "Private", "CataWiki", "Lauritz");
+        assertThat(paymentPlatformMapper.findAll()).extracting(PaymentPlatform::getPaymentPlatformName)
+                .containsExactlyInAnyOrder("PayPal", "Credit Card");
+        assertThat(externalServiceTypeMapper.findAll()).extracting(ExternalServiceType::getExternalServiceTypeName)
+                .containsExactlyInAnyOrder("LEGO", "MARKETPLACE", "AUCTION", "THIRDPARTY");
+        assertThat(externalServiceMapper.findAll()).extracting(ExternalService::getExternalServiceName)
+                .containsExactlyInAnyOrder("LEGO", "BRICKLINK", "EBAY", "CATAWIKI", "LAURITZ", "QXL", "PNW Steam Shop", "Brick Model Railroader", "Rebrickable");
+        assertThat(categoryMapper.findAll()).extracting(Category::getCategoryName)
+                .containsExactlyInAnyOrder("Brick", "Star Wars", "The Hobbit and The Lord of the Rings", "Technic", "Star Wars");
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalItemMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalItemMapperTest.java
@@ -11,7 +11,7 @@ class ExternalItemMapperTest extends MapperTestSupport {
     @Test
     void insertUpdateFindsAndUpsert() {
         seedExternalCatalog();
-        ExternalItem externalItem = externalItem("3001-1", 123L, "Brick 2 x 4", 100, 2);
+        ExternalItem externalItem = externalItem("3001-1", 123L, "Brick 2 x 4", 5, 2);
 
         externalItemMapper.insert(externalItem);
         assertThat(externalItem.getExternalItemId()).isNotNull();
@@ -23,7 +23,7 @@ class ExternalItemMapperTest extends MapperTestSupport {
                 .hasValueSatisfying(found -> {
                     assertThat(found.getName()).isEqualTo("Brick 2 x 4 Updated");
                     assertThat(found.getExternalService().getExternalServiceName()).isEqualTo("BRICKLINK");
-                    assertThat(found.getCategory().getCategoryName()).isEqualTo("Sets");
+                    assertThat(found.getCategory().getCategoryName()).isEqualTo("Brick");
                 });
         assertThat(externalItemMapper.findByExternalServiceAndUniqueId(2, 123))
                 .hasValueSatisfying(found -> assertThat(found.getExternalNumber()).isEqualTo("3001-1"));
@@ -33,7 +33,7 @@ class ExternalItemMapperTest extends MapperTestSupport {
                 .extracting(ExternalItem::getExternalNumber)
                 .containsExactly("3001-1");
 
-        externalItemMapper.upsert(externalItem("3001-1", 456L, "Brick 2 x 4 Upserted", 100, 2));
+        externalItemMapper.upsert(externalItem("3001-1", 456L, "Brick 2 x 4 Upserted", 5, 2));
 
         assertThat(externalItemMapper.findByExternalServiceAndNumber(2, "3001-1"))
                 .hasValueSatisfying(found -> assertThat(found.getName()).isEqualTo("Brick 2 x 4 Upserted"));

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapperTest.java
@@ -12,9 +12,9 @@ class ExternalServiceMapperTest extends MapperTestSupport {
     @Test
     void insertUpdateFindByIdFindByNameAndFindAll() {
         externalServiceTypeMapper.insertExternalServiceType(ExternalServiceType.builder()
-                .externalServiceTypeId(1)
-                .externalServiceTypeName("Marketplace")
-                .externalServiceTypeDescription("Marketplace APIs")
+                .externalServiceTypeId(2)
+                .externalServiceTypeName("MARKETPLACE")
+                .externalServiceTypeDescription("Marketplace")
                 .build());
         ExternalService service = externalService(2, "BRICKLINK");
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
@@ -10,6 +10,7 @@ class ItemInventoryMapperTest extends MapperTestSupport {
 
     @Test
     void insertUpdateFindsAndUpsert() {
+        seedDefaultCondition();
         ItemInventory itemInventory = itemInventory("uuid-inventory");
 
         itemInventoryMapper.insert(itemInventory);

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -2,6 +2,7 @@ package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.BricklinkItemInventory;
 import io.legohunter.data.dto.Category;
+import io.legohunter.data.dto.Condition;
 import io.legohunter.data.dto.ExternalItem;
 import io.legohunter.data.dto.ExternalItemInventory;
 import io.legohunter.data.dto.ExternalImage;
@@ -51,12 +52,12 @@ abstract class MapperTestSupport {
 
     void seedExternalCatalog() {
         externalServiceTypeMapper.insertExternalServiceType(ExternalServiceType.builder()
-                .externalServiceTypeId(1)
-                .externalServiceTypeName("Marketplace")
-                .externalServiceTypeDescription("Marketplace APIs")
+                .externalServiceTypeId(2)
+                .externalServiceTypeName("MARKETPLACE")
+                .externalServiceTypeDescription("Marketplace")
                 .build());
         externalServiceMapper.insertExternalService(externalService(2, "BRICKLINK"));
-        categoryMapper.insert(category(2, 100, "Sets", null));
+        categoryMapper.insert(category(2, 5, "Brick", null));
     }
 
     ExternalService externalService(Integer id, String name) {
@@ -64,7 +65,7 @@ abstract class MapperTestSupport {
         service.setExternalServiceId(id);
         service.setExternalServiceName(name);
         service.setExternalServiceUrl("https://" + name.toLowerCase() + ".example");
-        service.setExternalServiceTypeId(1);
+        service.setExternalServiceTypeId(2);
         return service;
     }
 
@@ -108,14 +109,29 @@ abstract class MapperTestSupport {
     }
 
     ItemInventory insertItemInventory(String uuid) {
+        seedDefaultCondition();
         ItemInventory itemInventory = itemInventory(uuid);
         itemInventoryMapper.insert(itemInventory);
         return itemInventory;
     }
 
+    void seedDefaultCondition() {
+        conditionMapper.findConditionById(1)
+                .orElseGet(() -> {
+                    Condition condition = Condition.builder()
+                            .conditionId(1)
+                            .conditionCode("G")
+                            .conditionDescription("Good")
+                            .conditionText("Good")
+                            .build();
+                    conditionMapper.insert(condition);
+                    return condition;
+                });
+    }
+
     ExternalItem insertExternalItem(String number) {
         seedExternalCatalog();
-        ExternalItem externalItem = externalItem(number, 789L, "Bricklink item", 100, 2);
+        ExternalItem externalItem = externalItem(number, 789L, "Bricklink item", 5, 2);
         externalItemMapper.insert(externalItem);
         return externalItem;
     }

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_lookup_data.sql
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_lookup_data.sql
@@ -1,0 +1,73 @@
+INSERT INTO carrier (carrier_code, carrier_name, tracking_url_pattern) VALUES
+    ('DHL', 'Dalsey, Hillblom and Lynn', 'https://www.dhl.com/us-en/home/tracking.html?tracking-id=%s&submit=1'),
+    ('FEDEX', 'Federal Express', 'https://www.fedex.com/fedextrack/?action=track&trackingnumber=%s'),
+    ('UPS', 'United Parcel Service', 'http://wwwapps.ups.com/WebTracking/processRequest?HTMLVersion=5.0&Requester=NES&AgreeToTermsAndConditions=yes&loc=en_US&tracknum=%s'),
+    ('USPS', 'United States Postal Service', 'https://tools.usps.com/go/TrackConfirmAction.action?tLabels=%s');
+
+INSERT INTO `condition` (condition_id, condition_code, condition_description, condition_text) VALUES
+    (1, 'M', 'Mint', NULL),
+    (2, 'E', 'Excellent', NULL),
+    (3, 'VG', 'Very Good', NULL),
+    (4, 'G', 'Good', NULL),
+    (5, 'P', 'Poor', NULL),
+    (6, 'NA', 'Not Applicable', NULL),
+    (7, 'F', 'Fair', NULL),
+    (8, 'MS', 'Missing', NULL),
+    (9, 'CC', 'Color Copy', NULL),
+    (10, 'BW', 'Black & White Copy', NULL),
+    (11, 'SL', 'Sealed', 'Mint in sealed box');
+
+INSERT INTO cost_type (cost_type_code, cost_type_name, cost_type_description) VALUES
+    ('DISCOUNT', 'Discount', 'A Discount added to an item or entire order'),
+    ('FEE', 'Fee', 'A fee added to an item or entire order'),
+    ('INSURANCE', 'Insurance', 'The cost for insurance to ship an item or an entire order'),
+    ('PRICE', 'Price', 'The for-sale price or purchase cost of an item'),
+    ('SHIPPING', 'Shipping', 'The cost of shipping an item or an entire order'),
+    ('TAX', 'Tax', 'The sales tax amount added to an item or entire order');
+
+INSERT INTO transaction_type (transaction_type_code, transaction_type_description, conversion_factor) VALUES
+    ('A', 'Auction Purchase', 1),
+    ('B', 'Built from Loose Pieces', 1),
+    ('F', 'Find', 1),
+    ('G', 'Gift', 1),
+    ('P', 'Purchase', 1),
+    ('RM', 'Removed', -1),
+    ('S', 'Sale', -1),
+    ('TG', 'Trade Give', -1),
+    ('TR', 'Trade Receive', 1),
+    ('YS', 'Yard Sale/Flea Market Purchase', 1);
+
+INSERT INTO transaction_platform (transaction_platform_id, transaction_platform_name) VALUES
+    (1, 'Bricklink'),
+    (2, 'eBay'),
+    (3, 'Private'),
+    (4, 'CataWiki'),
+    (5, 'Lauritz');
+
+INSERT INTO payment_platform (payment_platform_id, payment_platform_name, payment_platform_url) VALUES
+    (1, 'PayPal', 'https://www.paypal.com/'),
+    (2, 'Credit Card', NULL);
+
+INSERT INTO external_service_type (external_service_type_id, external_service_type_name, external_service_type_description) VALUES
+    (1, 'LEGO', 'LEGO'),
+    (2, 'MARKETPLACE', 'Marketplace'),
+    (3, 'AUCTION', 'Auction'),
+    (4, 'THIRDPARTY', 'Third Party Producer');
+
+INSERT INTO external_service (external_service_id, external_service_name, external_service_url, external_service_type_id) VALUES
+    (1, 'LEGO', 'https://www.lego.com', 1),
+    (2, 'BRICKLINK', 'https://www.bricklink.com', 2),
+    (3, 'EBAY', 'https://www.ebay.com', 3),
+    (4, 'CATAWIKI', 'https://www.catawiki.com', 3),
+    (5, 'LAURITZ', 'https://www.lauritz.com', 3),
+    (6, 'QXL', 'https://www.qxl.dk', 3),
+    (7, 'PNW Steam Shop', 'https://www.pnwsteamshop.com', 4),
+    (8, 'Brick Model Railroader', 'https://brickmodelrailroader.com', 4),
+    (9, 'Rebrickable', 'https://rebrickable.com', 2);
+
+INSERT INTO category (external_service_id, external_category_id, category_name, parent_id) VALUES
+    (2, 5, 'Brick', NULL),
+    (2, 65, 'Star Wars', NULL),
+    (2, 789, 'The Hobbit and The Lord of the Rings', NULL),
+    (9, 1, 'Technic', NULL),
+    (9, 18, 'Star Wars', 1);

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -169,7 +169,7 @@ CREATE TABLE inventory_index (
     description VARCHAR(2048),
     active BOOLEAN,
     moved_to_box_id INT,
-    PRIMARY KEY (box_id, box_index, item_number)
+    PRIMARY KEY (box_id, box_index)
 );
 
 CREATE TABLE item (
@@ -189,7 +189,8 @@ CREATE TABLE item_inventory_photo (
     status VARCHAR(32),
     created_at TIMESTAMP,
     updated_at TIMESTAMP,
-    uploaded_at TIMESTAMP
+    uploaded_at TIMESTAMP,
+    CONSTRAINT uq_item_service_key UNIQUE (s3_key)
 );
 
 CREATE TABLE external_image_album (
@@ -290,3 +291,138 @@ CREATE TABLE transaction_item_cost (
     amount DOUBLE,
     notes VARCHAR(2048)
 );
+
+ALTER TABLE external_service
+    ADD CONSTRAINT fk_external_service_external_service_type1
+    FOREIGN KEY (external_service_type_id) REFERENCES external_service_type (external_service_type_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE category
+    ADD CONSTRAINT fk_category_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item
+    ADD CONSTRAINT fk_external_item_category1
+    FOREIGN KEY (external_service_id, external_category_id) REFERENCES category (external_service_id, external_category_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory
+    ADD CONSTRAINT fk_item_inventory_condition1
+    FOREIGN KEY (item_condition_id) REFERENCES `condition` (condition_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory
+    ADD CONSTRAINT fk_item_inventory_condition2
+    FOREIGN KEY (instructions_condition_id) REFERENCES `condition` (condition_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_service_item
+    ADD CONSTRAINT fk_external_service_item_external_item1
+    FOREIGN KEY (external_item_id) REFERENCES external_item (external_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_service_item
+    ADD CONSTRAINT fk_external_service_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item_inventory
+    ADD CONSTRAINT fk_external_item_has_item_inventory_external_item1
+    FOREIGN KEY (external_item_id) REFERENCES external_item (external_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_item_inventory
+    ADD CONSTRAINT fk_external_item_has_item_inventory_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE bricklink_item_inventory
+    ADD CONSTRAINT fk_bricklink_item_inventory_external_item_inventory1
+    FOREIGN KEY (external_item_id, item_inventory_id) REFERENCES external_item_inventory (external_item_id, item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE item_inventory_photo
+    ADD CONSTRAINT fk_item_inventory_photo_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album
+    ADD CONSTRAINT fk_external_image_album_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album
+    ADD CONSTRAINT fk_external_image_album_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image
+    ADD CONSTRAINT fk_external_image_external_service1
+    FOREIGN KEY (external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image
+    ADD CONSTRAINT fk_external_image_item_inventory_photo1
+    FOREIGN KEY (item_inventory_photo_id) REFERENCES item_inventory_photo (item_inventory_photo_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album_image
+    ADD CONSTRAINT fk_external_image_album_image_album1
+    FOREIGN KEY (external_image_album_id) REFERENCES external_image_album (external_image_album_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE external_image_album_image
+    ADD CONSTRAINT fk_external_image_album_image_image1
+    FOREIGN KEY (external_image_id) REFERENCES external_image (external_image_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_party1
+    FOREIGN KEY (from_party_id) REFERENCES party (party_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_party2
+    FOREIGN KEY (to_party_id) REFERENCES party (party_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_transaction_platform1
+    FOREIGN KEY (transaction_platform_id) REFERENCES transaction_platform (transaction_platform_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_transactions1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_transaction_type1
+    FOREIGN KEY (transaction_type_code) REFERENCES transaction_type (transaction_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item
+    ADD CONSTRAINT fk_transaction_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_cost
+    ADD CONSTRAINT fk_transaction_cost_transactions1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_cost
+    ADD CONSTRAINT fk_transaction_cost_cost_type10
+    FOREIGN KEY (cost_type_code) REFERENCES cost_type (cost_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item_cost
+    ADD CONSTRAINT fk_transaction_item_cost_transaction_item1
+    FOREIGN KEY (transaction_item_id) REFERENCES transaction_item (transaction_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE transaction_item_cost
+    ADD CONSTRAINT fk_transaction_cost_cost_type1
+    FOREIGN KEY (cost_type_code) REFERENCES cost_type (cost_type_code)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;


### PR DESCRIPTION
## Summary
- mirror current MySQL model constraints in the H2 current_schema fixtures used by mapper and DAO tests
- add sandbox-derived lookup/reference seed data for current H2 tests
- add mapper coverage validating the lookup fixture and update DAO/mapper tests to use realistic reference rows

## Verification
- mvn clean install