### PR TITLE
Add image hosting scheduled sync candidate selection

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
@@ -6,7 +6,8 @@ import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.LinkedHashSet;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -42,33 +43,54 @@ public class ExternalImageDao {
     }
 
     public List<Integer> findItemInventoryIdsNeedingSync(Integer externalServiceId, boolean includeFailed, int limit) {
+        return findItemInventorySyncCandidates(externalServiceId, includeFailed, limit).stream()
+                .map(ImageHostingSyncCandidate::itemInventoryId)
+                .toList();
+    }
+
+    public List<ImageHostingSyncCandidate> findItemInventorySyncCandidates(Integer externalServiceId, boolean includeFailed, int limit) {
         int effectiveLimit = Math.max(1, limit);
-        LinkedHashSet<Integer> itemInventoryIds = new LinkedHashSet<>();
-        addUntilLimit(
-                itemInventoryIds,
+        LinkedHashMap<Integer, EnumSet<ImageHostingSyncCandidateReason>> candidates = new LinkedHashMap<>();
+        addCandidates(
+                candidates,
                 effectiveLimit,
-                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsMissingExternalImages(serviceId, queryLimit),
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
+                externalImageMapper::findItemInventoryIdsMissingAlbumLinks,
                 externalServiceId
         );
-        addUntilLimit(
-                itemInventoryIds,
+        addCandidates(
+                candidates,
                 effectiveLimit,
-                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(serviceId, queryLimit),
+                ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK,
+                externalImageMapper::findItemInventoryIdsMissingExternalImageLinks,
                 externalServiceId
         );
-        addUntilLimit(
-                itemInventoryIds,
+        if (includeFailed) {
+            addCandidates(
+                    candidates,
+                    effectiveLimit,
+                    ImageHostingSyncCandidateReason.FAILED_SYNC,
+                    externalImageMapper::findItemInventoryIdsWithFailedSyncRows,
+                    externalServiceId
+            );
+        }
+        addCandidates(
+                candidates,
                 effectiveLimit,
-                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsWithUnsyncedImages(serviceId, includeFailed, queryLimit),
+                ImageHostingSyncCandidateReason.PENDING_SYNC,
+                externalImageMapper::findItemInventoryIdsWithPendingSyncRows,
                 externalServiceId
         );
-        addUntilLimit(
-                itemInventoryIds,
+        addCandidates(
+                candidates,
                 effectiveLimit,
-                (serviceId, queryLimit) -> externalImageMapper.findItemInventoryIdsWithMetadataDrift(serviceId, queryLimit),
+                ImageHostingSyncCandidateReason.METADATA_CHANGED,
+                externalImageMapper::findItemInventoryIdsWithMetadataDrift,
                 externalServiceId
         );
-        return List.copyOf(itemInventoryIds);
+        return candidates.entrySet().stream()
+                .map(entry -> ImageHostingSyncCandidate.of(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     public ExternalImage insert(ExternalImage externalImage) {
@@ -107,22 +129,25 @@ public class ExternalImageDao {
                 .isPresent();
     }
 
-    private void addUntilLimit(
-            LinkedHashSet<Integer> itemInventoryIds,
+    private void addCandidates(
+            LinkedHashMap<Integer, EnumSet<ImageHostingSyncCandidateReason>> candidates,
             int limit,
+            ImageHostingSyncCandidateReason reason,
             BiFunction<Integer, Integer, List<Integer>> query,
             Integer externalServiceId
     ) {
-        if (itemInventoryIds.size() >= limit) {
-            return;
-        }
-        itemInventoryIds.addAll(query.apply(externalServiceId, limit));
-        if (itemInventoryIds.size() > limit) {
-            List<Integer> limited = itemInventoryIds.stream()
-                    .limit(limit)
-                    .toList();
-            itemInventoryIds.clear();
-            itemInventoryIds.addAll(limited);
+        List<Integer> itemInventoryIds = query.apply(externalServiceId, limit);
+        for (Integer itemInventoryId : itemInventoryIds) {
+            if (itemInventoryId == null) {
+                continue;
+            }
+            if (candidates.containsKey(itemInventoryId)) {
+                candidates.get(itemInventoryId).add(reason);
+                continue;
+            }
+            if (candidates.size() < limit) {
+                candidates.put(itemInventoryId, EnumSet.of(reason));
+            }
         }
     }
 }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidate.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidate.java
@@ -1,0 +1,20 @@
+package io.legohunter.data.dao;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public record ImageHostingSyncCandidate(
+        Integer itemInventoryId,
+        Set<ImageHostingSyncCandidateReason> reasons
+) {
+    public ImageHostingSyncCandidate {
+        reasons = reasons == null || reasons.isEmpty()
+                ? Set.of()
+                : Collections.unmodifiableSet(EnumSet.copyOf(reasons));
+    }
+
+    static ImageHostingSyncCandidate of(Integer itemInventoryId, EnumSet<ImageHostingSyncCandidateReason> reasons) {
+        return new ImageHostingSyncCandidate(itemInventoryId, reasons);
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidateReason.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidateReason.java
@@ -1,0 +1,9 @@
+package io.legohunter.data.dao;
+
+public enum ImageHostingSyncCandidateReason {
+    MISSING_ALBUM_LINK,
+    MISSING_PHOTO_LINK,
+    FAILED_SYNC,
+    PENDING_SYNC,
+    METADATA_CHANGED
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
@@ -27,41 +29,105 @@ class ExternalImageDaoUnitTest {
     }
 
     @Test
-    void findItemInventoryIdsNeedingSyncMergesFocusedQueriesInPriorityOrder() {
-        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 10))
+    void findItemInventorySyncCandidatesMergesFocusedQueriesInPriorityOrderAndTracksReasons() {
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 10))
                 .thenReturn(List.of(100, 101));
-        when(externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(10, 10))
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
                 .thenReturn(List.of(101, 102));
-        when(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, true, 10))
+        when(externalImageMapper.findItemInventoryIdsWithFailedSyncRows(10, 10))
                 .thenReturn(List.of(102, 103));
-        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
                 .thenReturn(List.of(103, 104));
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+                .thenReturn(List.of(104, 105));
 
-        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, true, 10))
-                .containsExactly(100, 101, 102, 103, 104);
+        List<ImageHostingSyncCandidate> candidates = externalImageDao.findItemInventorySyncCandidates(10, true, 10);
 
-        verify(externalImageMapper).findItemInventoryIdsWithUnsyncedImages(10, true, 10);
+        assertThat(candidates)
+                .extracting(ImageHostingSyncCandidate::itemInventoryId)
+                .containsExactly(100, 101, 102, 103, 104, 105);
+        assertThat(candidates.get(1).reasons()).containsExactlyInAnyOrder(
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
+                ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK
+        );
+        assertThat(candidates.get(2).reasons()).containsExactlyInAnyOrder(
+                ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK,
+                ImageHostingSyncCandidateReason.FAILED_SYNC
+        );
+        assertThat(candidates.get(4).reasons()).containsExactlyInAnyOrder(
+                ImageHostingSyncCandidateReason.PENDING_SYNC,
+                ImageHostingSyncCandidateReason.METADATA_CHANGED
+        );
+        verify(externalImageMapper).findItemInventoryIdsWithFailedSyncRows(10, 10);
     }
 
     @Test
-    void findItemInventoryIdsNeedingSyncAppliesLimitAndStopsWhenFull() {
-        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 2))
+    void findItemInventorySyncCandidatesAppliesLimitButStillAddsLaterReasonsForSelectedIds() {
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 2))
                 .thenReturn(List.of(100, 101));
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 2))
+                .thenReturn(List.of(101, 102));
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 2))
+                .thenReturn(List.of(100, 103));
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 2))
+                .thenReturn(List.of(104));
 
-        assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, false, 2))
+        List<ImageHostingSyncCandidate> candidates = externalImageDao.findItemInventorySyncCandidates(10, false, 2);
+
+        assertThat(candidates)
+                .extracting(ImageHostingSyncCandidate::itemInventoryId)
                 .containsExactly(100, 101);
-
-        verify(externalImageMapper, never()).findItemInventoryIdsMissingOrUnsyncedAlbums(10, 2);
-        verify(externalImageMapper, never()).findItemInventoryIdsWithUnsyncedImages(10, false, 2);
-        verify(externalImageMapper, never()).findItemInventoryIdsWithMetadataDrift(10, 2);
+        assertThat(candidates.get(0).reasons()).containsExactlyInAnyOrder(
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
+                ImageHostingSyncCandidateReason.PENDING_SYNC
+        );
+        assertThat(candidates.get(1).reasons()).containsExactlyInAnyOrder(
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
+                ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK
+        );
     }
 
     @Test
     void findItemInventoryIdsNeedingSyncNormalizesInvalidLimitToOne() {
-        when(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 1))
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 1))
                 .thenReturn(List.of(100, 101));
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 1))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 1))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 1))
+                .thenReturn(List.of());
 
         assertThat(externalImageDao.findItemInventoryIdsNeedingSync(10, false, 0))
                 .containsExactly(100);
+    }
+
+    @Test
+    void findItemInventorySyncCandidatesSkipsFailedRowsWhenRetryFailedIsDisabled() {
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 10))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+                .thenReturn(List.of());
+
+        List<ImageHostingSyncCandidate> candidates = externalImageDao.findItemInventorySyncCandidates(10, false, 10);
+
+        assertThat(candidates).isEmpty();
+        verify(externalImageMapper, never()).findItemInventoryIdsWithFailedSyncRows(10, 10);
+    }
+
+    @Test
+    void imageHostingSyncCandidateDefensivelyCopiesReasons() {
+        EnumSet<ImageHostingSyncCandidateReason> reasons =
+                EnumSet.of(ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK);
+
+        ImageHostingSyncCandidate candidate = ImageHostingSyncCandidate.of(100, reasons);
+        reasons.add(ImageHostingSyncCandidateReason.METADATA_CHANGED);
+
+        assertThat(candidate.reasons()).containsExactly(ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK);
+        assertThat(new ImageHostingSyncCandidate(101, null).reasons()).isEqualTo(Set.of());
     }
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
@@ -71,11 +71,15 @@ public interface ExternalImageMapper {
               ON image.item_inventory_photo_id = photo.item_inventory_photo_id
              AND image.external_service_id = #{externalServiceId}
             WHERE photo.status = 'PROCESSED'
-              AND image.external_image_id IS NULL
+              AND (
+                    image.external_image_id IS NULL
+                 OR image.external_service_image_id IS NULL
+                 OR image.external_service_image_id = ''
+              )
             ORDER BY photo.item_inventory_id
             LIMIT #{limit}
             """)
-    List<Integer> findItemInventoryIdsMissingExternalImages(
+    List<Integer> findItemInventoryIdsMissingExternalImageLinks(
             @Param("externalServiceId") Integer externalServiceId,
             @Param("limit") int limit
     );
@@ -89,12 +93,13 @@ public interface ExternalImageMapper {
             WHERE photo.status = 'PROCESSED'
               AND (
                     album.external_image_album_id IS NULL
-                 OR album.sync_status <> 'SYNCED'
+                 OR album.external_album_id IS NULL
+                 OR album.external_album_id = ''
               )
             ORDER BY photo.item_inventory_id
             LIMIT #{limit}
             """)
-    List<Integer> findItemInventoryIdsMissingOrUnsyncedAlbums(
+    List<Integer> findItemInventoryIdsMissingAlbumLinks(
             @Param("externalServiceId") Integer externalServiceId,
             @Param("limit") int limit
     );
@@ -106,17 +111,43 @@ public interface ExternalImageMapper {
               ON image.item_inventory_photo_id = photo.item_inventory_photo_id
              AND image.external_service_id = #{externalServiceId}
             WHERE photo.status = 'PROCESSED'
-              AND image.sync_status <> 'SYNCED'
               AND (
-                    image.sync_status <> 'FAILED'
-                 OR #{includeFailed} = TRUE
+                    image.sync_status = 'PENDING'
+                 OR EXISTS (
+                        SELECT 1
+                        FROM external_image_album album
+                        WHERE album.item_inventory_id = photo.item_inventory_id
+                          AND album.external_service_id = #{externalServiceId}
+                          AND album.sync_status = 'PENDING'
+                    )
               )
             ORDER BY photo.item_inventory_id
             LIMIT #{limit}
             """)
-    List<Integer> findItemInventoryIdsWithUnsyncedImages(
+    List<Integer> findItemInventoryIdsWithPendingSyncRows(
             @Param("externalServiceId") Integer externalServiceId,
-            @Param("includeFailed") boolean includeFailed,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
+            LEFT JOIN external_image image
+              ON image.item_inventory_photo_id = photo.item_inventory_photo_id
+             AND image.external_service_id = #{externalServiceId}
+            LEFT JOIN external_image_album album
+              ON album.item_inventory_id = photo.item_inventory_id
+             AND album.external_service_id = #{externalServiceId}
+            WHERE photo.status = 'PROCESSED'
+              AND (
+                    image.sync_status = 'FAILED'
+                 OR album.sync_status = 'FAILED'
+              )
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsWithFailedSyncRows(
+            @Param("externalServiceId") Integer externalServiceId,
             @Param("limit") int limit
     );
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
@@ -77,8 +77,8 @@ class ExternalImageMapperTest extends MapperTestSupport {
     @Test
     void findItemInventoryIdsNeedingSyncWorkFindsEachFocusedWorkType() {
         insertImageHostingService();
-        ItemInventory missingImageInventory = insertItemInventory("uuid-missing-image");
-        insertItemInventoryPhoto(missingImageInventory.getItemInventoryId(), "11111111111111111111111111111111");
+        ItemInventory missingPhotoLinkInventory = insertItemInventory("uuid-missing-photo-link");
+        insertItemInventoryPhoto(missingPhotoLinkInventory.getItemInventoryId(), "11111111111111111111111111111111");
 
         ItemInventory metadataMismatchInventory = insertItemInventory("uuid-metadata-mismatch");
         ItemInventoryPhoto metadataMismatchPhoto = insertItemInventoryPhoto(metadataMismatchInventory.getItemInventoryId(), "22222222222222222222222222222222");
@@ -90,11 +90,23 @@ class ExternalImageMapperTest extends MapperTestSupport {
         metadataMismatchAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(metadataMismatchAlbum);
 
-        ItemInventory missingAlbumInventory = insertItemInventory("uuid-missing-album");
-        ItemInventoryPhoto missingAlbumPhoto = insertItemInventoryPhoto(missingAlbumInventory.getItemInventoryId(), "33333333333333333333333333333333");
-        ExternalImage missingAlbumImage = externalImage(10, missingAlbumPhoto.getItemInventoryPhotoId(), "image-missing-album", "33333333333333333333333333333333");
-        missingAlbumImage.setSyncStatus(ExternalSyncStatus.SYNCED);
-        externalImageMapper.insert(missingAlbumImage);
+        ItemInventory missingAlbumLinkInventory = insertItemInventory("uuid-missing-album-link");
+        ItemInventoryPhoto missingAlbumLinkPhoto = insertItemInventoryPhoto(missingAlbumLinkInventory.getItemInventoryId(), "33333333333333333333333333333333");
+        ExternalImage missingAlbumLinkImage = externalImage(10, missingAlbumLinkPhoto.getItemInventoryPhotoId(), "image-missing-album", "33333333333333333333333333333333");
+        missingAlbumLinkImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(missingAlbumLinkImage);
+        ExternalImageAlbum missingAlbumLinkAlbum = externalImageAlbum(10, missingAlbumLinkInventory.getItemInventoryId(), null);
+        missingAlbumLinkAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(missingAlbumLinkAlbum);
+
+        ItemInventory stalePhotoLinkInventory = insertItemInventory("uuid-stale-photo-link");
+        ItemInventoryPhoto stalePhotoLinkPhoto = insertItemInventoryPhoto(stalePhotoLinkInventory.getItemInventoryId(), "77777777777777777777777777777777");
+        ExternalImage stalePhotoLinkImage = externalImage(10, stalePhotoLinkPhoto.getItemInventoryPhotoId(), null, "77777777777777777777777777777777");
+        stalePhotoLinkImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(stalePhotoLinkImage);
+        ExternalImageAlbum stalePhotoLinkAlbum = externalImageAlbum(10, stalePhotoLinkInventory.getItemInventoryId(), "album-stale-photo-link");
+        stalePhotoLinkAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(stalePhotoLinkAlbum);
 
         ItemInventory failedImageInventory = insertItemInventory("uuid-failed-image");
         ItemInventoryPhoto failedImagePhoto = insertItemInventoryPhoto(failedImageInventory.getItemInventoryId(), "44444444444444444444444444444444");
@@ -105,6 +117,15 @@ class ExternalImageMapperTest extends MapperTestSupport {
         failedImageAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(failedImageAlbum);
 
+        ItemInventory failedAlbumInventory = insertItemInventory("uuid-failed-album");
+        ItemInventoryPhoto failedAlbumPhoto = insertItemInventoryPhoto(failedAlbumInventory.getItemInventoryId(), "88888888888888888888888888888888");
+        ExternalImage failedAlbumImage = externalImage(10, failedAlbumPhoto.getItemInventoryPhotoId(), "image-failed-album", "88888888888888888888888888888888");
+        failedAlbumImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(failedAlbumImage);
+        ExternalImageAlbum failedAlbum = externalImageAlbum(10, failedAlbumInventory.getItemInventoryId(), "album-failed-status");
+        failedAlbum.setSyncStatus(ExternalSyncStatus.FAILED);
+        externalImageAlbumMapper.insert(failedAlbum);
+
         ItemInventory pendingImageInventory = insertItemInventory("uuid-pending-image");
         ItemInventoryPhoto pendingImagePhoto = insertItemInventoryPhoto(pendingImageInventory.getItemInventoryId(), "66666666666666666666666666666666");
         ExternalImage pendingImage = externalImage(10, pendingImagePhoto.getItemInventoryPhotoId(), "image-pending", "66666666666666666666666666666666");
@@ -112,6 +133,15 @@ class ExternalImageMapperTest extends MapperTestSupport {
         ExternalImageAlbum pendingImageAlbum = externalImageAlbum(10, pendingImageInventory.getItemInventoryId(), "album-pending");
         pendingImageAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(pendingImageAlbum);
+
+        ItemInventory pendingAlbumInventory = insertItemInventory("uuid-pending-album");
+        ItemInventoryPhoto pendingAlbumPhoto = insertItemInventoryPhoto(pendingAlbumInventory.getItemInventoryId(), "99999999999999999999999999999999");
+        ExternalImage pendingAlbumImage = externalImage(10, pendingAlbumPhoto.getItemInventoryPhotoId(), "image-pending-album", "99999999999999999999999999999999");
+        pendingAlbumImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(pendingAlbumImage);
+        ExternalImageAlbum pendingAlbum = externalImageAlbum(10, pendingAlbumInventory.getItemInventoryId(), "album-pending-status");
+        pendingAlbum.setSyncStatus(ExternalSyncStatus.PENDING);
+        externalImageAlbumMapper.insert(pendingAlbum);
 
         ItemInventory syncedInventory = insertItemInventory("uuid-synced");
         ItemInventoryPhoto syncedPhoto = insertItemInventoryPhoto(syncedInventory.getItemInventoryId(), "55555555555555555555555555555555");
@@ -122,24 +152,30 @@ class ExternalImageMapperTest extends MapperTestSupport {
         syncedAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(syncedAlbum);
 
-        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 10))
-                .containsExactly(missingImageInventory.getItemInventoryId());
-        assertThat(externalImageMapper.findItemInventoryIdsMissingOrUnsyncedAlbums(10, 10))
+        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
                 .containsExactly(
-                        missingImageInventory.getItemInventoryId(),
-                        missingAlbumInventory.getItemInventoryId()
+                        missingPhotoLinkInventory.getItemInventoryId(),
+                        stalePhotoLinkInventory.getItemInventoryId()
                 );
-        assertThat(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, false, 10))
-                .containsExactly(pendingImageInventory.getItemInventoryId());
-        assertThat(externalImageMapper.findItemInventoryIdsWithUnsyncedImages(10, true, 10))
+        assertThat(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 10))
+                .containsExactly(
+                        missingPhotoLinkInventory.getItemInventoryId(),
+                        missingAlbumLinkInventory.getItemInventoryId()
+                );
+        assertThat(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
+                .containsExactly(
+                        pendingImageInventory.getItemInventoryId(),
+                        pendingAlbumInventory.getItemInventoryId()
+                );
+        assertThat(externalImageMapper.findItemInventoryIdsWithFailedSyncRows(10, 10))
                 .containsExactly(
                         failedImageInventory.getItemInventoryId(),
-                        pendingImageInventory.getItemInventoryId()
+                        failedAlbumInventory.getItemInventoryId()
                 );
         assertThat(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
                 .containsExactly(metadataMismatchInventory.getItemInventoryId());
-        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImages(10, 1))
-                .containsExactly(missingImageInventory.getItemInventoryId());
+        assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 1))
+                .containsExactly(missingPhotoLinkInventory.getItemInventoryId());
     }
 
     private void insertImageHostingService() {


### PR DESCRIPTION
## Summary
- Adds a typed image-hosting sync candidate model with explicit selection reasons.
- Splits scheduled sync discovery into focused queries for missing Flickr album links, missing Flickr photo links, failed sync rows, pending sync rows, and metadata drift.
- Keeps the legacy ID-only discovery method as a compatibility wrapper over the richer candidate model.

## Review Notes
- Missing album linkage now means a processed DB photo exists but the Flickr album row is absent or has a blank external album id.
- Missing photo linkage now includes absent external_image rows and stale rows with blank external_service_image_id.
- Failed rows are only included when the caller asks to include failed work; pending rows are always considered.

## Verification
- mvn -pl lego-data-dao,lego-data-mybatis -Dtest=ExternalImageDaoUnitTest,ExternalImageDaoTest,ExternalImageMapperTest test
- mvn clean install