### PR TITLE
Flickr Integration Phase 3: sync work discovery

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
@@ -6,9 +6,11 @@ import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 @Component
 @RequiredArgsConstructor
@@ -40,7 +42,33 @@ public class ExternalImageDao {
     }
 
     public List<Integer> findItemInventoryIdsNeedingSync(Integer externalServiceId, boolean includeFailed, int limit) {
-        return externalImageMapper.findItemInventoryIdsNeedingSync(externalServiceId, includeFailed, limit);
+        int effectiveLimit = Math.max(1, limit);
+        LinkedHashSet<Integer> itemInventoryIds = new LinkedHashSet<>();
+        addUntilLimit(
+                itemInventoryIds,
+                effectiveLimit,
+                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsMissingExternalImages(serviceId, queryLimit),
+                externalServiceId
+        );
+        addUntilLimit(
+                itemInventoryIds,
+                effectiveLimit,
+                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(serviceId, queryLimit),
+                externalServiceId
+        );
+        addUntilLimit(
+                itemInventoryIds,
+                effectiveLimit,
+                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsWithUnsyncedImages(serviceId, includeFailed, queryLimit),
+                externalServiceId
+        );
+        addUntilLimit(
+                itemInventoryIds,
+                effectiveLimit,
+                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsWithMetadataDrift(serviceId, queryLimit),
+                externalServiceId
+        );
+        return List.copyOf(itemInventoryIds);
     }
 
     public ExternalImage insert(ExternalImage externalImage) {
@@ -77,5 +105,24 @@ public class ExternalImageDao {
                 .map(ExternalImage::getMetadataHashAtSync)
                 .filter(metadataHash::equals)
                 .isPresent();
+    }
+
+    private void addUntilLimit(
+            LinkedHashSet<Integer> itemInventoryIds,
+            int limit,
+            BiFunction<Integer, Integer, List<Integer>> query,
+            Integer externalServiceId
+    ) {
+        if (itemInventoryIds.size() >= limit) {
+            return;
+        }
+        itemInventoryIds.addAll(query.apply(externalServiceId, limit));
+        if (itemInventoryIds.size() > limit) {
+            List<Integer> limited = itemInventoryIds.stream()
+                    .limit(limit)
+                    .toList();
+            itemInventoryIds.clear();
+            itemInventoryIds.addAll(limited);
+        }
     }
 }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
@@ -6,6 +6,7 @@ import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -36,6 +37,10 @@ public class ExternalImageDao {
 
     public Set<ExternalImage> findBySyncStatus(ExternalSyncStatus syncStatus) {
         return externalImageMapper.findBySyncStatus(syncStatus);
+    }
+
+    public List<Integer> findItemInventoryIdsNeedingSync(Integer externalServiceId, boolean includeFailed, int limit) {
+        return externalImageMapper.findItemInventoryIdsNeedingSync(externalServiceId, includeFailed, limit);
     }
 
     public ExternalImage insert(ExternalImage externalImage) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoTest.java
@@ -96,6 +96,8 @@ class ExternalImageDaoTest {
         assertThat(externalImageDao.hasUploadedMd5(10, photo.getItemInventoryPhotoId(), "ffffffffffffffffffffffffffffffff")).isFalse();
         assertThat(externalImageDao.hasSyncedMetadataHash(10, photo.getItemInventoryPhotoId(), "metadata-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")).isTrue();
         assertThat(externalImageDao.hasSyncedMetadataHash(10, photo.getItemInventoryPhotoId(), "different-metadata")).isFalse();
+        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, false, 10))
+                .containsExactly(itemInventory.getItemInventoryId());
 
         image.setMd5AtUpload("ffffffffffffffffffffffffffffffff");
         image.setMetadataHashAtSync("metadata-updated");

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
@@ -1,0 +1,67 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalImageDaoUnitTest {
+    @Mock
+    private ExternalImageMapper externalImageMapper;
+
+    private ExternalImageDao externalImageDao;
+
+    @BeforeEach
+    void setUp() {
+        externalImageDao = new ExternalImageDao(externalImageMapper);
+    }
+
+    @Test
+    void findItemInventoryIdsNeedingSyncMergesFocusedQueriesInPriorityOrder() {
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 10))
+                .thenReturn(List.of(100, 101));
+        when(externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(10, 10))
+                .thenReturn(List.of(101, 102));
+        when(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, true, 10))
+                .thenReturn(List.of(102, 103));
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+                .thenReturn(List.of(103, 104));
+
+        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, true, 10))
+                .containsExactly(100, 101, 102, 103, 104);
+
+        verify(externalImageMapper).findItemInventoryIdsWithUnsyncedImages(10, true, 10);
+    }
+
+    @Test
+    void findItemInventoryIdsNeedingSyncAppliesLimitAndStopsWhenFull() {
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 2))
+                .thenReturn(List.of(100, 101));
+
+        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, false, 2))
+                .containsExactly(100, 101);
+
+        verify(externalImageMapper, never()).findItemInventoryIdsMissingOrUnsyncedAlbums(10, 2);
+        verify(externalImageMapper, never()).findItemInventoryIdsWithUnsyncedImages(10, false, 2);
+        verify(externalImageMapper, never()).findItemInventoryIdsWithMetadataDrift(10, 2);
+    }
+
+    @Test
+    void findItemInventoryIdsNeedingSyncNormalizesInvalidLimitToOne() {
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 1))
+                .thenReturn(List.of(100, 101));
+
+        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, false, 0))
+                .containsExactly(100);
+    }
+}

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -240,6 +240,13 @@ CREATE TABLE external_image_album_image (
     PRIMARY KEY (external_image_album_id, external_image_id)
 );
 
+CREATE INDEX idx_item_inventory_photo_status_inventory
+    ON item_inventory_photo (status, item_inventory_id);
+CREATE INDEX idx_external_image_service_photo_status_metadata
+    ON external_image (external_service_id, item_inventory_photo_id, sync_status, metadata_hash_at_sync);
+CREATE INDEX idx_external_image_album_service_inventory_status
+    ON external_image_album (external_service_id, item_inventory_id, sync_status);
+
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     party_first_name VARCHAR(255),

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
@@ -70,33 +70,74 @@ public interface ExternalImageMapper {
             LEFT JOIN external_image image
               ON image.item_inventory_photo_id = photo.item_inventory_photo_id
              AND image.external_service_id = #{externalServiceId}
+            WHERE photo.status = 'PROCESSED'
+              AND image.external_image_id IS NULL
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsMissingExternalImages(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
             LEFT JOIN external_image_album album
               ON album.item_inventory_id = photo.item_inventory_id
              AND album.external_service_id = #{externalServiceId}
             WHERE photo.status = 'PROCESSED'
               AND (
-                    image.external_image_id IS NULL
-                 OR album.external_image_album_id IS NULL
+                    album.external_image_album_id IS NULL
                  OR album.sync_status <> 'SYNCED'
-                 OR (
-                        image.sync_status <> 'SYNCED'
-                    AND (image.sync_status <> 'FAILED' OR #{includeFailed} = TRUE)
-                    )
-                 OR (
-                        image.external_service_image_id IS NOT NULL
-                    AND (
-                            (photo.metadata_hash IS NULL AND image.metadata_hash_at_sync IS NOT NULL)
-                         OR (photo.metadata_hash IS NOT NULL AND image.metadata_hash_at_sync IS NULL)
-                         OR photo.metadata_hash <> image.metadata_hash_at_sync
-                        )
-                    )
               )
             ORDER BY photo.item_inventory_id
             LIMIT #{limit}
             """)
-    List<Integer> findItemInventoryIdsNeedingSync(
+    List<Integer> findItemInventoryIdsMissingOrUnsyncedAlbums(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
+            INNER JOIN external_image image
+              ON image.item_inventory_photo_id = photo.item_inventory_photo_id
+             AND image.external_service_id = #{externalServiceId}
+            WHERE photo.status = 'PROCESSED'
+              AND image.sync_status <> 'SYNCED'
+              AND (
+                    image.sync_status <> 'FAILED'
+                 OR #{includeFailed} = TRUE
+              )
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsWithUnsyncedImages(
             @Param("externalServiceId") Integer externalServiceId,
             @Param("includeFailed") boolean includeFailed,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
+            INNER JOIN external_image image
+              ON image.item_inventory_photo_id = photo.item_inventory_photo_id
+             AND image.external_service_id = #{externalServiceId}
+            WHERE photo.status = 'PROCESSED'
+              AND image.external_service_image_id IS NOT NULL
+              AND (
+                    (photo.metadata_hash IS NULL AND image.metadata_hash_at_sync IS NOT NULL)
+                 OR (photo.metadata_hash IS NOT NULL AND image.metadata_hash_at_sync IS NULL)
+                 OR photo.metadata_hash <> image.metadata_hash_at_sync
+              )
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsWithMetadataDrift(
+            @Param("externalServiceId") Integer externalServiceId,
             @Param("limit") int limit
     );
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
@@ -5,10 +5,12 @@ import io.legohunter.data.enums.ExternalSyncStatus;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -61,6 +63,42 @@ public interface ExternalImageMapper {
     @Select("SELECT " + ALL_COLUMNS + " FROM external_image WHERE sync_status = #{syncStatus.name}")
     @ResultMap("externalImageResultMap")
     Set<ExternalImage> findBySyncStatus(ExternalSyncStatus syncStatus);
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
+            LEFT JOIN external_image image
+              ON image.item_inventory_photo_id = photo.item_inventory_photo_id
+             AND image.external_service_id = #{externalServiceId}
+            LEFT JOIN external_image_album album
+              ON album.item_inventory_id = photo.item_inventory_id
+             AND album.external_service_id = #{externalServiceId}
+            WHERE photo.status = 'PROCESSED'
+              AND (
+                    image.external_image_id IS NULL
+                 OR album.external_image_album_id IS NULL
+                 OR album.sync_status <> 'SYNCED'
+                 OR (
+                        image.sync_status <> 'SYNCED'
+                    AND (image.sync_status <> 'FAILED' OR #{includeFailed} = TRUE)
+                    )
+                 OR (
+                        image.external_service_image_id IS NOT NULL
+                    AND (
+                            (photo.metadata_hash IS NULL AND image.metadata_hash_at_sync IS NOT NULL)
+                         OR (photo.metadata_hash IS NOT NULL AND image.metadata_hash_at_sync IS NULL)
+                         OR photo.metadata_hash <> image.metadata_hash_at_sync
+                        )
+                    )
+              )
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsNeedingSync(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("includeFailed") boolean includeFailed,
+            @Param("limit") int limit
+    );
 
     @Insert("""
             INSERT INTO external_image (

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
@@ -75,7 +75,7 @@ class ExternalImageMapperTest extends MapperTestSupport {
     }
 
     @Test
-    void findItemInventoryIdsNeedingSyncFindsDistinctPendingFlickrWork() {
+    void findItemInventoryIdsNeedingSyncWorkFindsEachFocusedWorkType() {
         insertImageHostingService();
         ItemInventory missingImageInventory = insertItemInventory("uuid-missing-image");
         insertItemInventoryPhoto(missingImageInventory.getItemInventoryId(), "11111111111111111111111111111111");
@@ -105,6 +105,14 @@ class ExternalImageMapperTest extends MapperTestSupport {
         failedImageAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(failedImageAlbum);
 
+        ItemInventory pendingImageInventory = insertItemInventory("uuid-pending-image");
+        ItemInventoryPhoto pendingImagePhoto = insertItemInventoryPhoto(pendingImageInventory.getItemInventoryId(), "66666666666666666666666666666666");
+        ExternalImage pendingImage = externalImage(10, pendingImagePhoto.getItemInventoryPhotoId(), "image-pending", "66666666666666666666666666666666");
+        externalImageMapper.insert(pendingImage);
+        ExternalImageAlbum pendingImageAlbum = externalImageAlbum(10, pendingImageInventory.getItemInventoryId(), "album-pending");
+        pendingImageAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(pendingImageAlbum);
+
         ItemInventory syncedInventory = insertItemInventory("uuid-synced");
         ItemInventoryPhoto syncedPhoto = insertItemInventoryPhoto(syncedInventory.getItemInventoryId(), "55555555555555555555555555555555");
         ExternalImage syncedImage = externalImage(10, syncedPhoto.getItemInventoryPhotoId(), "image-synced", "55555555555555555555555555555555");
@@ -114,24 +122,24 @@ class ExternalImageMapperTest extends MapperTestSupport {
         syncedAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(syncedAlbum);
 
-        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, false, 10))
+        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 10))
+                .containsExactly(missingImageInventory.getItemInventoryId());
+        assertThat(externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(10, 10))
                 .containsExactly(
                         missingImageInventory.getItemInventoryId(),
-                        metadataMismatchInventory.getItemInventoryId(),
                         missingAlbumInventory.getItemInventoryId()
                 );
-        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, true, 10))
+        assertThat(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, false, 10))
+                .containsExactly(pendingImageInventory.getItemInventoryId());
+        assertThat(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, true, 10))
                 .containsExactly(
-                        missingImageInventory.getItemInventoryId(),
-                        metadataMismatchInventory.getItemInventoryId(),
-                        missingAlbumInventory.getItemInventoryId(),
-                        failedImageInventory.getItemInventoryId()
+                        failedImageInventory.getItemInventoryId(),
+                        pendingImageInventory.getItemInventoryId()
                 );
-        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, true, 2))
-                .containsExactly(
-                        missingImageInventory.getItemInventoryId(),
-                        metadataMismatchInventory.getItemInventoryId()
-                );
+        assertThat(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+                .containsExactly(metadataMismatchInventory.getItemInventoryId());
+        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 1))
+                .containsExactly(missingImageInventory.getItemInventoryId());
     }
 
     private void insertImageHostingService() {

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
@@ -1,6 +1,7 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ExternalImageAlbum;
 import io.legohunter.data.dto.ExternalService;
 import io.legohunter.data.dto.ExternalServiceType;
 import io.legohunter.data.dto.ItemInventory;
@@ -71,6 +72,66 @@ class ExternalImageMapperTest extends MapperTestSupport {
 
         externalImageMapper.insert(image);
         assertThat(externalImageMapper.deleteByExternalImageId(image.getExternalImageId())).isOne();
+    }
+
+    @Test
+    void findItemInventoryIdsNeedingSyncFindsDistinctPendingFlickrWork() {
+        insertImageHostingService();
+        ItemInventory missingImageInventory = insertItemInventory("uuid-missing-image");
+        insertItemInventoryPhoto(missingImageInventory.getItemInventoryId(), "11111111111111111111111111111111");
+
+        ItemInventory metadataMismatchInventory = insertItemInventory("uuid-metadata-mismatch");
+        ItemInventoryPhoto metadataMismatchPhoto = insertItemInventoryPhoto(metadataMismatchInventory.getItemInventoryId(), "22222222222222222222222222222222");
+        ExternalImage metadataMismatchImage = externalImage(10, metadataMismatchPhoto.getItemInventoryPhotoId(), "image-metadata-mismatch", "22222222222222222222222222222222");
+        metadataMismatchImage.setMetadataHashAtSync("old-metadata");
+        metadataMismatchImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(metadataMismatchImage);
+        ExternalImageAlbum metadataMismatchAlbum = externalImageAlbum(10, metadataMismatchInventory.getItemInventoryId(), "album-metadata-mismatch");
+        metadataMismatchAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(metadataMismatchAlbum);
+
+        ItemInventory missingAlbumInventory = insertItemInventory("uuid-missing-album");
+        ItemInventoryPhoto missingAlbumPhoto = insertItemInventoryPhoto(missingAlbumInventory.getItemInventoryId(), "33333333333333333333333333333333");
+        ExternalImage missingAlbumImage = externalImage(10, missingAlbumPhoto.getItemInventoryPhotoId(), "image-missing-album", "33333333333333333333333333333333");
+        missingAlbumImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(missingAlbumImage);
+
+        ItemInventory failedImageInventory = insertItemInventory("uuid-failed-image");
+        ItemInventoryPhoto failedImagePhoto = insertItemInventoryPhoto(failedImageInventory.getItemInventoryId(), "44444444444444444444444444444444");
+        ExternalImage failedImage = externalImage(10, failedImagePhoto.getItemInventoryPhotoId(), "image-failed", "44444444444444444444444444444444");
+        failedImage.setSyncStatus(ExternalSyncStatus.FAILED);
+        externalImageMapper.insert(failedImage);
+        ExternalImageAlbum failedImageAlbum = externalImageAlbum(10, failedImageInventory.getItemInventoryId(), "album-failed");
+        failedImageAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(failedImageAlbum);
+
+        ItemInventory syncedInventory = insertItemInventory("uuid-synced");
+        ItemInventoryPhoto syncedPhoto = insertItemInventoryPhoto(syncedInventory.getItemInventoryId(), "55555555555555555555555555555555");
+        ExternalImage syncedImage = externalImage(10, syncedPhoto.getItemInventoryPhotoId(), "image-synced", "55555555555555555555555555555555");
+        syncedImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(syncedImage);
+        ExternalImageAlbum syncedAlbum = externalImageAlbum(10, syncedInventory.getItemInventoryId(), "album-synced");
+        syncedAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(syncedAlbum);
+
+        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, false, 10))
+                .containsExactly(
+                        missingImageInventory.getItemInventoryId(),
+                        metadataMismatchInventory.getItemInventoryId(),
+                        missingAlbumInventory.getItemInventoryId()
+                );
+        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, true, 10))
+                .containsExactly(
+                        missingImageInventory.getItemInventoryId(),
+                        metadataMismatchInventory.getItemInventoryId(),
+                        missingAlbumInventory.getItemInventoryId(),
+                        failedImageInventory.getItemInventoryId()
+                );
+        assertThat(externalImageMapper.findItemInventoryIdsNeedingSync(10, true, 2))
+                .containsExactly(
+                        missingImageInventory.getItemInventoryId(),
+                        metadataMismatchInventory.getItemInventoryId()
+                );
     }
 
     private void insertImageHostingService() {

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -240,6 +240,13 @@ CREATE TABLE external_image_album_image (
     PRIMARY KEY (external_image_album_id, external_image_id)
 );
 
+CREATE INDEX idx_item_inventory_photo_status_inventory
+    ON item_inventory_photo (status, item_inventory_id);
+CREATE INDEX idx_external_image_service_photo_status_metadata
+    ON external_image (external_service_id, item_inventory_photo_id, sync_status, metadata_hash_at_sync);
+CREATE INDEX idx_external_image_album_service_inventory_status
+    ON external_image_album (external_service_id, item_inventory_id, sync_status);
+
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     party_first_name VARCHAR(255),


### PR DESCRIPTION
## Summary
- Add data-layer discovery for item inventories with pending Flickr/image-hosting sync work
- Detect missing external images, missing or unsynced albums, retryable failed images, pending image rows, and metadata hash drift
- Add H2 indexes and coverage for mapper and DAO behavior

## Verification
- mvn clean install