### PR TITLE
Add eager marketplace catalog associations

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
@@ -1,10 +1,14 @@
 package io.legohunter.data.dao;
 
+import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -12,6 +16,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ItemInventoryDao {
     private final ItemInventoryMapper itemInventoryMapper;
+    private final MarketplaceListingDao marketplaceListingDao;
 
     public Set<ItemInventory> findAll() {
         return itemInventoryMapper.findAll();
@@ -23,6 +28,26 @@ public class ItemInventoryDao {
 
     public Optional<ItemInventory> findByUuid(String uuid) {
         return itemInventoryMapper.findByUuid(uuid);
+    }
+
+    public Optional<ExternalCatalogItem> getPrimaryExternalCatalogItem(ItemInventory itemInventory) {
+        if (itemInventory == null || itemInventory.getExternalCatalogItems() == null) {
+            return Optional.empty();
+        }
+
+        return itemInventory.getExternalCatalogItems().stream()
+                .filter(externalCatalogItem -> Boolean.TRUE.equals(externalCatalogItem.getPrimary()))
+                .map(ItemInventoryExternalCatalogItem::getExternalCatalogItem)
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    public Set<MarketplaceListing> findMarketplaceListings(ItemInventory itemInventory) {
+        if (itemInventory == null || itemInventory.getItemInventoryId() == null) {
+            return Set.of();
+        }
+
+        return marketplaceListingDao.findByItemInventoryId(itemInventory.getItemInventoryId());
     }
 
     public ItemInventory insert(ItemInventory itemInventory) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -173,6 +173,7 @@ class CurrentDaoIntegrationTest {
         assertThat(itemInventoryDao.findByItemInventoryId(inventory.getItemInventoryId())).isPresent();
         assertThat(itemInventoryDao.findByUuid("dao-inventory-1")).isPresent();
         assertThat(itemInventoryDao.findAll()).extracting(ItemInventory::getUuid).contains("dao-inventory-1");
+        assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(inventory)).isEmpty();
 
         ItemInventoryExternalCatalogItem inventoryCatalogItem = ItemInventoryExternalCatalogItem.builder()
                 .itemInventoryId(inventory.getItemInventoryId())
@@ -182,8 +183,15 @@ class CurrentDaoIntegrationTest {
         inventoryCatalogItem = itemInventoryExternalCatalogItemDao.insert(inventoryCatalogItem);
         inventoryCatalogItem.setPrimary(false);
         assertThat(itemInventoryExternalCatalogItemDao.update(inventoryCatalogItem).getPrimary()).isFalse();
+        assertThat(itemInventoryDao.findByItemInventoryId(inventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(found)).isEmpty());
         inventoryCatalogItem.setPrimary(true);
         assertThat(itemInventoryExternalCatalogItemDao.upsert(inventoryCatalogItem).getPrimary()).isTrue();
+        Integer externalCatalogItemId = catalogItem.getExternalCatalogItemId();
+        assertThat(itemInventoryDao.findByItemInventoryId(inventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(found))
+                        .map(ExternalCatalogItem::getExternalCatalogItemId)
+                        .contains(externalCatalogItemId));
         assertThat(itemInventoryExternalCatalogItemDao.findByItemInventoryIdAndExternalCatalogItemId(inventory.getItemInventoryId(), catalogItem.getExternalCatalogItemId())).isPresent();
         assertThat(itemInventoryExternalCatalogItemDao.findByItemInventoryId(inventory.getItemInventoryId())).hasSize(1);
         assertThat(itemInventoryExternalCatalogItemDao.findByExternalCatalogItemId(catalogItem.getExternalCatalogItemId())).hasSize(1);
@@ -215,6 +223,10 @@ class CurrentDaoIntegrationTest {
         assertThat(marketplaceListingDao.findByMarketplaceListingId(listing.getMarketplaceListingId())).isPresent();
         assertThat(marketplaceListingDao.findByListingExternalServiceIdAndExternalListingId(2, "DAO-BL-1")).isPresent();
         assertThat(marketplaceListingDao.findByItemInventoryId(inventory.getItemInventoryId())).hasSize(1);
+        assertThat(itemInventoryDao.findMarketplaceListings(inventory))
+                .hasSize(1)
+                .first()
+                .satisfies(this::assertHydratedMarketplaceCatalogItem);
         assertThat(marketplaceListingDao.findAll()).hasSize(1);
 
         BricklinkMarketplaceListing bricklink = bricklinkMarketplaceListing(listing.getMarketplaceListingId(), 3001);
@@ -313,6 +325,18 @@ class CurrentDaoIntegrationTest {
                 .currencyCode("USD")
                 .fixedPrice(true)
                 .build();
+    }
+
+    private void assertHydratedMarketplaceCatalogItem(MarketplaceListing listing) {
+        assertThat(listing.getExternalCatalogItem()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalItemKey()).isEqualTo("dao-listing-item");
+        assertThat(listing.getExternalCatalogItem().getExternalService()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalService().getServiceCode()).isEqualTo("BRICKLINK");
+        assertThat(listing.getExternalCatalogItem().getExternalService().getExternalServiceType()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalService().getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+        assertThat(listing.getExternalCatalogItem().getExternalService().getCapabilities())
+                .extracting(ExternalServiceCapability::getCapabilityCode)
+                .contains("CATALOG", "MARKETPLACE_LISTING", "PRICE_GUIDE");
     }
 
     private BricklinkMarketplaceListing bricklinkMarketplaceListing(Integer marketplaceListingId, Integer bricklinkInventoryId) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
@@ -1,0 +1,93 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemInventoryDaoUnitTest {
+    @Mock
+    private ItemInventoryMapper itemInventoryMapper;
+
+    @Mock
+    private MarketplaceListingDao marketplaceListingDao;
+
+    private ItemInventoryDao itemInventoryDao;
+
+    @BeforeEach
+    void setUp() {
+        itemInventoryDao = new ItemInventoryDao(itemInventoryMapper, marketplaceListingDao);
+    }
+
+    @Test
+    void getPrimaryExternalCatalogItemReturnsEmptyForMissingInventoryOrPrimaryLink() {
+        assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(null)).isEmpty();
+        assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(new ItemInventory())).isEmpty();
+
+        ItemInventory inventory = new ItemInventory();
+        inventory.setExternalCatalogItems(Set.of(ItemInventoryExternalCatalogItem.builder()
+                .primary(false)
+                .externalCatalogItem(new ExternalCatalogItem())
+                .build()));
+
+        assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(inventory)).isEmpty();
+    }
+
+    @Test
+    void getPrimaryExternalCatalogItemReturnsHydratedPrimaryCatalogItem() {
+        ExternalCatalogItem catalogItem = ExternalCatalogItem.builder()
+                .externalCatalogItemId(101)
+                .externalItemKey("3001-1")
+                .build();
+        ItemInventory inventory = new ItemInventory();
+        inventory.setExternalCatalogItems(Set.of(
+                ItemInventoryExternalCatalogItem.builder()
+                        .primary(false)
+                        .externalCatalogItem(new ExternalCatalogItem())
+                        .build(),
+                ItemInventoryExternalCatalogItem.builder()
+                        .primary(true)
+                        .externalCatalogItem(catalogItem)
+                        .build()
+        ));
+
+        assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(inventory)).contains(catalogItem);
+    }
+
+    @Test
+    void findMarketplaceListingsReturnsEmptyForMissingInventoryId() {
+        assertThat(itemInventoryDao.findMarketplaceListings(null)).isEmpty();
+        assertThat(itemInventoryDao.findMarketplaceListings(new ItemInventory())).isEmpty();
+
+        verify(marketplaceListingDao, never()).findByItemInventoryId(null);
+    }
+
+    @Test
+    void findMarketplaceListingsDelegatesToMarketplaceListingDao() {
+        ItemInventory inventory = new ItemInventory();
+        inventory.setItemInventoryId(200);
+        MarketplaceListing marketplaceListing = MarketplaceListing.builder()
+                .marketplaceListingId(300)
+                .itemInventoryId(200)
+                .build();
+        when(marketplaceListingDao.findByItemInventoryId(200)).thenReturn(Set.of(marketplaceListing));
+
+        assertThat(itemInventoryDao.findMarketplaceListings(inventory)).containsExactly(marketplaceListing);
+
+        verify(marketplaceListingDao).findByItemInventoryId(200);
+    }
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalService.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ExternalService.java
@@ -3,6 +3,8 @@ package io.legohunter.data.dto;
 import lombok.Data;
 import lombok.Getter;
 
+import java.util.Set;
+
 @Data
 public class ExternalService {
     private Integer externalServiceId;
@@ -10,6 +12,8 @@ public class ExternalService {
     private String displayName;
     private String serviceUrl;
     private Integer externalServiceTypeId;
+    private ExternalServiceType externalServiceType;
+    private Set<ExternalServiceCapability> capabilities;
 
     @Getter
     public enum Service {

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventory.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventory.java
@@ -3,6 +3,7 @@ package io.legohunter.data.dto;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.util.Set;
 
 @Data
 public class ItemInventory {
@@ -20,4 +21,5 @@ public class ItemInventory {
     private Integer instructionsConditionId;
     private Boolean sealed;
     private Boolean builtOnce;
+    private Set<ItemInventoryExternalCatalogItem> externalCatalogItems;
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventoryExternalCatalogItem.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventoryExternalCatalogItem.java
@@ -16,6 +16,7 @@ public class ItemInventoryExternalCatalogItem {
     private Integer externalCatalogItemId;
     private Boolean primary;
     private ZonedDateTime createdAt;
+    private ExternalCatalogItem externalCatalogItem;
 }
 
 

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceListing.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceListing.java
@@ -31,6 +31,7 @@ public class MarketplaceListing {
     private ZonedDateTime publishedAt;
     private ZonedDateTime endedAt;
     private ZonedDateTime lastSynchronizedAt;
+    private ExternalCatalogItem externalCatalogItem;
 }
 
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalCatalogItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalCatalogItemMapper.java
@@ -16,63 +16,89 @@ public interface ExternalCatalogItemMapper {
             eci.item_type_code,
             eci.item_url,
             eci.year_released,
-            es.service_code,
-            es.display_name,
-            es.service_url,
-            es.external_service_type_id
+            es.external_service_id AS es_external_service_id,
+            es.service_code AS es_service_code,
+            es.display_name AS es_display_name,
+            es.service_url AS es_service_url,
+            es.external_service_type_id AS es_external_service_type_id,
+            est.external_service_type_id AS es_est_external_service_type_id,
+            est.external_service_type_name AS es_est_external_service_type_name,
+            est.external_service_type_description AS es_est_external_service_type_description,
+            esc.external_service_id AS es_esc_external_service_id,
+            esc.capability_code AS es_esc_capability_code
+            """;
+
+    String FROM_CLAUSE = """
+            FROM external_catalog_item eci
+            JOIN external_service es
+                ON es.external_service_id = eci.external_service_id
+            JOIN external_service_type est
+                ON est.external_service_type_id = es.external_service_type_id
+            LEFT JOIN external_service_capability esc
+                ON esc.external_service_id = es.external_service_id
             """;
 
     @Select("""
             SELECT ${columns}
-            FROM external_catalog_item eci
-            JOIN external_service es ON es.external_service_id = eci.external_service_id
+            ${fromClause}
             """)
     @ResultMap("externalCatalogItemResultMap")
-    Set<ExternalCatalogItem> findAll(@Param("columns") String columns);
+    Set<ExternalCatalogItem> findAll(@Param("columns") String columns, @Param("fromClause") String fromClause);
 
     default Set<ExternalCatalogItem> findAll() {
-        return findAll(ALL_COLUMNS);
+        return findAll(ALL_COLUMNS, FROM_CLAUSE);
     }
 
     @Select("""
             SELECT ${columns}
-            FROM external_catalog_item eci
-            JOIN external_service es ON es.external_service_id = eci.external_service_id
+            ${fromClause}
             WHERE eci.external_catalog_item_id = #{externalCatalogItemId}
             """)
     @ResultMap("externalCatalogItemResultMap")
-    Optional<ExternalCatalogItem> findByExternalCatalogItemId(@Param("externalCatalogItemId") Integer externalCatalogItemId, @Param("columns") String columns);
+    Optional<ExternalCatalogItem> findByExternalCatalogItemId(
+            @Param("externalCatalogItemId") Integer externalCatalogItemId,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
 
     default Optional<ExternalCatalogItem> findByExternalCatalogItemId(Integer externalCatalogItemId) {
-        return findByExternalCatalogItemId(externalCatalogItemId, ALL_COLUMNS);
+        return findByExternalCatalogItemId(externalCatalogItemId, ALL_COLUMNS, FROM_CLAUSE);
     }
 
     @Select("""
             SELECT ${columns}
-            FROM external_catalog_item eci
-            JOIN external_service es ON es.external_service_id = eci.external_service_id
+            ${fromClause}
             WHERE eci.external_service_id = #{externalServiceId}
               AND eci.external_item_key = #{externalItemKey}
             """)
     @ResultMap("externalCatalogItemResultMap")
-    Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalItemKey(@Param("externalServiceId") Integer externalServiceId, @Param("externalItemKey") String externalItemKey, @Param("columns") String columns);
+    Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalItemKey(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("externalItemKey") String externalItemKey,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
 
     default Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalItemKey(Integer externalServiceId, String externalItemKey) {
-        return findByExternalServiceIdAndExternalItemKey(externalServiceId, externalItemKey, ALL_COLUMNS);
+        return findByExternalServiceIdAndExternalItemKey(externalServiceId, externalItemKey, ALL_COLUMNS, FROM_CLAUSE);
     }
 
     @Select("""
             SELECT ${columns}
-            FROM external_catalog_item eci
-            JOIN external_service es ON es.external_service_id = eci.external_service_id
+            ${fromClause}
             WHERE eci.external_service_id = #{externalServiceId}
               AND eci.external_unique_key = #{externalUniqueKey}
             """)
     @ResultMap("externalCatalogItemResultMap")
-    Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalUniqueKey(@Param("externalServiceId") Integer externalServiceId, @Param("externalUniqueKey") String externalUniqueKey, @Param("columns") String columns);
+    Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalUniqueKey(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("externalUniqueKey") String externalUniqueKey,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
 
     default Optional<ExternalCatalogItem> findByExternalServiceIdAndExternalUniqueKey(Integer externalServiceId, String externalUniqueKey) {
-        return findByExternalServiceIdAndExternalUniqueKey(externalServiceId, externalUniqueKey, ALL_COLUMNS);
+        return findByExternalServiceIdAndExternalUniqueKey(externalServiceId, externalUniqueKey, ALL_COLUMNS, FROM_CLAUSE);
     }
 
     @Insert("""

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapper.java
@@ -1,33 +1,42 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.ExternalService;
-import org.apache.ibatis.annotations.Delete;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.Select;
-import org.apache.ibatis.annotations.Update;
+import org.apache.ibatis.annotations.*;
 
 import java.util.Optional;
 import java.util.Set;
 
 public interface ExternalServiceMapper {
     String ALL_COLUMNS = """
-            external_service_id,
-            service_code,
-            display_name,
-            service_url,
-            external_service_type_id
+            es.external_service_id,
+            es.service_code,
+            es.display_name,
+            es.service_url,
+            es.external_service_type_id,
+            est.external_service_type_id AS est_external_service_type_id,
+            est.external_service_type_name AS est_external_service_type_name,
+            est.external_service_type_description AS est_external_service_type_description,
+            esc.external_service_id AS esc_external_service_id,
+            esc.capability_code AS esc_capability_code
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM external_service")
+    String FROM_CLAUSE = """
+            FROM external_service es
+            JOIN external_service_type est
+                ON est.external_service_type_id = es.external_service_type_id
+            LEFT JOIN external_service_capability esc
+                ON esc.external_service_id = es.external_service_id
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
     @ResultMap("externalServiceResultMap")
     Set<ExternalService> findAll();
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM external_service WHERE external_service_id = #{externalServiceId}")
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE es.external_service_id = #{externalServiceId}")
     @ResultMap("externalServiceResultMap")
     Optional<ExternalService> findByExternalServiceId(Integer externalServiceId);
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM external_service WHERE service_code = #{serviceCode}")
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE es.service_code = #{serviceCode}")
     @ResultMap("externalServiceResultMap")
     Optional<ExternalService> findByServiceCode(String serviceCode);
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryExternalCatalogItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryExternalCatalogItemMapper.java
@@ -8,36 +8,69 @@ import java.util.Set;
 
 public interface ItemInventoryExternalCatalogItemMapper {
     String ALL_COLUMNS = """
-            item_inventory_id,
-            external_catalog_item_id,
-            is_primary,
-            created_at
+            iieci.item_inventory_id,
+            iieci.external_catalog_item_id,
+            iieci.is_primary,
+            iieci.created_at,
+            eci.external_catalog_item_id AS eci_external_catalog_item_id,
+            eci.external_service_id AS eci_external_service_id,
+            eci.external_item_key AS eci_external_item_key,
+            eci.external_unique_key AS eci_external_unique_key,
+            eci.item_name AS eci_item_name,
+            eci.item_type_code AS eci_item_type_code,
+            eci.item_url AS eci_item_url,
+            eci.year_released AS eci_year_released,
+            es.external_service_id AS eci_es_external_service_id,
+            es.service_code AS eci_es_service_code,
+            es.display_name AS eci_es_display_name,
+            es.service_url AS eci_es_service_url,
+            es.external_service_type_id AS eci_es_external_service_type_id,
+            est.external_service_type_id AS eci_es_est_external_service_type_id,
+            est.external_service_type_name AS eci_es_est_external_service_type_name,
+            est.external_service_type_description AS eci_es_est_external_service_type_description,
+            esc.external_service_id AS eci_es_esc_external_service_id,
+            esc.capability_code AS eci_es_esc_capability_code
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory_external_catalog_item")
+    String FROM_CLAUSE = """
+            FROM item_inventory_external_catalog_item iieci
+            JOIN external_catalog_item eci
+                ON eci.external_catalog_item_id = iieci.external_catalog_item_id
+            JOIN external_service es
+                ON es.external_service_id = eci.external_service_id
+            JOIN external_service_type est
+                ON est.external_service_type_id = es.external_service_type_id
+            LEFT JOIN external_service_capability esc
+                ON esc.external_service_id = es.external_service_id
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
     @ResultMap("itemInventoryExternalCatalogItemResultMap")
     Set<ItemInventoryExternalCatalogItem> findAll();
 
     @Select("""
-            SELECT item_inventory_id,
-                   external_catalog_item_id,
-                   is_primary,
-                   created_at
-            FROM item_inventory_external_catalog_item
-            WHERE item_inventory_id = #{itemInventoryId}
-              AND external_catalog_item_id = #{externalCatalogItemId}
+            SELECT ${columns}
+            ${fromClause}
+            WHERE iieci.item_inventory_id = #{itemInventoryId}
+              AND iieci.external_catalog_item_id = #{externalCatalogItemId}
             """)
     @ResultMap("itemInventoryExternalCatalogItemResultMap")
     Optional<ItemInventoryExternalCatalogItem> findByItemInventoryIdAndExternalCatalogItemId(
             @Param("itemInventoryId") Integer itemInventoryId,
-            @Param("externalCatalogItemId") Integer externalCatalogItemId
+            @Param("externalCatalogItemId") Integer externalCatalogItemId,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
     );
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory_external_catalog_item WHERE item_inventory_id = #{itemInventoryId}")
+    default Optional<ItemInventoryExternalCatalogItem> findByItemInventoryIdAndExternalCatalogItemId(Integer itemInventoryId, Integer externalCatalogItemId) {
+        return findByItemInventoryIdAndExternalCatalogItemId(itemInventoryId, externalCatalogItemId, ALL_COLUMNS, FROM_CLAUSE);
+    }
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE iieci.item_inventory_id = #{itemInventoryId}")
     @ResultMap("itemInventoryExternalCatalogItemResultMap")
     Set<ItemInventoryExternalCatalogItem> findByItemInventoryId(Integer itemInventoryId);
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory_external_catalog_item WHERE external_catalog_item_id = #{externalCatalogItemId}")
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE iieci.external_catalog_item_id = #{externalCatalogItemId}")
     @ResultMap("itemInventoryExternalCatalogItemResultMap")
     Set<ItemInventoryExternalCatalogItem> findByExternalCatalogItemId(Integer externalCatalogItemId);
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
@@ -4,6 +4,7 @@ import io.legohunter.data.dto.ItemInventory;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
@@ -13,33 +14,93 @@ import java.util.Set;
 
 public interface ItemInventoryMapper {
     String ALL_COLUMNS = """
-            item_inventory_id,
-            uuid,
-            box_number,
-            purchase_price,
-            description,
-            active,
-            for_sale,
-            new_or_used,
-            completeness,
-            item_condition_id,
-            box_condition_id,
-            instructions_condition_id,
-            sealed,
-            built_once
+            ii.item_inventory_id,
+            ii.uuid,
+            ii.box_number,
+            ii.purchase_price,
+            ii.description,
+            ii.active,
+            ii.for_sale,
+            ii.new_or_used,
+            ii.completeness,
+            ii.item_condition_id,
+            ii.box_condition_id,
+            ii.instructions_condition_id,
+            ii.sealed,
+            ii.built_once,
+            iieci.item_inventory_id AS iieci_item_inventory_id,
+            iieci.external_catalog_item_id AS iieci_external_catalog_item_id,
+            iieci.is_primary AS iieci_is_primary,
+            iieci.created_at AS iieci_created_at,
+            eci.external_catalog_item_id AS iieci_eci_external_catalog_item_id,
+            eci.external_service_id AS iieci_eci_external_service_id,
+            eci.external_item_key AS iieci_eci_external_item_key,
+            eci.external_unique_key AS iieci_eci_external_unique_key,
+            eci.item_name AS iieci_eci_item_name,
+            eci.item_type_code AS iieci_eci_item_type_code,
+            eci.item_url AS iieci_eci_item_url,
+            eci.year_released AS iieci_eci_year_released,
+            es.external_service_id AS iieci_eci_es_external_service_id,
+            es.service_code AS iieci_eci_es_service_code,
+            es.display_name AS iieci_eci_es_display_name,
+            es.service_url AS iieci_eci_es_service_url,
+            es.external_service_type_id AS iieci_eci_es_external_service_type_id,
+            est.external_service_type_id AS iieci_eci_es_est_external_service_type_id,
+            est.external_service_type_name AS iieci_eci_es_est_external_service_type_name,
+            est.external_service_type_description AS iieci_eci_es_est_external_service_type_description,
+            esc.external_service_id AS iieci_eci_es_esc_external_service_id,
+            esc.capability_code AS iieci_eci_es_esc_capability_code
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory")
+    String FROM_CLAUSE = """
+            FROM item_inventory ii
+            LEFT JOIN item_inventory_external_catalog_item iieci
+                ON iieci.item_inventory_id = ii.item_inventory_id
+            LEFT JOIN external_catalog_item eci
+                ON eci.external_catalog_item_id = iieci.external_catalog_item_id
+            LEFT JOIN external_service es
+                ON es.external_service_id = eci.external_service_id
+            LEFT JOIN external_service_type est
+                ON est.external_service_type_id = es.external_service_type_id
+            LEFT JOIN external_service_capability esc
+                ON esc.external_service_id = es.external_service_id
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
     @ResultMap("itemInventoryResultMap")
     Set<ItemInventory> findAll();
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory WHERE item_inventory_id = #{itemInventoryId}")
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ii.item_inventory_id = #{itemInventoryId}
+            """)
     @ResultMap("itemInventoryResultMap")
-    Optional<ItemInventory> findByItemInventoryId(Integer itemInventoryId);
+    Optional<ItemInventory> findByItemInventoryId(
+            @Param("itemInventoryId") Integer itemInventoryId,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM item_inventory WHERE uuid = #{uuid}")
+    default Optional<ItemInventory> findByItemInventoryId(Integer itemInventoryId) {
+        return findByItemInventoryId(itemInventoryId, ALL_COLUMNS, FROM_CLAUSE);
+    }
+
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ii.uuid = #{uuid}
+            """)
     @ResultMap("itemInventoryResultMap")
-    Optional<ItemInventory> findByUuid(String uuid);
+    Optional<ItemInventory> findByUuid(
+            @Param("uuid") String uuid,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Optional<ItemInventory> findByUuid(String uuid) {
+        return findByUuid(uuid, ALL_COLUMNS, FROM_CLAUSE);
+    }
 
     @Insert("""
             INSERT INTO item_inventory (

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -14,66 +14,93 @@ import java.util.Set;
 
 public interface MarketplaceListingMapper {
     String ALL_COLUMNS = """
-            marketplace_listing_id,
-            item_inventory_id,
-            listing_external_service_id,
-            external_catalog_item_id,
-            external_listing_id,
-            external_listing_url,
-            listing_status_code,
-            title,
-            description,
-            private_notes,
-            unit_price,
-            currency_code,
-            fixed_price,
-            created_at,
-            updated_at,
-            published_at,
-            ended_at,
-            last_synchronized_at
+            ml.marketplace_listing_id,
+            ml.item_inventory_id,
+            ml.listing_external_service_id,
+            ml.external_catalog_item_id,
+            ml.external_listing_id,
+            ml.external_listing_url,
+            ml.listing_status_code,
+            ml.title,
+            ml.description,
+            ml.private_notes,
+            ml.unit_price,
+            ml.currency_code,
+            ml.fixed_price,
+            ml.created_at,
+            ml.updated_at,
+            ml.published_at,
+            ml.ended_at,
+            ml.last_synchronized_at,
+            eci.external_catalog_item_id AS eci_external_catalog_item_id,
+            eci.external_service_id AS eci_external_service_id,
+            eci.external_item_key AS eci_external_item_key,
+            eci.external_unique_key AS eci_external_unique_key,
+            eci.item_name AS eci_item_name,
+            eci.item_type_code AS eci_item_type_code,
+            eci.item_url AS eci_item_url,
+            eci.year_released AS eci_year_released,
+            es.external_service_id AS eci_es_external_service_id,
+            es.service_code AS eci_es_service_code,
+            es.display_name AS eci_es_display_name,
+            es.service_url AS eci_es_service_url,
+            es.external_service_type_id AS eci_es_external_service_type_id,
+            est.external_service_type_id AS eci_es_est_external_service_type_id,
+            est.external_service_type_name AS eci_es_est_external_service_type_name,
+            est.external_service_type_description AS eci_es_est_external_service_type_description,
+            esc.external_service_id AS eci_es_esc_external_service_id,
+            esc.capability_code AS eci_es_esc_capability_code
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing")
+    String FROM_CLAUSE = """
+            FROM marketplace_listing ml
+            LEFT JOIN external_catalog_item eci
+                ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            LEFT JOIN external_service es
+                ON es.external_service_id = eci.external_service_id
+            LEFT JOIN external_service_type est
+                ON est.external_service_type_id = es.external_service_type_id
+            LEFT JOIN external_service_capability esc
+                ON esc.external_service_id = es.external_service_id
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
     @ResultMap("marketplaceListingResultMap")
     Set<MarketplaceListing> findAll();
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE ml.marketplace_listing_id = #{marketplaceListingId}")
     @ResultMap("marketplaceListingResultMap")
     Optional<MarketplaceListing> findByMarketplaceListingId(Integer marketplaceListingId);
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing WHERE item_inventory_id = #{itemInventoryId}")
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE + " WHERE ml.item_inventory_id = #{itemInventoryId}")
     @ResultMap("marketplaceListingResultMap")
     Set<MarketplaceListing> findByItemInventoryId(Integer itemInventoryId);
 
     @Select("""
-            SELECT marketplace_listing_id,
-                   item_inventory_id,
-                   listing_external_service_id,
-                   external_catalog_item_id,
-                   external_listing_id,
-                   external_listing_url,
-                   listing_status_code,
-                   title,
-                   description,
-                   private_notes,
-                   unit_price,
-                   currency_code,
-                   fixed_price,
-                   created_at,
-                   updated_at,
-                   published_at,
-                   ended_at,
-                   last_synchronized_at
-            FROM marketplace_listing
-            WHERE listing_external_service_id = #{listingExternalServiceId}
-              AND external_listing_id = #{externalListingId}
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.external_listing_id = #{externalListingId}
             """)
     @ResultMap("marketplaceListingResultMap")
     Optional<MarketplaceListing> findByListingExternalServiceIdAndExternalListingId(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
-            @Param("externalListingId") String externalListingId
+            @Param("externalListingId") String externalListingId,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
     );
+
+    default Optional<MarketplaceListing> findByListingExternalServiceIdAndExternalListingId(
+            Integer listingExternalServiceId,
+            String externalListingId
+    ) {
+        return findByListingExternalServiceIdAndExternalListingId(
+                listingExternalServiceId,
+                externalListingId,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
 
     @Insert("""
             INSERT INTO marketplace_listing (

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalCatalogItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalCatalogItemMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ExternalCatalogItemMapper">
   <resultMap type="io.legohunter.data.dto.ExternalCatalogItem" id="externalCatalogItemResultMap">
-    <result column="external_catalog_item_id" property="externalCatalogItemId"/>
+    <id     column="external_catalog_item_id" property="externalCatalogItemId"/>
     <result column="external_service_id"      property="externalServiceId"/>
     <result column="external_item_key"        property="externalItemKey"/>
     <result column="external_unique_key"      property="externalUniqueKey"/>
@@ -11,12 +11,8 @@
     <result column="year_released"            property="yearReleased"/>
     <association property="externalService"
                  resultMap="io.legohunter.data.mybatis.mapper.ExternalServiceMapper.externalServiceResultMap"
-                 javaType="io.legohunter.data.dto.ExternalService">
-      <id column="external_service_id" property="externalServiceId"/>
-      <result column="service_code" property="serviceCode"/>
-      <result column="display_name" property="displayName"/>
-      <result column="service_url" property="serviceUrl"/>
-      <result column="external_service_type_id" property="externalServiceTypeId"/>
-    </association>
+                 columnPrefix="es_"
+                 notNullColumn="external_service_id"
+                 javaType="io.legohunter.data.dto.ExternalService"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceCapabilityMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceCapabilityMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ExternalServiceCapabilityMapper">
   <resultMap type="io.legohunter.data.dto.ExternalServiceCapability" id="externalServiceCapabilityResultMap">
-    <result column="external_service_id" property="externalServiceId"/>
-    <result column="capability_code"     property="capabilityCode"/>
+    <id column="external_service_id" property="externalServiceId"/>
+    <id column="capability_code"     property="capabilityCode"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceMapper.xml
@@ -1,10 +1,20 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ExternalServiceMapper">
   <resultMap type="io.legohunter.data.dto.ExternalService" id="externalServiceResultMap">
-    <result column="external_service_id"      property="externalServiceId"/>
+    <id     column="external_service_id"      property="externalServiceId"/>
     <result column="service_code"             property="serviceCode"/>
     <result column="display_name"             property="displayName"/>
     <result column="service_url"              property="serviceUrl"/>
     <result column="external_service_type_id" property="externalServiceTypeId"/>
+    <association property="externalServiceType"
+                 resultMap="io.legohunter.data.mybatis.mapper.ExternalServiceTypeMapper.externalServiceTypeResultMap"
+                 columnPrefix="est_"
+                 notNullColumn="external_service_type_id"
+                 javaType="io.legohunter.data.dto.ExternalServiceType"/>
+    <collection property="capabilities"
+                resultMap="io.legohunter.data.mybatis.mapper.ExternalServiceCapabilityMapper.externalServiceCapabilityResultMap"
+                columnPrefix="esc_"
+                notNullColumn="capability_code"
+                javaType="java.util.LinkedHashSet"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceTypeMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ExternalServiceTypeMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ExternalServiceTypeMapper">
   <resultMap type="io.legohunter.data.dto.ExternalServiceType" id="externalServiceTypeResultMap">
-    <result column="external_service_type_id"          property="externalServiceTypeId"/>
+    <id     column="external_service_type_id"          property="externalServiceTypeId"/>
     <result column="external_service_type_name"        property="externalServiceTypeName"/>
     <result column="external_service_type_description" property="externalServiceTypeDescription"/>
   </resultMap>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryExternalCatalogItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryExternalCatalogItemMapper.xml
@@ -1,9 +1,13 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ItemInventoryExternalCatalogItemMapper">
   <resultMap type="io.legohunter.data.dto.ItemInventoryExternalCatalogItem" id="itemInventoryExternalCatalogItemResultMap">
-    <result column="item_inventory_id"        property="itemInventoryId"/>
-    <result column="external_catalog_item_id" property="externalCatalogItemId"/>
+    <id     column="item_inventory_id"        property="itemInventoryId"/>
+    <id     column="external_catalog_item_id" property="externalCatalogItemId"/>
     <result column="is_primary"               property="primary"/>
     <result column="created_at"               property="createdAt"/>
+    <association property="externalCatalogItem"
+                 resultMap="io.legohunter.data.mybatis.mapper.ExternalCatalogItemMapper.externalCatalogItemResultMap"
+                 columnPrefix="eci_"
+                 javaType="io.legohunter.data.dto.ExternalCatalogItem"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.ItemInventoryMapper">
     <resultMap type="io.legohunter.data.dto.ItemInventory" id="itemInventoryResultMap">
-        <result column="item_inventory_id"         property="itemInventoryId"/>
+        <id     column="item_inventory_id"         property="itemInventoryId"/>
         <result column="uuid"                      property="uuid"/>
         <result column="box_number"                property="boxNumber"/>
         <result column="purchase_price"            property="purchasePrice"/>
@@ -15,5 +15,10 @@
         <result column="instructions_condition_id" property="instructionsConditionId"/>
         <result column="sealed"                    property="sealed"/>
         <result column="built_once"                property="builtOnce"/>
+        <collection property="externalCatalogItems"
+                    resultMap="io.legohunter.data.mybatis.mapper.ItemInventoryExternalCatalogItemMapper.itemInventoryExternalCatalogItemResultMap"
+                    columnPrefix="iieci_"
+                    notNullColumn="item_inventory_id"
+                    javaType="java.util.LinkedHashSet"/>
     </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceListingMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceListing" id="marketplaceListingResultMap">
-    <result column="marketplace_listing_id"      property="marketplaceListingId"/>
+    <id     column="marketplace_listing_id"      property="marketplaceListingId"/>
     <result column="item_inventory_id"           property="itemInventoryId"/>
     <result column="listing_external_service_id" property="listingExternalServiceId"/>
     <result column="external_catalog_item_id"    property="externalCatalogItemId"/>
@@ -19,5 +19,10 @@
     <result column="published_at"                property="publishedAt"/>
     <result column="ended_at"                    property="endedAt"/>
     <result column="last_synchronized_at"        property="lastSynchronizedAt"/>
+    <association property="externalCatalogItem"
+                 resultMap="io.legohunter.data.mybatis.mapper.ExternalCatalogItemMapper.externalCatalogItemResultMap"
+                 columnPrefix="eci_"
+                 notNullColumn="external_catalog_item_id"
+                 javaType="io.legohunter.data.dto.ExternalCatalogItem"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalCatalogMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalCatalogMapperTest.java
@@ -40,6 +40,8 @@ class ExternalCatalogMapperTest extends MapperTestSupport {
     @Test
     void externalCatalogItemSupportsBaselineCrudAndServiceKeyLookups() {
         seedExternalCatalog();
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "CATALOG"));
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "PRICE_GUIDE"));
         ExternalCatalogItem item = externalCatalogItem("3001-1", "123", "Brick 2 x 4", 2);
 
         externalCatalogItemMapper.insert(item);
@@ -50,6 +52,10 @@ class ExternalCatalogMapperTest extends MapperTestSupport {
                 .hasValueSatisfying(found -> {
                     assertThat(found.getItemName()).isEqualTo("Brick 2 x 4 Updated");
                     assertThat(found.getExternalService().getServiceCode()).isEqualTo("BRICKLINK");
+                    assertThat(found.getExternalService().getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+                    assertThat(found.getExternalService().getCapabilities())
+                            .extracting("capabilityCode")
+                            .containsExactlyInAnyOrder("CATALOG", "PRICE_GUIDE");
                 });
         assertThat(externalCatalogItemMapper.findByExternalServiceIdAndExternalItemKey(2, "3001-1")).isPresent();
         assertThat(externalCatalogItemMapper.findByExternalServiceIdAndExternalUniqueKey(2, "123")).isPresent();
@@ -91,6 +97,7 @@ class ExternalCatalogMapperTest extends MapperTestSupport {
     @Test
     void itemInventoryExternalCatalogItemSupportsJoinCrud() {
         ExternalCatalogItem item = insertExternalCatalogItem("iieci-1");
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "CATALOG"));
         ItemInventory inventory = insertItemInventory("uuid-iieci");
         ItemInventoryExternalCatalogItem join = itemInventoryExternalCatalogItem(inventory.getItemInventoryId(), item.getExternalCatalogItemId());
 
@@ -99,7 +106,17 @@ class ExternalCatalogMapperTest extends MapperTestSupport {
         itemInventoryExternalCatalogItemMapper.update(join);
 
         assertThat(itemInventoryExternalCatalogItemMapper.findByItemInventoryIdAndExternalCatalogItemId(inventory.getItemInventoryId(), item.getExternalCatalogItemId()))
-                .hasValueSatisfying(found -> assertThat(found.getPrimary()).isFalse());
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getPrimary()).isFalse();
+                    assertThat(found.getExternalCatalogItem()).isNotNull();
+                    assertThat(found.getExternalCatalogItem().getExternalItemKey()).isEqualTo("iieci-1");
+                    assertThat(found.getExternalCatalogItem().getExternalService()).isNotNull();
+                    assertThat(found.getExternalCatalogItem().getExternalService().getServiceCode()).isEqualTo("BRICKLINK");
+                    assertThat(found.getExternalCatalogItem().getExternalService().getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+                    assertThat(found.getExternalCatalogItem().getExternalService().getCapabilities())
+                            .extracting("capabilityCode")
+                            .containsExactly("CATALOG");
+                });
         assertThat(itemInventoryExternalCatalogItemMapper.findByItemInventoryId(inventory.getItemInventoryId())).hasSize(1);
         assertThat(itemInventoryExternalCatalogItemMapper.findByExternalCatalogItemId(item.getExternalCatalogItemId())).hasSize(1);
         assertThat(itemInventoryExternalCatalogItemMapper.findAll()).hasSize(1);

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalServiceMapperTest.java
@@ -20,11 +20,18 @@ class ExternalServiceMapperTest extends MapperTestSupport {
         ExternalService service = externalService(2, "BRICKLINK", "BrickLink", 2);
 
         externalServiceMapper.insertExternalService(service);
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "CATALOG"));
         service.setServiceUrl("https://bricklink.test");
         externalServiceMapper.updateExternalService(service);
 
         assertThat(externalServiceMapper.findExternalServiceById(2))
-                .hasValueSatisfying(found -> assertThat(found.getServiceUrl()).isEqualTo("https://bricklink.test"));
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getServiceUrl()).isEqualTo("https://bricklink.test");
+                    assertThat(found.getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+                    assertThat(found.getCapabilities())
+                            .extracting(ExternalServiceCapability::getCapabilityCode)
+                            .containsExactly("CATALOG");
+                });
         assertThat(externalServiceMapper.findExternalServiceByName("BRICKLINK"))
                 .hasValueSatisfying(found -> assertThat(found.getExternalServiceId()).isEqualTo(2));
         assertThat(externalServiceMapper.findAll()).extracting(ExternalService::getServiceCode).containsExactly("BRICKLINK");
@@ -34,6 +41,7 @@ class ExternalServiceMapperTest extends MapperTestSupport {
         assertThat(externalServiceMapper.findByServiceCode("BRICKLINK"))
                 .hasValueSatisfying(found -> assertThat(found.getDisplayName()).isEqualTo("BrickLink Updated"));
 
+        assertThat(externalServiceCapabilityMapper.delete(2, "CATALOG")).isOne();
         assertThat(externalServiceMapper.delete(2)).isOne();
     }
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
@@ -1,6 +1,8 @@
 package io.legohunter.data.mybatis.mapper;
 
+import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,10 +13,16 @@ class ItemInventoryMapperTest extends MapperTestSupport {
     @Test
     void insertUpdateFindsAndUpsert() {
         seedDefaultCondition();
+        ExternalCatalogItem externalCatalogItem = insertExternalCatalogItem("uuid-inventory-catalog-item");
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "CATALOG"));
         ItemInventory itemInventory = itemInventory("uuid-inventory");
 
         itemInventoryMapper.insert(itemInventory);
         assertThat(itemInventory.getItemInventoryId()).isNotNull();
+        itemInventoryExternalCatalogItemMapper.insert(itemInventoryExternalCatalogItem(
+                itemInventory.getItemInventoryId(),
+                externalCatalogItem.getExternalCatalogItemId()
+        ));
 
         itemInventory.setDescription("Updated inventory");
         assertThat(itemInventoryMapper.update(itemInventory)).isEqualTo(1);
@@ -23,6 +31,10 @@ class ItemInventoryMapperTest extends MapperTestSupport {
                 .hasValueSatisfying(found -> {
                     assertThat(found.getDescription()).isEqualTo("Updated inventory");
                     assertThat(found.getPurchasePrice()).isEqualByComparingTo("12.34");
+                    assertThat(found.getExternalCatalogItems())
+                            .hasSize(1)
+                            .first()
+                            .satisfies(this::assertHydratedCatalogLink);
                 });
         assertThat(itemInventoryMapper.findByUuid("uuid-inventory"))
                 .hasValueSatisfying(found -> assertThat(found.getItemInventoryId()).isEqualTo(itemInventory.getItemInventoryId()));
@@ -34,7 +46,22 @@ class ItemInventoryMapperTest extends MapperTestSupport {
         assertThat(itemInventoryMapper.findByUuid("uuid-inventory"))
                 .hasValueSatisfying(found -> assertThat(found.getDescription()).isEqualTo("Upserted inventory"));
 
+        assertThat(itemInventoryExternalCatalogItemMapper.delete(
+                itemInventory.getItemInventoryId(),
+                externalCatalogItem.getExternalCatalogItemId()
+        )).isOne();
         assertThat(itemInventoryMapper.delete(itemInventory.getItemInventoryId())).isOne();
         assertThat(itemInventoryMapper.findByUuid("uuid-inventory")).isEmpty();
+    }
+
+    private void assertHydratedCatalogLink(ItemInventoryExternalCatalogItem link) {
+        assertThat(link.getExternalCatalogItem()).isNotNull();
+        assertThat(link.getExternalCatalogItem().getExternalItemKey()).isEqualTo("uuid-inventory-catalog-item");
+        assertThat(link.getExternalCatalogItem().getExternalService()).isNotNull();
+        assertThat(link.getExternalCatalogItem().getExternalService().getServiceCode()).isEqualTo("BRICKLINK");
+        assertThat(link.getExternalCatalogItem().getExternalService().getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+        assertThat(link.getExternalCatalogItem().getExternalService().getCapabilities())
+                .extracting("capabilityCode")
+                .containsExactly("CATALOG");
     }
 }

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -18,6 +18,8 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
     @Test
     void marketplaceListingSupportsCrudAndExternalListingLookup() {
         ListingFixture fixture = listingFixture("listing-1");
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "MARKETPLACE_LISTING"));
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "PRICE_GUIDE"));
         MarketplaceListing listing = marketplaceListing(fixture.inventory().getItemInventoryId(), fixture.item().getExternalCatalogItemId(), 2, "BL-1");
 
         marketplaceListingMapper.insert(listing);
@@ -29,9 +31,13 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
                 .hasValueSatisfying(found -> {
                     assertThat(found.getTitle()).isEqualTo("Updated listing");
                     assertThat(found.getUnitPrice()).isEqualByComparingTo("24.99");
+                    assertHydratedCatalogItem(found);
                 });
         assertThat(marketplaceListingMapper.findByListingExternalServiceIdAndExternalListingId(2, "BL-1")).isPresent();
-        assertThat(marketplaceListingMapper.findByItemInventoryId(fixture.inventory().getItemInventoryId())).hasSize(1);
+        assertThat(marketplaceListingMapper.findByItemInventoryId(fixture.inventory().getItemInventoryId()))
+                .hasSize(1)
+                .first()
+                .satisfies(this::assertHydratedCatalogItem);
         assertThat(marketplaceListingMapper.findAll()).hasSize(1);
 
         listing.setListingStatusCode("ENDED");
@@ -108,6 +114,18 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         ExternalCatalogItem item = insertExternalCatalogItem(itemKey);
         ItemInventory inventory = insertItemInventory("uuid-" + itemKey);
         return new ListingFixture(item, inventory);
+    }
+
+    private void assertHydratedCatalogItem(MarketplaceListing listing) {
+        assertThat(listing.getExternalCatalogItem()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalItemKey()).isEqualTo("listing-1");
+        assertThat(listing.getExternalCatalogItem().getExternalService()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalService().getServiceCode()).isEqualTo("BRICKLINK");
+        assertThat(listing.getExternalCatalogItem().getExternalService().getExternalServiceType()).isNotNull();
+        assertThat(listing.getExternalCatalogItem().getExternalService().getExternalServiceType().getExternalServiceTypeName()).isEqualTo("MARKETPLACE");
+        assertThat(listing.getExternalCatalogItem().getExternalService().getCapabilities())
+                .extracting("capabilityCode")
+                .containsExactlyInAnyOrder("MARKETPLACE_LISTING", "PRICE_GUIDE");
     }
 
     private record ListingFixture(ExternalCatalogItem item, ItemInventory inventory) {


### PR DESCRIPTION
## Summary
- Add eager ItemInventory -> ItemInventoryExternalCatalogItem -> ExternalCatalogItem hydration.
- Add MarketplaceListing -> ExternalCatalogItem -> ExternalService -> ExternalServiceType/ExternalServiceCapability eager hydration.
- Add ItemInventoryDao helpers for primary catalog item selection and explicit marketplace listing lookup.
- Update mapper/DAO tests to assert the hydrated graph and add focused ItemInventoryDao unit coverage.

## Verification
- mvn -q clean install