### PR TITLE
Add marketplace order sync data layer

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderDao.java
@@ -1,0 +1,45 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceOrder;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceOrderDao {
+    private final MarketplaceOrderMapper marketplaceOrderMapper;
+
+    public Set<MarketplaceOrder> findAll() {
+        return marketplaceOrderMapper.findAll();
+    }
+
+    public Optional<MarketplaceOrder> findByMarketplaceOrderId(Integer marketplaceOrderId) {
+        return marketplaceOrderMapper.findByMarketplaceOrderId(marketplaceOrderId);
+    }
+
+    public Optional<MarketplaceOrder> findByMarketplaceCodeAndExternalOrderId(String marketplaceCode, String externalOrderId) {
+        return marketplaceOrderMapper.findByMarketplaceCodeAndExternalOrderId(marketplaceCode, externalOrderId);
+    }
+
+    public MarketplaceOrder insert(MarketplaceOrder marketplaceOrder) {
+        marketplaceOrderMapper.insert(marketplaceOrder);
+        return marketplaceOrder;
+    }
+
+    public int update(MarketplaceOrder marketplaceOrder) {
+        return marketplaceOrderMapper.update(marketplaceOrder);
+    }
+
+    public int delete(Integer marketplaceOrderId) {
+        return marketplaceOrderMapper.delete(marketplaceOrderId);
+    }
+
+    public MarketplaceOrder upsert(MarketplaceOrder marketplaceOrder) {
+        marketplaceOrderMapper.upsert(marketplaceOrder);
+        return marketplaceOrder;
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderItemDao.java
@@ -1,0 +1,41 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderItemMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceOrderItemDao {
+    private final MarketplaceOrderItemMapper marketplaceOrderItemMapper;
+
+    public Set<MarketplaceOrderItem> findAll() {
+        return marketplaceOrderItemMapper.findAll();
+    }
+
+    public Optional<MarketplaceOrderItem> findByMarketplaceOrderItemId(Integer marketplaceOrderItemId) {
+        return marketplaceOrderItemMapper.findByMarketplaceOrderItemId(marketplaceOrderItemId);
+    }
+
+    public MarketplaceOrderItem insert(MarketplaceOrderItem marketplaceOrderItem) {
+        marketplaceOrderItemMapper.insert(marketplaceOrderItem);
+        return marketplaceOrderItem;
+    }
+
+    public int update(MarketplaceOrderItem marketplaceOrderItem) {
+        return marketplaceOrderItemMapper.update(marketplaceOrderItem);
+    }
+
+    public int delete(Integer marketplaceOrderItemId) {
+        return marketplaceOrderItemMapper.delete(marketplaceOrderItemId);
+    }
+
+    public MarketplaceOrderItem upsert(MarketplaceOrderItem marketplaceOrderItem) {
+        marketplaceOrderItemMapper.upsert(marketplaceOrderItem);
+        return marketplaceOrderItem;
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderPayloadDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderPayloadDao.java
@@ -1,0 +1,41 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceOrderPayload;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderPayloadMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceOrderPayloadDao {
+    private final MarketplaceOrderPayloadMapper marketplaceOrderPayloadMapper;
+
+    public Set<MarketplaceOrderPayload> findAll() {
+        return marketplaceOrderPayloadMapper.findAll();
+    }
+
+    public Optional<MarketplaceOrderPayload> findByMarketplaceOrderPayloadId(Integer marketplaceOrderPayloadId) {
+        return marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(marketplaceOrderPayloadId);
+    }
+
+    public MarketplaceOrderPayload insert(MarketplaceOrderPayload marketplaceOrderPayload) {
+        marketplaceOrderPayloadMapper.insert(marketplaceOrderPayload);
+        return marketplaceOrderPayload;
+    }
+
+    public int update(MarketplaceOrderPayload marketplaceOrderPayload) {
+        return marketplaceOrderPayloadMapper.update(marketplaceOrderPayload);
+    }
+
+    public int delete(Integer marketplaceOrderPayloadId) {
+        return marketplaceOrderPayloadMapper.delete(marketplaceOrderPayloadId);
+    }
+
+    public MarketplaceOrderPayload upsert(MarketplaceOrderPayload marketplaceOrderPayload) {
+        marketplaceOrderPayloadMapper.upsert(marketplaceOrderPayload);
+        return marketplaceOrderPayload;
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderSyncRunDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderSyncRunDao.java
@@ -1,0 +1,41 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceOrderSyncRun;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderSyncRunMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceOrderSyncRunDao {
+    private final MarketplaceOrderSyncRunMapper marketplaceOrderSyncRunMapper;
+
+    public Set<MarketplaceOrderSyncRun> findAll() {
+        return marketplaceOrderSyncRunMapper.findAll();
+    }
+
+    public Optional<MarketplaceOrderSyncRun> findByMarketplaceOrderSyncRunId(Integer marketplaceOrderSyncRunId) {
+        return marketplaceOrderSyncRunMapper.findByMarketplaceOrderSyncRunId(marketplaceOrderSyncRunId);
+    }
+
+    public MarketplaceOrderSyncRun insert(MarketplaceOrderSyncRun marketplaceOrderSyncRun) {
+        marketplaceOrderSyncRunMapper.insert(marketplaceOrderSyncRun);
+        return marketplaceOrderSyncRun;
+    }
+
+    public int update(MarketplaceOrderSyncRun marketplaceOrderSyncRun) {
+        return marketplaceOrderSyncRunMapper.update(marketplaceOrderSyncRun);
+    }
+
+    public int delete(Integer marketplaceOrderSyncRunId) {
+        return marketplaceOrderSyncRunMapper.delete(marketplaceOrderSyncRunId);
+    }
+
+    public MarketplaceOrderSyncRun upsert(MarketplaceOrderSyncRun marketplaceOrderSyncRun) {
+        marketplaceOrderSyncRunMapper.upsert(marketplaceOrderSyncRun);
+        return marketplaceOrderSyncRun;
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderTransactionLinkDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderTransactionLinkDao.java
@@ -1,0 +1,41 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceOrderTransactionLink;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderTransactionLinkMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceOrderTransactionLinkDao {
+    private final MarketplaceOrderTransactionLinkMapper marketplaceOrderTransactionLinkMapper;
+
+    public Set<MarketplaceOrderTransactionLink> findAll() {
+        return marketplaceOrderTransactionLinkMapper.findAll();
+    }
+
+    public Optional<MarketplaceOrderTransactionLink> findByMarketplaceOrderTransactionLinkId(Integer marketplaceOrderTransactionLinkId) {
+        return marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(marketplaceOrderTransactionLinkId);
+    }
+
+    public MarketplaceOrderTransactionLink insert(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink) {
+        marketplaceOrderTransactionLinkMapper.insert(marketplaceOrderTransactionLink);
+        return marketplaceOrderTransactionLink;
+    }
+
+    public int update(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink) {
+        return marketplaceOrderTransactionLinkMapper.update(marketplaceOrderTransactionLink);
+    }
+
+    public int delete(Integer marketplaceOrderTransactionLinkId) {
+        return marketplaceOrderTransactionLinkMapper.delete(marketplaceOrderTransactionLinkId);
+    }
+
+    public MarketplaceOrderTransactionLink upsert(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink) {
+        marketplaceOrderTransactionLinkMapper.upsert(marketplaceOrderTransactionLink);
+        return marketplaceOrderTransactionLink;
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
@@ -1,0 +1,334 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.config.LegoDataDaoConfiguration;
+import io.legohunter.data.config.MyBatisV2Configuration;
+import io.legohunter.data.dto.MarketplaceOrder;
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import io.legohunter.data.dto.MarketplaceOrderPayload;
+import io.legohunter.data.dto.MarketplaceOrderSyncRun;
+import io.legohunter.data.dto.MarketplaceOrderTransactionLink;
+import io.legohunter.data.dto.Party;
+import io.legohunter.data.dto.TransactionItem;
+import io.legohunter.data.dto.TransactionPlatform;
+import io.legohunter.data.dto.TransactionType;
+import io.legohunter.data.dto.Transactions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@Import({MyBatisV2Configuration.class, LegoDataDaoConfiguration.class})
+@Sql(scripts = "/scripts/db/h2/current_schema.ddl")
+class MarketplaceOrderSyncDaoTest {
+    private static final ZonedDateTime STARTED_AT = ZonedDateTime.parse("2026-06-01T12:00:00Z");
+    private static final ZonedDateTime ORDERED_AT = ZonedDateTime.parse("2026-06-01T13:00:00Z");
+
+    @Autowired MarketplaceOrderSyncRunDao marketplaceOrderSyncRunDao;
+    @Autowired MarketplaceOrderDao marketplaceOrderDao;
+    @Autowired MarketplaceOrderItemDao marketplaceOrderItemDao;
+    @Autowired MarketplaceOrderPayloadDao marketplaceOrderPayloadDao;
+    @Autowired MarketplaceOrderTransactionLinkDao marketplaceOrderTransactionLinkDao;
+    @Autowired PartyDao partyDao;
+    @Autowired TransactionPlatformDao transactionPlatformDao;
+    @Autowired TransactionsDao transactionsDao;
+    @Autowired TransactionTypeDao transactionTypeDao;
+    @Autowired TransactionItemDao transactionItemDao;
+
+    @Test
+    void marketplaceOrderSyncRunDaoExposesMapperMethods() {
+        MarketplaceOrderSyncRun syncRun = marketplaceOrderSyncRunDao.insert(marketplaceOrderSyncRun());
+        syncRun.setSyncStatusCode("SUCCESS");
+        syncRun.setCompletedAt(STARTED_AT.plusMinutes(5));
+        assertThat(marketplaceOrderSyncRunDao.update(syncRun)).isOne();
+
+        assertThat(marketplaceOrderSyncRunDao.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId()))
+                .hasValueSatisfying(found -> assertThat(found.getSyncStatusCode()).isEqualTo("SUCCESS"));
+        assertThat(marketplaceOrderSyncRunDao.findAll()).hasSize(1);
+
+        syncRun.setOrdersFetched(4);
+        marketplaceOrderSyncRunDao.upsert(syncRun);
+        assertThat(marketplaceOrderSyncRunDao.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId()))
+                .hasValueSatisfying(found -> assertThat(found.getOrdersFetched()).isEqualTo(4));
+
+        assertThat(marketplaceOrderSyncRunDao.delete(syncRun.getMarketplaceOrderSyncRunId())).isOne();
+        assertThat(marketplaceOrderSyncRunDao.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderDaoExposesMapperMethods() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = marketplaceOrderDao.insert(marketplaceOrder(syncRun.getMarketplaceOrderSyncRunId(), "DAO-BL-1001"));
+        order.setExternalStatusCode("PAID");
+        order.setGrandTotalAmount(new BigDecimal("29.99"));
+        assertThat(marketplaceOrderDao.update(order)).isOne();
+
+        assertThat(marketplaceOrderDao.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalStatusCode()).isEqualTo("PAID"));
+        assertThat(marketplaceOrderDao.findByMarketplaceCodeAndExternalOrderId("BRICKLINK", "DAO-BL-1001")).isPresent();
+        assertThat(marketplaceOrderDao.findAll()).hasSize(1);
+
+        MarketplaceOrder naturalKeyOrder = marketplaceOrder(syncRun.getMarketplaceOrderSyncRunId(), "DAO-BL-1001");
+        naturalKeyOrder.setExternalStatusCode("UPDATED");
+        marketplaceOrderDao.upsert(naturalKeyOrder);
+        assertThat(marketplaceOrderDao.findByMarketplaceCodeAndExternalOrderId("BRICKLINK", "DAO-BL-1001"))
+                .hasValueSatisfying(found -> assertThat(found.getExternalStatusCode()).isEqualTo("UPDATED"));
+
+        assertThat(marketplaceOrderDao.delete(order.getMarketplaceOrderId())).isOne();
+        assertThat(marketplaceOrderDao.findByMarketplaceOrderId(order.getMarketplaceOrderId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderItemDaoExposesMapperMethods() {
+        MarketplaceOrder order = insertedOrder("DAO-BL-ITEM-1");
+        MarketplaceOrderItem item = marketplaceOrderItemDao.insert(marketplaceOrderItem(order.getMarketplaceOrderId()));
+        item.setQuantity(2);
+        item.setRemarks("DAO updated remarks");
+        item.setDescription("DAO updated description");
+        assertThat(marketplaceOrderItemDao.update(item)).isOne();
+
+        assertThat(marketplaceOrderItemDao.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getQuantity()).isEqualTo(2);
+                    assertThat(found.getRemarks()).isEqualTo("DAO updated remarks");
+                    assertThat(found.getDescription()).isEqualTo("DAO updated description");
+                });
+        assertThat(marketplaceOrderItemDao.findAll()).hasSize(1);
+
+        item.setQuantity(6);
+        marketplaceOrderItemDao.upsert(item);
+        assertThat(marketplaceOrderItemDao.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
+                .hasValueSatisfying(found -> assertThat(found.getQuantity()).isEqualTo(6));
+
+        assertThat(marketplaceOrderItemDao.delete(item.getMarketplaceOrderItemId())).isOne();
+        assertThat(marketplaceOrderItemDao.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderPayloadDaoExposesMapperMethods() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), "DAO-BL-PAYLOAD-1");
+        MarketplaceOrderPayload payload = marketplaceOrderPayloadDao.insert(marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId()));
+        payload.setPayloadHash("dao-hash-updated");
+        payload.setPayloadJson("{\"dao\":\"updated\"}");
+        assertThat(marketplaceOrderPayloadDao.update(payload)).isOne();
+
+        assertThat(marketplaceOrderPayloadDao.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId()))
+                .hasValueSatisfying(found -> assertThat(found.getPayloadHash()).isEqualTo("dao-hash-updated"));
+        assertThat(marketplaceOrderPayloadDao.findAll()).hasSize(1);
+
+        payload.setPayloadTypeCode("ORDER_ITEMS_RESPONSE");
+        marketplaceOrderPayloadDao.upsert(payload);
+        assertThat(marketplaceOrderPayloadDao.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId()))
+                .hasValueSatisfying(found -> assertThat(found.getPayloadTypeCode()).isEqualTo("ORDER_ITEMS_RESPONSE"));
+
+        assertThat(marketplaceOrderPayloadDao.delete(payload.getMarketplaceOrderPayloadId())).isOne();
+        assertThat(marketplaceOrderPayloadDao.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderTransactionLinkDaoExposesMapperMethods() {
+        MarketplaceOrder order = insertedOrder("DAO-BL-LINK-1");
+        MarketplaceOrderItem orderItem = marketplaceOrderItemDao.insert(marketplaceOrderItem(order.getMarketplaceOrderId()));
+        TransactionItem transactionItem = insertedTransactionItem();
+        MarketplaceOrderTransactionLink link = marketplaceOrderTransactionLinkDao.insert(marketplaceOrderTransactionLink(
+                order.getMarketplaceOrderId(),
+                transactionItem.getTransactionId(),
+                orderItem.getMarketplaceOrderItemId(),
+                transactionItem.getTransactionItemId()
+        ));
+        link.setLinkStatusCode("UNLINKED");
+        link.setUnlinkedAt(STARTED_AT.plusDays(1));
+        assertThat(marketplaceOrderTransactionLinkDao.update(link)).isOne();
+
+        assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
+                .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("UNLINKED"));
+        assertThat(marketplaceOrderTransactionLinkDao.findAll()).hasSize(1);
+
+        link.setLinkStatusCode("ACTIVE");
+        link.setUnlinkedAt(null);
+        marketplaceOrderTransactionLinkDao.upsert(link);
+        assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
+                .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("ACTIVE"));
+
+        assertThat(marketplaceOrderTransactionLinkDao.delete(link.getMarketplaceOrderTransactionLinkId())).isOne();
+        assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId())).isEmpty();
+    }
+
+    private MarketplaceOrderSyncRun insertedSyncRun() {
+        return marketplaceOrderSyncRunDao.insert(marketplaceOrderSyncRun());
+    }
+
+    private MarketplaceOrder insertedOrder(String externalOrderId) {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        return insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), externalOrderId);
+    }
+
+    private MarketplaceOrder insertedOrder(Integer syncRunId, String externalOrderId) {
+        return marketplaceOrderDao.insert(marketplaceOrder(syncRunId, externalOrderId));
+    }
+
+    private TransactionItem insertedTransactionItem() {
+        Party fromParty = party("From");
+        partyDao.insert(fromParty);
+        Party toParty = party("To");
+        partyDao.insert(toParty);
+        transactionPlatformDao.insert(TransactionPlatform.builder()
+                .transactionPlatformId(1)
+                .transactionPlatformName("BrickLink")
+                .build());
+        transactionTypeDao.insert(TransactionType.builder()
+                .transactionTypeCode("BUY")
+                .transactionTypeDescription("Buy")
+                .conversionFactor(1)
+                .build());
+        Transactions transaction = Transactions.builder()
+                .transactionDateTime(STARTED_AT)
+                .notes("DAO transaction")
+                .fromPartyId(fromParty.getPartyId())
+                .toPartyId(toParty.getPartyId())
+                .transactionPlatformId(1)
+                .transactionOrderId("DAO-ORDER-1")
+                .build();
+        transactionsDao.insert(transaction);
+        TransactionItem transactionItem = TransactionItem.builder()
+                .transactionId(transaction.getTransactionId())
+                .transactionTypeCode("BUY")
+                .notes("DAO transaction item")
+                .build();
+        transactionItemDao.insert(transactionItem);
+        return transactionItem;
+    }
+
+    private Party party(String name) {
+        return Party.builder()
+                .partyFirstName(name)
+                .partyLastName("Tester")
+                .partyAddress1("123 Main")
+                .partyCity("Charlotte")
+                .partyState("NC")
+                .partyPostalCode("28202")
+                .partyCountryCode("US")
+                .partyCountry("United States")
+                .partyEmail(name.toLowerCase() + "@example.com")
+                .partyType("PERSON")
+                .partyActivationDate(LocalDateTime.parse("2026-01-01T00:00:00"))
+                .build();
+    }
+
+    private MarketplaceOrderSyncRun marketplaceOrderSyncRun() {
+        return MarketplaceOrderSyncRun.builder()
+                .marketplaceCode("BRICKLINK")
+                .syncJobName("bricklink-order-sync")
+                .syncDirection("IN")
+                .syncStatusCode("STARTED")
+                .startedAt(STARTED_AT)
+                .ordersDiscovered(1)
+                .ordersFetched(0)
+                .ordersFailed(0)
+                .build();
+    }
+
+    private MarketplaceOrder marketplaceOrder(Integer syncRunId, String externalOrderId) {
+        return MarketplaceOrder.builder()
+                .lastSyncRunId(syncRunId)
+                .marketplaceCode("BRICKLINK")
+                .externalOrderId(externalOrderId)
+                .orderDirection("IN")
+                .externalStatusCode("PENDING")
+                .orderedAt(ORDERED_AT)
+                .statusChangedAt(ORDERED_AT.plusHours(1))
+                .buyerDisplayName("DAO Buyer")
+                .buyerEmail("dao-buyer@example.com")
+                .paymentStatusCode("PENDING")
+                .paymentMethod("PayPal")
+                .paymentCurrencyCode("USD")
+                .paidAt(ORDERED_AT.plusHours(2))
+                .shippingMethod("Request for invoice")
+                .shippingMethodId("1")
+                .shippingAddressPresent(true)
+                .trackingPresent(false)
+                .subtotalAmount(new BigDecimal("12.34"))
+                .shippingAmount(new BigDecimal("6.42"))
+                .grandTotalAmount(new BigDecimal("18.76"))
+                .currencyCode("USD")
+                .displayCurrencyCode("USD")
+                .totalCount(2)
+                .uniqueCount(1)
+                .totalWeight(new BigDecimal("1.250"))
+                .invoiced(false)
+                .filed(false)
+                .sentDriveThru(false)
+                .requireInsurance(false)
+                .payloadHash("dao-order-hash")
+                .lastSeenAt(ORDERED_AT.plusHours(3))
+                .build();
+    }
+
+    private MarketplaceOrderItem marketplaceOrderItem(Integer marketplaceOrderId) {
+        return MarketplaceOrderItem.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .externalOrderItemId("dao-line-1")
+                .externalInventoryId("dao-inventory-1")
+                .externalItemNo("3001")
+                .externalItemType("SET")
+                .colorId(5)
+                .colorName("Red")
+                .quantity(1)
+                .conditionCode("N")
+                .completenessCode("C")
+                .unitPrice(new BigDecimal("5.99"))
+                .finalUnitPrice(new BigDecimal("5.49"))
+                .currencyCode("USD")
+                .itemWeight(new BigDecimal("0.250"))
+                .remarks("DAO initial remarks")
+                .description("DAO initial description")
+                .payloadHash("dao-item-hash")
+                .build();
+    }
+
+    private MarketplaceOrderPayload marketplaceOrderPayload(Integer marketplaceOrderId, Integer syncRunId) {
+        return MarketplaceOrderPayload.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .marketplaceOrderSyncRunId(syncRunId)
+                .payloadTypeCode("ORDER_RESPONSE")
+                .payloadHash("dao-hash-initial")
+                .payloadJson("{\"dao\":\"initial\"}")
+                .capturedAt(STARTED_AT.plusMinutes(1))
+                .build();
+    }
+
+    private MarketplaceOrderTransactionLink marketplaceOrderTransactionLink(
+            Integer marketplaceOrderId,
+            Long transactionId,
+            Integer marketplaceOrderItemId,
+            Long transactionItemId
+    ) {
+        return MarketplaceOrderTransactionLink.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .transactionId(transactionId)
+                .marketplaceOrderItemId(marketplaceOrderItemId)
+                .transactionItemId(transactionItemId)
+                .linkTypeCode("FULFILLMENT")
+                .linkStatusCode("ACTIVE")
+                .linkedAt(STARTED_AT.plusHours(1))
+                .build();
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    @PropertySource("application.properties")
+    static class TestConfiguration {
+    }
+}

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -1,3 +1,8 @@
+DROP TABLE IF EXISTS marketplace_order_transaction_link;
+DROP TABLE IF EXISTS marketplace_order_payload;
+DROP TABLE IF EXISTS marketplace_order_item;
+DROP TABLE IF EXISTS marketplace_order;
+DROP TABLE IF EXISTS marketplace_order_sync_run;
 DROP TABLE IF EXISTS ebay_listing_item_specific;
 DROP TABLE IF EXISTS ebay_marketplace_listing;
 DROP TABLE IF EXISTS bricklink_marketplace_listing;
@@ -210,6 +215,110 @@ CREATE TABLE ebay_listing_item_specific (
     PRIMARY KEY (marketplace_listing_id, name, `value`)
 );
 
+CREATE TABLE marketplace_order_sync_run (
+    marketplace_order_sync_run_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_code VARCHAR(30) NOT NULL,
+    sync_job_name VARCHAR(100),
+    sync_direction VARCHAR(20) NOT NULL,
+    sync_status_code VARCHAR(30) NOT NULL,
+    started_at TIMESTAMP NOT NULL,
+    completed_at TIMESTAMP,
+    orders_discovered INT NOT NULL DEFAULT 0,
+    orders_fetched INT NOT NULL DEFAULT 0,
+    orders_failed INT NOT NULL DEFAULT 0,
+    error_message CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order (
+    marketplace_order_id INT AUTO_INCREMENT PRIMARY KEY,
+    last_sync_run_id INT,
+    marketplace_code VARCHAR(30) NOT NULL,
+    external_order_id VARCHAR(100) NOT NULL,
+    order_direction VARCHAR(20) NOT NULL,
+    external_status_code VARCHAR(50) NOT NULL,
+    ordered_at TIMESTAMP,
+    status_changed_at TIMESTAMP,
+    buyer_display_name VARCHAR(150),
+    buyer_email VARCHAR(255),
+    payment_status_code VARCHAR(50),
+    payment_method VARCHAR(100),
+    payment_currency_code CHAR(3),
+    paid_at TIMESTAMP,
+    shipping_method VARCHAR(150),
+    shipping_method_id VARCHAR(100),
+    shipping_address_present BOOLEAN DEFAULT FALSE,
+    tracking_present BOOLEAN DEFAULT FALSE,
+    subtotal_amount DECIMAL(10,2),
+    shipping_amount DECIMAL(10,2),
+    grand_total_amount DECIMAL(10,2),
+    currency_code CHAR(3),
+    display_currency_code CHAR(3),
+    total_count INT,
+    unique_count INT,
+    total_weight DECIMAL(10,3),
+    is_invoiced BOOLEAN,
+    is_filed BOOLEAN,
+    sent_drive_thru BOOLEAN,
+    require_insurance BOOLEAN,
+    payload_hash VARCHAR(64),
+    last_seen_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_marketplace_order_source_order UNIQUE (marketplace_code, external_order_id)
+);
+
+CREATE TABLE marketplace_order_item (
+    marketplace_order_item_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    marketplace_listing_id INT,
+    item_inventory_id INT,
+    external_order_item_id VARCHAR(100),
+    external_inventory_id VARCHAR(100),
+    external_item_no VARCHAR(100),
+    external_item_type VARCHAR(30),
+    color_id INT,
+    color_name VARCHAR(100),
+    quantity INT NOT NULL DEFAULT 0,
+    condition_code VARCHAR(10),
+    completeness_code VARCHAR(10),
+    unit_price DECIMAL(10,2),
+    final_unit_price DECIMAL(10,2),
+    currency_code CHAR(3),
+    item_weight DECIMAL(10,3),
+    remarks CLOB,
+    description CLOB,
+    payload_hash VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order_payload (
+    marketplace_order_payload_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    marketplace_order_sync_run_id INT,
+    payload_type_code VARCHAR(50) NOT NULL,
+    payload_hash VARCHAR(64),
+    payload_json CLOB,
+    captured_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order_transaction_link (
+    marketplace_order_transaction_link_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    transaction_id BIGINT NOT NULL,
+    marketplace_order_item_id INT,
+    transaction_item_id BIGINT,
+    link_type_code VARCHAR(30) NOT NULL,
+    link_status_code VARCHAR(30) NOT NULL,
+    linked_at TIMESTAMP NOT NULL,
+    unlinked_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE inventory_index (
     box_id INT NOT NULL,
     box_index INT NOT NULL,
@@ -302,6 +411,38 @@ CREATE INDEX idx_marketplace_listing_inventory
     ON marketplace_listing (item_inventory_id);
 CREATE INDEX idx_marketplace_listing_catalog_item
     ON marketplace_listing (external_catalog_item_id);
+CREATE INDEX idx_marketplace_order_sync_run_marketplace_status
+    ON marketplace_order_sync_run (marketplace_code, sync_status_code);
+CREATE INDEX idx_marketplace_order_sync_run_started_at
+    ON marketplace_order_sync_run (started_at);
+CREATE INDEX idx_marketplace_order_status
+    ON marketplace_order (marketplace_code, external_status_code);
+CREATE INDEX idx_marketplace_order_last_sync_run
+    ON marketplace_order (last_sync_run_id);
+CREATE INDEX idx_marketplace_order_item_order
+    ON marketplace_order_item (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_item_listing
+    ON marketplace_order_item (marketplace_listing_id);
+CREATE INDEX idx_marketplace_order_item_inventory
+    ON marketplace_order_item (item_inventory_id);
+CREATE INDEX idx_marketplace_order_item_external_inventory
+    ON marketplace_order_item (external_inventory_id);
+CREATE INDEX idx_marketplace_order_payload_order
+    ON marketplace_order_payload (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_payload_sync_run
+    ON marketplace_order_payload (marketplace_order_sync_run_id);
+CREATE INDEX idx_marketplace_order_payload_type_hash
+    ON marketplace_order_payload (payload_type_code, payload_hash);
+CREATE INDEX idx_marketplace_order_transaction_link_order
+    ON marketplace_order_transaction_link (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_transaction_link_transaction
+    ON marketplace_order_transaction_link (transaction_id);
+CREATE INDEX idx_marketplace_order_transaction_link_order_item
+    ON marketplace_order_transaction_link (marketplace_order_item_id);
+CREATE INDEX idx_marketplace_order_transaction_link_transaction_item
+    ON marketplace_order_transaction_link (transaction_item_id);
+CREATE INDEX idx_marketplace_order_transaction_link_type_status
+    ON marketplace_order_transaction_link (link_type_code, link_status_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -447,6 +588,36 @@ ALTER TABLE ebay_listing_item_specific
     FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
+ALTER TABLE marketplace_order
+    ADD CONSTRAINT fk_marketplace_order_sync_run1
+    FOREIGN KEY (last_sync_run_id) REFERENCES marketplace_order_sync_run (marketplace_order_sync_run_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_payload
+    ADD CONSTRAINT fk_marketplace_order_payload_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_payload
+    ADD CONSTRAINT fk_marketplace_order_payload_sync_run1
+    FOREIGN KEY (marketplace_order_sync_run_id) REFERENCES marketplace_order_sync_run (marketplace_order_sync_run_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
 ALTER TABLE item_inventory_photo
     ADD CONSTRAINT fk_item_inventory_photo_item_inventory1
     FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
@@ -510,6 +681,26 @@ ALTER TABLE transaction_item
 ALTER TABLE transaction_item
     ADD CONSTRAINT fk_transaction_item_item_inventory1
     FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_transaction1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_order_item1
+    FOREIGN KEY (marketplace_order_item_id) REFERENCES marketplace_order_item (marketplace_order_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_transaction_item1
+    FOREIGN KEY (transaction_item_id) REFERENCES transaction_item (transaction_item_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE transaction_cost

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrder.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrder.java
@@ -1,0 +1,50 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceOrder {
+    private Integer marketplaceOrderId;
+    private Integer lastSyncRunId;
+    private String marketplaceCode;
+    private String externalOrderId;
+    private String orderDirection;
+    private String externalStatusCode;
+    private ZonedDateTime orderedAt;
+    private ZonedDateTime statusChangedAt;
+    private String buyerDisplayName;
+    private String buyerEmail;
+    private String paymentStatusCode;
+    private String paymentMethod;
+    private String paymentCurrencyCode;
+    private ZonedDateTime paidAt;
+    private String shippingMethod;
+    private String shippingMethodId;
+    private Boolean shippingAddressPresent;
+    private Boolean trackingPresent;
+    private BigDecimal subtotalAmount;
+    private BigDecimal shippingAmount;
+    private BigDecimal grandTotalAmount;
+    private String currencyCode;
+    private String displayCurrencyCode;
+    private Integer totalCount;
+    private Integer uniqueCount;
+    private BigDecimal totalWeight;
+    private Boolean invoiced;
+    private Boolean filed;
+    private Boolean sentDriveThru;
+    private Boolean requireInsurance;
+    private String payloadHash;
+    private ZonedDateTime lastSeenAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderItem.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderItem.java
@@ -1,0 +1,38 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceOrderItem {
+    private Integer marketplaceOrderItemId;
+    private Integer marketplaceOrderId;
+    private Integer marketplaceListingId;
+    private Integer itemInventoryId;
+    private String externalOrderItemId;
+    private String externalInventoryId;
+    private String externalItemNo;
+    private String externalItemType;
+    private Integer colorId;
+    private String colorName;
+    private Integer quantity;
+    private String conditionCode;
+    private String completenessCode;
+    private BigDecimal unitPrice;
+    private BigDecimal finalUnitPrice;
+    private String currencyCode;
+    private BigDecimal itemWeight;
+    private String remarks;
+    private String description;
+    private String payloadHash;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderPayload.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderPayload.java
@@ -1,0 +1,23 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceOrderPayload {
+    private Integer marketplaceOrderPayloadId;
+    private Integer marketplaceOrderId;
+    private Integer marketplaceOrderSyncRunId;
+    private String payloadTypeCode;
+    private String payloadHash;
+    private String payloadJson;
+    private ZonedDateTime capturedAt;
+    private ZonedDateTime createdAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderSyncRun.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderSyncRun.java
@@ -1,0 +1,28 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceOrderSyncRun {
+    private Integer marketplaceOrderSyncRunId;
+    private String marketplaceCode;
+    private String syncJobName;
+    private String syncDirection;
+    private String syncStatusCode;
+    private ZonedDateTime startedAt;
+    private ZonedDateTime completedAt;
+    private Integer ordersDiscovered;
+    private Integer ordersFetched;
+    private Integer ordersFailed;
+    private String errorMessage;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderTransactionLink.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceOrderTransactionLink.java
@@ -1,0 +1,26 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceOrderTransactionLink {
+    private Integer marketplaceOrderTransactionLinkId;
+    private Integer marketplaceOrderId;
+    private Long transactionId;
+    private Integer marketplaceOrderItemId;
+    private Long transactionItemId;
+    private String linkTypeCode;
+    private String linkStatusCode;
+    private ZonedDateTime linkedAt;
+    private ZonedDateTime unlinkedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.java
@@ -1,0 +1,202 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceOrderItemMapper {
+    String ALL_COLUMNS = """
+            marketplace_order_item_id,
+            marketplace_order_id,
+            marketplace_listing_id,
+            item_inventory_id,
+            external_order_item_id,
+            external_inventory_id,
+            external_item_no,
+            external_item_type,
+            color_id,
+            color_name,
+            quantity,
+            condition_code,
+            completeness_code,
+            unit_price,
+            final_unit_price,
+            currency_code,
+            item_weight,
+            remarks,
+            description,
+            payload_hash,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_item")
+    @ResultMap("marketplaceOrderItemResultMap")
+    Set<MarketplaceOrderItem> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_item WHERE marketplace_order_item_id = #{marketplaceOrderItemId}")
+    @ResultMap("marketplaceOrderItemResultMap")
+    Optional<MarketplaceOrderItem> findByMarketplaceOrderItemId(Integer marketplaceOrderItemId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_item (
+                marketplace_order_id,
+                marketplace_listing_id,
+                item_inventory_id,
+                external_order_item_id,
+                external_inventory_id,
+                external_item_no,
+                external_item_type,
+                color_id,
+                color_name,
+                quantity,
+                condition_code,
+                completeness_code,
+                unit_price,
+                final_unit_price,
+                currency_code,
+                item_weight,
+                remarks,
+                description,
+                payload_hash,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderId},
+                #{marketplaceListingId},
+                #{itemInventoryId},
+                #{externalOrderItemId},
+                #{externalInventoryId},
+                #{externalItemNo},
+                #{externalItemType},
+                #{colorId},
+                #{colorName},
+                #{quantity},
+                #{conditionCode},
+                #{completenessCode},
+                #{unitPrice},
+                #{finalUnitPrice},
+                #{currencyCode},
+                #{itemWeight},
+                #{remarks},
+                #{description},
+                #{payloadHash},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderItemId")
+    void insert(MarketplaceOrderItem marketplaceOrderItem);
+
+    @Update("""
+            UPDATE marketplace_order_item
+            SET
+                marketplace_order_id = #{marketplaceOrderId},
+                marketplace_listing_id = #{marketplaceListingId},
+                item_inventory_id = #{itemInventoryId},
+                external_order_item_id = #{externalOrderItemId},
+                external_inventory_id = #{externalInventoryId},
+                external_item_no = #{externalItemNo},
+                external_item_type = #{externalItemType},
+                color_id = #{colorId},
+                color_name = #{colorName},
+                quantity = #{quantity},
+                condition_code = #{conditionCode},
+                completeness_code = #{completenessCode},
+                unit_price = #{unitPrice},
+                final_unit_price = #{finalUnitPrice},
+                currency_code = #{currencyCode},
+                item_weight = #{itemWeight},
+                remarks = #{remarks},
+                description = #{description},
+                payload_hash = #{payloadHash},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_order_item_id = #{marketplaceOrderItemId}
+            """)
+    int update(MarketplaceOrderItem marketplaceOrderItem);
+
+    @Delete("DELETE FROM marketplace_order_item WHERE marketplace_order_item_id = #{marketplaceOrderItemId}")
+    int delete(Integer marketplaceOrderItemId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_item (
+                marketplace_order_item_id,
+                marketplace_order_id,
+                marketplace_listing_id,
+                item_inventory_id,
+                external_order_item_id,
+                external_inventory_id,
+                external_item_no,
+                external_item_type,
+                color_id,
+                color_name,
+                quantity,
+                condition_code,
+                completeness_code,
+                unit_price,
+                final_unit_price,
+                currency_code,
+                item_weight,
+                remarks,
+                description,
+                payload_hash,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderItemId},
+                #{marketplaceOrderId},
+                #{marketplaceListingId},
+                #{itemInventoryId},
+                #{externalOrderItemId},
+                #{externalInventoryId},
+                #{externalItemNo},
+                #{externalItemType},
+                #{colorId},
+                #{colorName},
+                #{quantity},
+                #{conditionCode},
+                #{completenessCode},
+                #{unitPrice},
+                #{finalUnitPrice},
+                #{currencyCode},
+                #{itemWeight},
+                #{remarks},
+                #{description},
+                #{payloadHash},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_order_id = VALUES(marketplace_order_id),
+                marketplace_listing_id = VALUES(marketplace_listing_id),
+                item_inventory_id = VALUES(item_inventory_id),
+                external_order_item_id = VALUES(external_order_item_id),
+                external_inventory_id = VALUES(external_inventory_id),
+                external_item_no = VALUES(external_item_no),
+                external_item_type = VALUES(external_item_type),
+                color_id = VALUES(color_id),
+                color_name = VALUES(color_name),
+                quantity = VALUES(quantity),
+                condition_code = VALUES(condition_code),
+                completeness_code = VALUES(completeness_code),
+                unit_price = VALUES(unit_price),
+                final_unit_price = VALUES(final_unit_price),
+                currency_code = VALUES(currency_code),
+                item_weight = VALUES(item_weight),
+                remarks = VALUES(remarks),
+                description = VALUES(description),
+                payload_hash = VALUES(payload_hash),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderItemId")
+    void upsert(MarketplaceOrderItem marketplaceOrderItem);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
@@ -1,0 +1,296 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrder;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceOrderMapper {
+    String ALL_COLUMNS = """
+            marketplace_order_id,
+            last_sync_run_id,
+            marketplace_code,
+            external_order_id,
+            order_direction,
+            external_status_code,
+            ordered_at,
+            status_changed_at,
+            buyer_display_name,
+            buyer_email,
+            payment_status_code,
+            payment_method,
+            payment_currency_code,
+            paid_at,
+            shipping_method,
+            shipping_method_id,
+            shipping_address_present,
+            tracking_present,
+            subtotal_amount,
+            shipping_amount,
+            grand_total_amount,
+            currency_code,
+            display_currency_code,
+            total_count,
+            unique_count,
+            total_weight,
+            is_invoiced,
+            is_filed,
+            sent_drive_thru,
+            require_insurance,
+            payload_hash,
+            last_seen_at,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order")
+    @ResultMap("marketplaceOrderResultMap")
+    Set<MarketplaceOrder> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order WHERE marketplace_order_id = #{marketplaceOrderId}")
+    @ResultMap("marketplaceOrderResultMap")
+    Optional<MarketplaceOrder> findByMarketplaceOrderId(Integer marketplaceOrderId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM marketplace_order
+            WHERE marketplace_code = #{marketplaceCode}
+              AND external_order_id = #{externalOrderId}
+            """)
+    @ResultMap("marketplaceOrderResultMap")
+    Optional<MarketplaceOrder> findByMarketplaceCodeAndExternalOrderId(
+            @Param("marketplaceCode") String marketplaceCode,
+            @Param("externalOrderId") String externalOrderId);
+
+    @Insert("""
+            INSERT INTO marketplace_order (
+                last_sync_run_id,
+                marketplace_code,
+                external_order_id,
+                order_direction,
+                external_status_code,
+                ordered_at,
+                status_changed_at,
+                buyer_display_name,
+                buyer_email,
+                payment_status_code,
+                payment_method,
+                payment_currency_code,
+                paid_at,
+                shipping_method,
+                shipping_method_id,
+                shipping_address_present,
+                tracking_present,
+                subtotal_amount,
+                shipping_amount,
+                grand_total_amount,
+                currency_code,
+                display_currency_code,
+                total_count,
+                unique_count,
+                total_weight,
+                is_invoiced,
+                is_filed,
+                sent_drive_thru,
+                require_insurance,
+                payload_hash,
+                last_seen_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{lastSyncRunId},
+                #{marketplaceCode},
+                #{externalOrderId},
+                #{orderDirection},
+                #{externalStatusCode},
+                #{orderedAt},
+                #{statusChangedAt},
+                #{buyerDisplayName},
+                #{buyerEmail},
+                #{paymentStatusCode},
+                #{paymentMethod},
+                #{paymentCurrencyCode},
+                #{paidAt},
+                #{shippingMethod},
+                #{shippingMethodId},
+                #{shippingAddressPresent},
+                #{trackingPresent},
+                #{subtotalAmount},
+                #{shippingAmount},
+                #{grandTotalAmount},
+                #{currencyCode},
+                #{displayCurrencyCode},
+                #{totalCount},
+                #{uniqueCount},
+                #{totalWeight},
+                #{invoiced},
+                #{filed},
+                #{sentDriveThru},
+                #{requireInsurance},
+                #{payloadHash},
+                #{lastSeenAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderId")
+    void insert(MarketplaceOrder marketplaceOrder);
+
+    @Update("""
+            UPDATE marketplace_order
+            SET
+                last_sync_run_id = #{lastSyncRunId},
+                marketplace_code = #{marketplaceCode},
+                external_order_id = #{externalOrderId},
+                order_direction = #{orderDirection},
+                external_status_code = #{externalStatusCode},
+                ordered_at = #{orderedAt},
+                status_changed_at = #{statusChangedAt},
+                buyer_display_name = #{buyerDisplayName},
+                buyer_email = #{buyerEmail},
+                payment_status_code = #{paymentStatusCode},
+                payment_method = #{paymentMethod},
+                payment_currency_code = #{paymentCurrencyCode},
+                paid_at = #{paidAt},
+                shipping_method = #{shippingMethod},
+                shipping_method_id = #{shippingMethodId},
+                shipping_address_present = #{shippingAddressPresent},
+                tracking_present = #{trackingPresent},
+                subtotal_amount = #{subtotalAmount},
+                shipping_amount = #{shippingAmount},
+                grand_total_amount = #{grandTotalAmount},
+                currency_code = #{currencyCode},
+                display_currency_code = #{displayCurrencyCode},
+                total_count = #{totalCount},
+                unique_count = #{uniqueCount},
+                total_weight = #{totalWeight},
+                is_invoiced = #{invoiced},
+                is_filed = #{filed},
+                sent_drive_thru = #{sentDriveThru},
+                require_insurance = #{requireInsurance},
+                payload_hash = #{payloadHash},
+                last_seen_at = #{lastSeenAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_order_id = #{marketplaceOrderId}
+            """)
+    int update(MarketplaceOrder marketplaceOrder);
+
+    @Delete("DELETE FROM marketplace_order WHERE marketplace_order_id = #{marketplaceOrderId}")
+    int delete(Integer marketplaceOrderId);
+
+    @Insert("""
+            INSERT INTO marketplace_order (
+                marketplace_order_id,
+                last_sync_run_id,
+                marketplace_code,
+                external_order_id,
+                order_direction,
+                external_status_code,
+                ordered_at,
+                status_changed_at,
+                buyer_display_name,
+                buyer_email,
+                payment_status_code,
+                payment_method,
+                payment_currency_code,
+                paid_at,
+                shipping_method,
+                shipping_method_id,
+                shipping_address_present,
+                tracking_present,
+                subtotal_amount,
+                shipping_amount,
+                grand_total_amount,
+                currency_code,
+                display_currency_code,
+                total_count,
+                unique_count,
+                total_weight,
+                is_invoiced,
+                is_filed,
+                sent_drive_thru,
+                require_insurance,
+                payload_hash,
+                last_seen_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderId},
+                #{lastSyncRunId},
+                #{marketplaceCode},
+                #{externalOrderId},
+                #{orderDirection},
+                #{externalStatusCode},
+                #{orderedAt},
+                #{statusChangedAt},
+                #{buyerDisplayName},
+                #{buyerEmail},
+                #{paymentStatusCode},
+                #{paymentMethod},
+                #{paymentCurrencyCode},
+                #{paidAt},
+                #{shippingMethod},
+                #{shippingMethodId},
+                #{shippingAddressPresent},
+                #{trackingPresent},
+                #{subtotalAmount},
+                #{shippingAmount},
+                #{grandTotalAmount},
+                #{currencyCode},
+                #{displayCurrencyCode},
+                #{totalCount},
+                #{uniqueCount},
+                #{totalWeight},
+                #{invoiced},
+                #{filed},
+                #{sentDriveThru},
+                #{requireInsurance},
+                #{payloadHash},
+                #{lastSeenAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_order_id = LAST_INSERT_ID(marketplace_order_id),
+                last_sync_run_id = VALUES(last_sync_run_id),
+                order_direction = VALUES(order_direction),
+                external_status_code = VALUES(external_status_code),
+                ordered_at = VALUES(ordered_at),
+                status_changed_at = VALUES(status_changed_at),
+                buyer_display_name = VALUES(buyer_display_name),
+                buyer_email = VALUES(buyer_email),
+                payment_status_code = VALUES(payment_status_code),
+                payment_method = VALUES(payment_method),
+                payment_currency_code = VALUES(payment_currency_code),
+                paid_at = VALUES(paid_at),
+                shipping_method = VALUES(shipping_method),
+                shipping_method_id = VALUES(shipping_method_id),
+                shipping_address_present = VALUES(shipping_address_present),
+                tracking_present = VALUES(tracking_present),
+                subtotal_amount = VALUES(subtotal_amount),
+                shipping_amount = VALUES(shipping_amount),
+                grand_total_amount = VALUES(grand_total_amount),
+                currency_code = VALUES(currency_code),
+                display_currency_code = VALUES(display_currency_code),
+                total_count = VALUES(total_count),
+                unique_count = VALUES(unique_count),
+                total_weight = VALUES(total_weight),
+                is_invoiced = VALUES(is_invoiced),
+                is_filed = VALUES(is_filed),
+                sent_drive_thru = VALUES(sent_drive_thru),
+                require_insurance = VALUES(require_insurance),
+                payload_hash = VALUES(payload_hash),
+                last_seen_at = VALUES(last_seen_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderId")
+    void upsert(MarketplaceOrder marketplaceOrder);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.java
@@ -1,0 +1,104 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrderPayload;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceOrderPayloadMapper {
+    String ALL_COLUMNS = """
+            marketplace_order_payload_id,
+            marketplace_order_id,
+            marketplace_order_sync_run_id,
+            payload_type_code,
+            payload_hash,
+            payload_json,
+            captured_at,
+            created_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_payload")
+    @ResultMap("marketplaceOrderPayloadResultMap")
+    Set<MarketplaceOrderPayload> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_payload WHERE marketplace_order_payload_id = #{marketplaceOrderPayloadId}")
+    @ResultMap("marketplaceOrderPayloadResultMap")
+    Optional<MarketplaceOrderPayload> findByMarketplaceOrderPayloadId(Integer marketplaceOrderPayloadId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_payload (
+                marketplace_order_id,
+                marketplace_order_sync_run_id,
+                payload_type_code,
+                payload_hash,
+                payload_json,
+                captured_at,
+                created_at
+            )
+            VALUES (
+                #{marketplaceOrderId},
+                #{marketplaceOrderSyncRunId},
+                #{payloadTypeCode},
+                #{payloadHash},
+                #{payloadJson},
+                #{capturedAt},
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderPayloadId")
+    void insert(MarketplaceOrderPayload marketplaceOrderPayload);
+
+    @Update("""
+            UPDATE marketplace_order_payload
+            SET
+                marketplace_order_id = #{marketplaceOrderId},
+                marketplace_order_sync_run_id = #{marketplaceOrderSyncRunId},
+                payload_type_code = #{payloadTypeCode},
+                payload_hash = #{payloadHash},
+                payload_json = #{payloadJson},
+                captured_at = #{capturedAt}
+            WHERE marketplace_order_payload_id = #{marketplaceOrderPayloadId}
+            """)
+    int update(MarketplaceOrderPayload marketplaceOrderPayload);
+
+    @Delete("DELETE FROM marketplace_order_payload WHERE marketplace_order_payload_id = #{marketplaceOrderPayloadId}")
+    int delete(Integer marketplaceOrderPayloadId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_payload (
+                marketplace_order_payload_id,
+                marketplace_order_id,
+                marketplace_order_sync_run_id,
+                payload_type_code,
+                payload_hash,
+                payload_json,
+                captured_at,
+                created_at
+            )
+            VALUES (
+                #{marketplaceOrderPayloadId},
+                #{marketplaceOrderId},
+                #{marketplaceOrderSyncRunId},
+                #{payloadTypeCode},
+                #{payloadHash},
+                #{payloadJson},
+                #{capturedAt},
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_order_id = VALUES(marketplace_order_id),
+                marketplace_order_sync_run_id = VALUES(marketplace_order_sync_run_id),
+                payload_type_code = VALUES(payload_type_code),
+                payload_hash = VALUES(payload_hash),
+                payload_json = VALUES(payload_json),
+                captured_at = VALUES(captured_at)
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderPayloadId")
+    void upsert(MarketplaceOrderPayload marketplaceOrderPayload);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.java
@@ -1,0 +1,139 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrderSyncRun;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceOrderSyncRunMapper {
+    String ALL_COLUMNS = """
+            marketplace_order_sync_run_id,
+            marketplace_code,
+            sync_job_name,
+            sync_direction,
+            sync_status_code,
+            started_at,
+            completed_at,
+            orders_discovered,
+            orders_fetched,
+            orders_failed,
+            error_message,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_sync_run")
+    @ResultMap("marketplaceOrderSyncRunResultMap")
+    Set<MarketplaceOrderSyncRun> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_sync_run WHERE marketplace_order_sync_run_id = #{marketplaceOrderSyncRunId}")
+    @ResultMap("marketplaceOrderSyncRunResultMap")
+    Optional<MarketplaceOrderSyncRun> findByMarketplaceOrderSyncRunId(Integer marketplaceOrderSyncRunId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_sync_run (
+                marketplace_code,
+                sync_job_name,
+                sync_direction,
+                sync_status_code,
+                started_at,
+                completed_at,
+                orders_discovered,
+                orders_fetched,
+                orders_failed,
+                error_message,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceCode},
+                #{syncJobName},
+                #{syncDirection},
+                #{syncStatusCode},
+                #{startedAt},
+                #{completedAt},
+                #{ordersDiscovered},
+                #{ordersFetched},
+                #{ordersFailed},
+                #{errorMessage},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderSyncRunId")
+    void insert(MarketplaceOrderSyncRun marketplaceOrderSyncRun);
+
+    @Update("""
+            UPDATE marketplace_order_sync_run
+            SET
+                marketplace_code = #{marketplaceCode},
+                sync_job_name = #{syncJobName},
+                sync_direction = #{syncDirection},
+                sync_status_code = #{syncStatusCode},
+                started_at = #{startedAt},
+                completed_at = #{completedAt},
+                orders_discovered = #{ordersDiscovered},
+                orders_fetched = #{ordersFetched},
+                orders_failed = #{ordersFailed},
+                error_message = #{errorMessage},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_order_sync_run_id = #{marketplaceOrderSyncRunId}
+            """)
+    int update(MarketplaceOrderSyncRun marketplaceOrderSyncRun);
+
+    @Delete("DELETE FROM marketplace_order_sync_run WHERE marketplace_order_sync_run_id = #{marketplaceOrderSyncRunId}")
+    int delete(Integer marketplaceOrderSyncRunId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_sync_run (
+                marketplace_order_sync_run_id,
+                marketplace_code,
+                sync_job_name,
+                sync_direction,
+                sync_status_code,
+                started_at,
+                completed_at,
+                orders_discovered,
+                orders_fetched,
+                orders_failed,
+                error_message,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderSyncRunId},
+                #{marketplaceCode},
+                #{syncJobName},
+                #{syncDirection},
+                #{syncStatusCode},
+                #{startedAt},
+                #{completedAt},
+                #{ordersDiscovered},
+                #{ordersFetched},
+                #{ordersFailed},
+                #{errorMessage},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_code = VALUES(marketplace_code),
+                sync_job_name = VALUES(sync_job_name),
+                sync_direction = VALUES(sync_direction),
+                sync_status_code = VALUES(sync_status_code),
+                started_at = VALUES(started_at),
+                completed_at = VALUES(completed_at),
+                orders_discovered = VALUES(orders_discovered),
+                orders_fetched = VALUES(orders_fetched),
+                orders_failed = VALUES(orders_failed),
+                error_message = VALUES(error_message),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderSyncRunId")
+    void upsert(MarketplaceOrderSyncRun marketplaceOrderSyncRun);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.java
@@ -1,0 +1,125 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrderTransactionLink;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceOrderTransactionLinkMapper {
+    String ALL_COLUMNS = """
+            marketplace_order_transaction_link_id,
+            marketplace_order_id,
+            transaction_id,
+            marketplace_order_item_id,
+            transaction_item_id,
+            link_type_code,
+            link_status_code,
+            linked_at,
+            unlinked_at,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_transaction_link")
+    @ResultMap("marketplaceOrderTransactionLinkResultMap")
+    Set<MarketplaceOrderTransactionLink> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_transaction_link WHERE marketplace_order_transaction_link_id = #{marketplaceOrderTransactionLinkId}")
+    @ResultMap("marketplaceOrderTransactionLinkResultMap")
+    Optional<MarketplaceOrderTransactionLink> findByMarketplaceOrderTransactionLinkId(Integer marketplaceOrderTransactionLinkId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_transaction_link (
+                marketplace_order_id,
+                transaction_id,
+                marketplace_order_item_id,
+                transaction_item_id,
+                link_type_code,
+                link_status_code,
+                linked_at,
+                unlinked_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderId},
+                #{transactionId},
+                #{marketplaceOrderItemId},
+                #{transactionItemId},
+                #{linkTypeCode},
+                #{linkStatusCode},
+                #{linkedAt},
+                #{unlinkedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderTransactionLinkId")
+    void insert(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink);
+
+    @Update("""
+            UPDATE marketplace_order_transaction_link
+            SET
+                marketplace_order_id = #{marketplaceOrderId},
+                transaction_id = #{transactionId},
+                marketplace_order_item_id = #{marketplaceOrderItemId},
+                transaction_item_id = #{transactionItemId},
+                link_type_code = #{linkTypeCode},
+                link_status_code = #{linkStatusCode},
+                linked_at = #{linkedAt},
+                unlinked_at = #{unlinkedAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_order_transaction_link_id = #{marketplaceOrderTransactionLinkId}
+            """)
+    int update(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink);
+
+    @Delete("DELETE FROM marketplace_order_transaction_link WHERE marketplace_order_transaction_link_id = #{marketplaceOrderTransactionLinkId}")
+    int delete(Integer marketplaceOrderTransactionLinkId);
+
+    @Insert("""
+            INSERT INTO marketplace_order_transaction_link (
+                marketplace_order_transaction_link_id,
+                marketplace_order_id,
+                transaction_id,
+                marketplace_order_item_id,
+                transaction_item_id,
+                link_type_code,
+                link_status_code,
+                linked_at,
+                unlinked_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceOrderTransactionLinkId},
+                #{marketplaceOrderId},
+                #{transactionId},
+                #{marketplaceOrderItemId},
+                #{transactionItemId},
+                #{linkTypeCode},
+                #{linkStatusCode},
+                #{linkedAt},
+                #{unlinkedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_order_id = VALUES(marketplace_order_id),
+                transaction_id = VALUES(transaction_id),
+                marketplace_order_item_id = VALUES(marketplace_order_item_id),
+                transaction_item_id = VALUES(transaction_item_id),
+                link_type_code = VALUES(link_type_code),
+                link_status_code = VALUES(link_status_code),
+                linked_at = VALUES(linked_at),
+                unlinked_at = VALUES(unlinked_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "marketplaceOrderTransactionLinkId")
+    void upsert(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink);
+}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderItemMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceOrderItem" id="marketplaceOrderItemResultMap">
-    <result column="marketplace_order_item_id" property="marketplaceOrderItemId"/>
+    <id     column="marketplace_order_item_id" property="marketplaceOrderItemId"/>
     <result column="marketplace_order_id"      property="marketplaceOrderId"/>
     <result column="marketplace_listing_id"    property="marketplaceListingId"/>
     <result column="item_inventory_id"         property="itemInventoryId"/>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderItemMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceOrderItem" id="marketplaceOrderItemResultMap">
+    <result column="marketplace_order_item_id" property="marketplaceOrderItemId"/>
+    <result column="marketplace_order_id"      property="marketplaceOrderId"/>
+    <result column="marketplace_listing_id"    property="marketplaceListingId"/>
+    <result column="item_inventory_id"         property="itemInventoryId"/>
+    <result column="external_order_item_id"    property="externalOrderItemId"/>
+    <result column="external_inventory_id"     property="externalInventoryId"/>
+    <result column="external_item_no"          property="externalItemNo"/>
+    <result column="external_item_type"        property="externalItemType"/>
+    <result column="color_id"                  property="colorId"/>
+    <result column="color_name"                property="colorName"/>
+    <result column="quantity"                  property="quantity"/>
+    <result column="condition_code"            property="conditionCode"/>
+    <result column="completeness_code"         property="completenessCode"/>
+    <result column="unit_price"                property="unitPrice"/>
+    <result column="final_unit_price"          property="finalUnitPrice"/>
+    <result column="currency_code"             property="currencyCode"/>
+    <result column="item_weight"               property="itemWeight"/>
+    <result column="remarks"                   property="remarks"/>
+    <result column="description"               property="description"/>
+    <result column="payload_hash"              property="payloadHash"/>
+    <result column="created_at"                property="createdAt"/>
+    <result column="updated_at"                property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.xml
@@ -1,0 +1,39 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceOrder" id="marketplaceOrderResultMap">
+    <result column="marketplace_order_id"       property="marketplaceOrderId"/>
+    <result column="last_sync_run_id"           property="lastSyncRunId"/>
+    <result column="marketplace_code"           property="marketplaceCode"/>
+    <result column="external_order_id"          property="externalOrderId"/>
+    <result column="order_direction"            property="orderDirection"/>
+    <result column="external_status_code"       property="externalStatusCode"/>
+    <result column="ordered_at"                 property="orderedAt"/>
+    <result column="status_changed_at"          property="statusChangedAt"/>
+    <result column="buyer_display_name"         property="buyerDisplayName"/>
+    <result column="buyer_email"                property="buyerEmail"/>
+    <result column="payment_status_code"        property="paymentStatusCode"/>
+    <result column="payment_method"             property="paymentMethod"/>
+    <result column="payment_currency_code"      property="paymentCurrencyCode"/>
+    <result column="paid_at"                    property="paidAt"/>
+    <result column="shipping_method"            property="shippingMethod"/>
+    <result column="shipping_method_id"         property="shippingMethodId"/>
+    <result column="shipping_address_present"   property="shippingAddressPresent"/>
+    <result column="tracking_present"           property="trackingPresent"/>
+    <result column="subtotal_amount"            property="subtotalAmount"/>
+    <result column="shipping_amount"            property="shippingAmount"/>
+    <result column="grand_total_amount"         property="grandTotalAmount"/>
+    <result column="currency_code"              property="currencyCode"/>
+    <result column="display_currency_code"      property="displayCurrencyCode"/>
+    <result column="total_count"                property="totalCount"/>
+    <result column="unique_count"               property="uniqueCount"/>
+    <result column="total_weight"               property="totalWeight"/>
+    <result column="is_invoiced"                property="invoiced"/>
+    <result column="is_filed"                   property="filed"/>
+    <result column="sent_drive_thru"            property="sentDriveThru"/>
+    <result column="require_insurance"          property="requireInsurance"/>
+    <result column="payload_hash"               property="payloadHash"/>
+    <result column="last_seen_at"               property="lastSeenAt"/>
+    <result column="created_at"                 property="createdAt"/>
+    <result column="updated_at"                 property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceOrder" id="marketplaceOrderResultMap">
-    <result column="marketplace_order_id"       property="marketplaceOrderId"/>
+    <id     column="marketplace_order_id"       property="marketplaceOrderId"/>
     <result column="last_sync_run_id"           property="lastSyncRunId"/>
     <result column="marketplace_code"           property="marketplaceCode"/>
     <result column="external_order_id"          property="externalOrderId"/>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderPayloadMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceOrderPayload" id="marketplaceOrderPayloadResultMap">
+    <result column="marketplace_order_payload_id"  property="marketplaceOrderPayloadId"/>
+    <result column="marketplace_order_id"          property="marketplaceOrderId"/>
+    <result column="marketplace_order_sync_run_id" property="marketplaceOrderSyncRunId"/>
+    <result column="payload_type_code"             property="payloadTypeCode"/>
+    <result column="payload_hash"                  property="payloadHash"/>
+    <result column="payload_json"                  property="payloadJson"/>
+    <result column="captured_at"                   property="capturedAt"/>
+    <result column="created_at"                    property="createdAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderPayloadMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceOrderPayload" id="marketplaceOrderPayloadResultMap">
-    <result column="marketplace_order_payload_id"  property="marketplaceOrderPayloadId"/>
+    <id     column="marketplace_order_payload_id"  property="marketplaceOrderPayloadId"/>
     <result column="marketplace_order_id"          property="marketplaceOrderId"/>
     <result column="marketplace_order_sync_run_id" property="marketplaceOrderSyncRunId"/>
     <result column="payload_type_code"             property="payloadTypeCode"/>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderSyncRunMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceOrderSyncRun" id="marketplaceOrderSyncRunResultMap">
-    <result column="marketplace_order_sync_run_id" property="marketplaceOrderSyncRunId"/>
+    <id     column="marketplace_order_sync_run_id" property="marketplaceOrderSyncRunId"/>
     <result column="marketplace_code"              property="marketplaceCode"/>
     <result column="sync_job_name"                property="syncJobName"/>
     <result column="sync_direction"               property="syncDirection"/>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncRunMapper.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderSyncRunMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceOrderSyncRun" id="marketplaceOrderSyncRunResultMap">
+    <result column="marketplace_order_sync_run_id" property="marketplaceOrderSyncRunId"/>
+    <result column="marketplace_code"              property="marketplaceCode"/>
+    <result column="sync_job_name"                property="syncJobName"/>
+    <result column="sync_direction"               property="syncDirection"/>
+    <result column="sync_status_code"             property="syncStatusCode"/>
+    <result column="started_at"                   property="startedAt"/>
+    <result column="completed_at"                 property="completedAt"/>
+    <result column="orders_discovered"            property="ordersDiscovered"/>
+    <result column="orders_fetched"               property="ordersFetched"/>
+    <result column="orders_failed"                property="ordersFailed"/>
+    <result column="error_message"                property="errorMessage"/>
+    <result column="created_at"                   property="createdAt"/>
+    <result column="updated_at"                   property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderTransactionLinkMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceOrderTransactionLink" id="marketplaceOrderTransactionLinkResultMap">
+    <result column="marketplace_order_transaction_link_id" property="marketplaceOrderTransactionLinkId"/>
+    <result column="marketplace_order_id"                  property="marketplaceOrderId"/>
+    <result column="transaction_id"                        property="transactionId"/>
+    <result column="marketplace_order_item_id"             property="marketplaceOrderItemId"/>
+    <result column="transaction_item_id"                   property="transactionItemId"/>
+    <result column="link_type_code"                        property="linkTypeCode"/>
+    <result column="link_status_code"                      property="linkStatusCode"/>
+    <result column="linked_at"                             property="linkedAt"/>
+    <result column="unlinked_at"                           property="unlinkedAt"/>
+    <result column="created_at"                            property="createdAt"/>
+    <result column="updated_at"                            property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceOrderTransactionLinkMapper">
   <resultMap type="io.legohunter.data.dto.MarketplaceOrderTransactionLink" id="marketplaceOrderTransactionLinkResultMap">
-    <result column="marketplace_order_transaction_link_id" property="marketplaceOrderTransactionLinkId"/>
+    <id     column="marketplace_order_transaction_link_id" property="marketplaceOrderTransactionLinkId"/>
     <result column="marketplace_order_id"                  property="marketplaceOrderId"/>
     <result column="transaction_id"                        property="transactionId"/>
     <result column="marketplace_order_item_id"             property="marketplaceOrderItemId"/>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
@@ -1,0 +1,292 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceOrder;
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import io.legohunter.data.dto.MarketplaceOrderPayload;
+import io.legohunter.data.dto.MarketplaceOrderSyncRun;
+import io.legohunter.data.dto.MarketplaceOrderTransactionLink;
+import io.legohunter.data.dto.TransactionItem;
+import io.legohunter.data.dto.Transactions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
+    private static final ZonedDateTime STARTED_AT = ZonedDateTime.parse("2026-06-01T12:00:00Z");
+    private static final ZonedDateTime ORDERED_AT = ZonedDateTime.parse("2026-06-01T13:00:00Z");
+
+    @Autowired MarketplaceOrderSyncRunMapper marketplaceOrderSyncRunMapper;
+    @Autowired MarketplaceOrderMapper marketplaceOrderMapper;
+    @Autowired MarketplaceOrderItemMapper marketplaceOrderItemMapper;
+    @Autowired MarketplaceOrderPayloadMapper marketplaceOrderPayloadMapper;
+    @Autowired MarketplaceOrderTransactionLinkMapper marketplaceOrderTransactionLinkMapper;
+
+    @Test
+    void marketplaceOrderSyncRunSupportsCrudAndUpsert() {
+        MarketplaceOrderSyncRun syncRun = marketplaceOrderSyncRun();
+
+        marketplaceOrderSyncRunMapper.insert(syncRun);
+        syncRun.setSyncStatusCode("SUCCESS");
+        syncRun.setCompletedAt(STARTED_AT.plusMinutes(5));
+        assertThat(marketplaceOrderSyncRunMapper.update(syncRun)).isOne();
+
+        assertThat(marketplaceOrderSyncRunMapper.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId()))
+                .hasValueSatisfying(found -> assertThat(found.getSyncStatusCode()).isEqualTo("SUCCESS"));
+        assertThat(marketplaceOrderSyncRunMapper.findAll()).hasSize(1);
+
+        syncRun.setOrdersFetched(7);
+        marketplaceOrderSyncRunMapper.upsert(syncRun);
+        assertThat(marketplaceOrderSyncRunMapper.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId()))
+                .hasValueSatisfying(found -> assertThat(found.getOrdersFetched()).isEqualTo(7));
+
+        assertThat(marketplaceOrderSyncRunMapper.delete(syncRun.getMarketplaceOrderSyncRunId())).isOne();
+        assertThat(marketplaceOrderSyncRunMapper.findByMarketplaceOrderSyncRunId(syncRun.getMarketplaceOrderSyncRunId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderSupportsCrudUniqueLookupAndUpsert() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = marketplaceOrder(syncRun.getMarketplaceOrderSyncRunId(), "BL-1001");
+
+        marketplaceOrderMapper.insert(order);
+        order.setExternalStatusCode("PAID");
+        order.setGrandTotalAmount(new BigDecimal("19.99"));
+        assertThat(marketplaceOrderMapper.update(order)).isOne();
+
+        assertThat(marketplaceOrderMapper.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalStatusCode()).isEqualTo("PAID"));
+        assertThat(marketplaceOrderMapper.findByMarketplaceCodeAndExternalOrderId("BRICKLINK", "BL-1001")).isPresent();
+        assertThat(marketplaceOrderMapper.findAll()).hasSize(1);
+
+        MarketplaceOrder naturalKeyOrder = marketplaceOrder(syncRun.getMarketplaceOrderSyncRunId(), "BL-1001");
+        naturalKeyOrder.setExternalStatusCode("UPDATED");
+        marketplaceOrderMapper.upsert(naturalKeyOrder);
+        assertThat(marketplaceOrderMapper.findByMarketplaceCodeAndExternalOrderId("BRICKLINK", "BL-1001"))
+                .hasValueSatisfying(found -> assertThat(found.getExternalStatusCode()).isEqualTo("UPDATED"));
+
+        assertThat(marketplaceOrderMapper.delete(order.getMarketplaceOrderId())).isOne();
+        assertThat(marketplaceOrderMapper.findByMarketplaceOrderId(order.getMarketplaceOrderId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderItemSupportsCrudAndUpsert() {
+        MarketplaceOrder order = insertedOrder("BL-ITEM-1");
+        MarketplaceOrderItem item = marketplaceOrderItem(order.getMarketplaceOrderId());
+
+        marketplaceOrderItemMapper.insert(item);
+        item.setQuantity(3);
+        item.setRemarks("Updated remarks");
+        item.setDescription("Updated description");
+        assertThat(marketplaceOrderItemMapper.update(item)).isOne();
+
+        assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getQuantity()).isEqualTo(3);
+                    assertThat(found.getRemarks()).isEqualTo("Updated remarks");
+                    assertThat(found.getDescription()).isEqualTo("Updated description");
+                });
+        assertThat(marketplaceOrderItemMapper.findAll()).hasSize(1);
+
+        item.setQuantity(5);
+        marketplaceOrderItemMapper.upsert(item);
+        assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
+                .hasValueSatisfying(found -> assertThat(found.getQuantity()).isEqualTo(5));
+
+        assertThat(marketplaceOrderItemMapper.delete(item.getMarketplaceOrderItemId())).isOne();
+        assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderPayloadSupportsCrudAndUpsert() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), "BL-PAYLOAD-1");
+        MarketplaceOrderPayload payload = marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId());
+
+        marketplaceOrderPayloadMapper.insert(payload);
+        payload.setPayloadHash("hash-updated");
+        payload.setPayloadJson("{\"status\":\"updated\"}");
+        assertThat(marketplaceOrderPayloadMapper.update(payload)).isOne();
+
+        assertThat(marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId()))
+                .hasValueSatisfying(found -> assertThat(found.getPayloadHash()).isEqualTo("hash-updated"));
+        assertThat(marketplaceOrderPayloadMapper.findAll()).hasSize(1);
+
+        payload.setPayloadTypeCode("ORDER_ITEMS_RESPONSE");
+        marketplaceOrderPayloadMapper.upsert(payload);
+        assertThat(marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId()))
+                .hasValueSatisfying(found -> assertThat(found.getPayloadTypeCode()).isEqualTo("ORDER_ITEMS_RESPONSE"));
+
+        assertThat(marketplaceOrderPayloadMapper.delete(payload.getMarketplaceOrderPayloadId())).isOne();
+        assertThat(marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderTransactionLinkSupportsCrudAndUpsert() {
+        MarketplaceOrder order = insertedOrder("BL-LINK-1");
+        MarketplaceOrderItem orderItem = insertedOrderItem(order.getMarketplaceOrderId());
+        TransactionItem transactionItem = insertedTransactionItem();
+        MarketplaceOrderTransactionLink link = marketplaceOrderTransactionLink(
+                order.getMarketplaceOrderId(),
+                transactionItem.getTransactionId(),
+                orderItem.getMarketplaceOrderItemId(),
+                transactionItem.getTransactionItemId()
+        );
+
+        marketplaceOrderTransactionLinkMapper.insert(link);
+        link.setLinkStatusCode("UNLINKED");
+        link.setUnlinkedAt(STARTED_AT.plusDays(1));
+        assertThat(marketplaceOrderTransactionLinkMapper.update(link)).isOne();
+
+        assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
+                .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("UNLINKED"));
+        assertThat(marketplaceOrderTransactionLinkMapper.findAll()).hasSize(1);
+
+        link.setLinkStatusCode("ACTIVE");
+        link.setUnlinkedAt(null);
+        marketplaceOrderTransactionLinkMapper.upsert(link);
+        assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
+                .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("ACTIVE"));
+
+        assertThat(marketplaceOrderTransactionLinkMapper.delete(link.getMarketplaceOrderTransactionLinkId())).isOne();
+        assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId())).isEmpty();
+    }
+
+    private MarketplaceOrderSyncRun insertedSyncRun() {
+        MarketplaceOrderSyncRun syncRun = marketplaceOrderSyncRun();
+        marketplaceOrderSyncRunMapper.insert(syncRun);
+        return syncRun;
+    }
+
+    private MarketplaceOrder insertedOrder(String externalOrderId) {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        return insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), externalOrderId);
+    }
+
+    private MarketplaceOrder insertedOrder(Integer syncRunId, String externalOrderId) {
+        MarketplaceOrder order = marketplaceOrder(syncRunId, externalOrderId);
+        marketplaceOrderMapper.insert(order);
+        return order;
+    }
+
+    private MarketplaceOrderItem insertedOrderItem(Integer marketplaceOrderId) {
+        MarketplaceOrderItem orderItem = marketplaceOrderItem(marketplaceOrderId);
+        marketplaceOrderItemMapper.insert(orderItem);
+        return orderItem;
+    }
+
+    private TransactionItem insertedTransactionItem() {
+        Transactions transaction = insertTransaction();
+        insertTransactionType();
+        TransactionItem transactionItem = TransactionItem.builder()
+                .transactionId(transaction.getTransactionId())
+                .transactionTypeCode("BUY")
+                .notes("Transaction item")
+                .build();
+        transactionItemMapper.insert(transactionItem);
+        return transactionItem;
+    }
+
+    private MarketplaceOrderSyncRun marketplaceOrderSyncRun() {
+        return MarketplaceOrderSyncRun.builder()
+                .marketplaceCode("BRICKLINK")
+                .syncJobName("bricklink-order-sync")
+                .syncDirection("IN")
+                .syncStatusCode("STARTED")
+                .startedAt(STARTED_AT)
+                .ordersDiscovered(1)
+                .ordersFetched(0)
+                .ordersFailed(0)
+                .build();
+    }
+
+    private MarketplaceOrder marketplaceOrder(Integer syncRunId, String externalOrderId) {
+        return MarketplaceOrder.builder()
+                .lastSyncRunId(syncRunId)
+                .marketplaceCode("BRICKLINK")
+                .externalOrderId(externalOrderId)
+                .orderDirection("IN")
+                .externalStatusCode("PENDING")
+                .orderedAt(ORDERED_AT)
+                .statusChangedAt(ORDERED_AT.plusHours(1))
+                .buyerDisplayName("Buyer One")
+                .buyerEmail("buyer@example.com")
+                .paymentStatusCode("PENDING")
+                .paymentMethod("PayPal")
+                .paymentCurrencyCode("USD")
+                .paidAt(ORDERED_AT.plusHours(2))
+                .shippingMethod("Request for invoice")
+                .shippingMethodId("1")
+                .shippingAddressPresent(true)
+                .trackingPresent(false)
+                .subtotalAmount(new BigDecimal("12.34"))
+                .shippingAmount(new BigDecimal("6.42"))
+                .grandTotalAmount(new BigDecimal("18.76"))
+                .currencyCode("USD")
+                .displayCurrencyCode("USD")
+                .totalCount(2)
+                .uniqueCount(1)
+                .totalWeight(new BigDecimal("1.250"))
+                .invoiced(false)
+                .filed(false)
+                .sentDriveThru(false)
+                .requireInsurance(false)
+                .payloadHash("order-hash")
+                .lastSeenAt(ORDERED_AT.plusHours(3))
+                .build();
+    }
+
+    private MarketplaceOrderItem marketplaceOrderItem(Integer marketplaceOrderId) {
+        return MarketplaceOrderItem.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .externalOrderItemId("line-1")
+                .externalInventoryId("inventory-1")
+                .externalItemNo("3001")
+                .externalItemType("SET")
+                .colorId(5)
+                .colorName("Red")
+                .quantity(1)
+                .conditionCode("N")
+                .completenessCode("C")
+                .unitPrice(new BigDecimal("5.99"))
+                .finalUnitPrice(new BigDecimal("5.49"))
+                .currencyCode("USD")
+                .itemWeight(new BigDecimal("0.250"))
+                .remarks("Initial remarks")
+                .description("Initial description")
+                .payloadHash("item-hash")
+                .build();
+    }
+
+    private MarketplaceOrderPayload marketplaceOrderPayload(Integer marketplaceOrderId, Integer syncRunId) {
+        return MarketplaceOrderPayload.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .marketplaceOrderSyncRunId(syncRunId)
+                .payloadTypeCode("ORDER_RESPONSE")
+                .payloadHash("hash-initial")
+                .payloadJson("{\"status\":\"initial\"}")
+                .capturedAt(STARTED_AT.plusMinutes(1))
+                .build();
+    }
+
+    private MarketplaceOrderTransactionLink marketplaceOrderTransactionLink(
+            Integer marketplaceOrderId,
+            Long transactionId,
+            Integer marketplaceOrderItemId,
+            Long transactionItemId
+    ) {
+        return MarketplaceOrderTransactionLink.builder()
+                .marketplaceOrderId(marketplaceOrderId)
+                .transactionId(transactionId)
+                .marketplaceOrderItemId(marketplaceOrderItemId)
+                .transactionItemId(transactionItemId)
+                .linkTypeCode("FULFILLMENT")
+                .linkStatusCode("ACTIVE")
+                .linkedAt(STARTED_AT.plusHours(1))
+                .build();
+    }
+}

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -1,3 +1,8 @@
+DROP TABLE IF EXISTS marketplace_order_transaction_link;
+DROP TABLE IF EXISTS marketplace_order_payload;
+DROP TABLE IF EXISTS marketplace_order_item;
+DROP TABLE IF EXISTS marketplace_order;
+DROP TABLE IF EXISTS marketplace_order_sync_run;
 DROP TABLE IF EXISTS ebay_listing_item_specific;
 DROP TABLE IF EXISTS ebay_marketplace_listing;
 DROP TABLE IF EXISTS bricklink_marketplace_listing;
@@ -210,6 +215,110 @@ CREATE TABLE ebay_listing_item_specific (
     PRIMARY KEY (marketplace_listing_id, name, `value`)
 );
 
+CREATE TABLE marketplace_order_sync_run (
+    marketplace_order_sync_run_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_code VARCHAR(30) NOT NULL,
+    sync_job_name VARCHAR(100),
+    sync_direction VARCHAR(20) NOT NULL,
+    sync_status_code VARCHAR(30) NOT NULL,
+    started_at TIMESTAMP NOT NULL,
+    completed_at TIMESTAMP,
+    orders_discovered INT NOT NULL DEFAULT 0,
+    orders_fetched INT NOT NULL DEFAULT 0,
+    orders_failed INT NOT NULL DEFAULT 0,
+    error_message CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order (
+    marketplace_order_id INT AUTO_INCREMENT PRIMARY KEY,
+    last_sync_run_id INT,
+    marketplace_code VARCHAR(30) NOT NULL,
+    external_order_id VARCHAR(100) NOT NULL,
+    order_direction VARCHAR(20) NOT NULL,
+    external_status_code VARCHAR(50) NOT NULL,
+    ordered_at TIMESTAMP,
+    status_changed_at TIMESTAMP,
+    buyer_display_name VARCHAR(150),
+    buyer_email VARCHAR(255),
+    payment_status_code VARCHAR(50),
+    payment_method VARCHAR(100),
+    payment_currency_code CHAR(3),
+    paid_at TIMESTAMP,
+    shipping_method VARCHAR(150),
+    shipping_method_id VARCHAR(100),
+    shipping_address_present BOOLEAN DEFAULT FALSE,
+    tracking_present BOOLEAN DEFAULT FALSE,
+    subtotal_amount DECIMAL(10,2),
+    shipping_amount DECIMAL(10,2),
+    grand_total_amount DECIMAL(10,2),
+    currency_code CHAR(3),
+    display_currency_code CHAR(3),
+    total_count INT,
+    unique_count INT,
+    total_weight DECIMAL(10,3),
+    is_invoiced BOOLEAN,
+    is_filed BOOLEAN,
+    sent_drive_thru BOOLEAN,
+    require_insurance BOOLEAN,
+    payload_hash VARCHAR(64),
+    last_seen_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_marketplace_order_source_order UNIQUE (marketplace_code, external_order_id)
+);
+
+CREATE TABLE marketplace_order_item (
+    marketplace_order_item_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    marketplace_listing_id INT,
+    item_inventory_id INT,
+    external_order_item_id VARCHAR(100),
+    external_inventory_id VARCHAR(100),
+    external_item_no VARCHAR(100),
+    external_item_type VARCHAR(30),
+    color_id INT,
+    color_name VARCHAR(100),
+    quantity INT NOT NULL DEFAULT 0,
+    condition_code VARCHAR(10),
+    completeness_code VARCHAR(10),
+    unit_price DECIMAL(10,2),
+    final_unit_price DECIMAL(10,2),
+    currency_code CHAR(3),
+    item_weight DECIMAL(10,3),
+    remarks CLOB,
+    description CLOB,
+    payload_hash VARCHAR(64),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order_payload (
+    marketplace_order_payload_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    marketplace_order_sync_run_id INT,
+    payload_type_code VARCHAR(50) NOT NULL,
+    payload_hash VARCHAR(64),
+    payload_json CLOB,
+    captured_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE marketplace_order_transaction_link (
+    marketplace_order_transaction_link_id INT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_order_id INT NOT NULL,
+    transaction_id BIGINT NOT NULL,
+    marketplace_order_item_id INT,
+    transaction_item_id BIGINT,
+    link_type_code VARCHAR(30) NOT NULL,
+    link_status_code VARCHAR(30) NOT NULL,
+    linked_at TIMESTAMP NOT NULL,
+    unlinked_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE inventory_index (
     box_id INT NOT NULL,
     box_index INT NOT NULL,
@@ -302,6 +411,38 @@ CREATE INDEX idx_marketplace_listing_inventory
     ON marketplace_listing (item_inventory_id);
 CREATE INDEX idx_marketplace_listing_catalog_item
     ON marketplace_listing (external_catalog_item_id);
+CREATE INDEX idx_marketplace_order_sync_run_marketplace_status
+    ON marketplace_order_sync_run (marketplace_code, sync_status_code);
+CREATE INDEX idx_marketplace_order_sync_run_started_at
+    ON marketplace_order_sync_run (started_at);
+CREATE INDEX idx_marketplace_order_status
+    ON marketplace_order (marketplace_code, external_status_code);
+CREATE INDEX idx_marketplace_order_last_sync_run
+    ON marketplace_order (last_sync_run_id);
+CREATE INDEX idx_marketplace_order_item_order
+    ON marketplace_order_item (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_item_listing
+    ON marketplace_order_item (marketplace_listing_id);
+CREATE INDEX idx_marketplace_order_item_inventory
+    ON marketplace_order_item (item_inventory_id);
+CREATE INDEX idx_marketplace_order_item_external_inventory
+    ON marketplace_order_item (external_inventory_id);
+CREATE INDEX idx_marketplace_order_payload_order
+    ON marketplace_order_payload (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_payload_sync_run
+    ON marketplace_order_payload (marketplace_order_sync_run_id);
+CREATE INDEX idx_marketplace_order_payload_type_hash
+    ON marketplace_order_payload (payload_type_code, payload_hash);
+CREATE INDEX idx_marketplace_order_transaction_link_order
+    ON marketplace_order_transaction_link (marketplace_order_id);
+CREATE INDEX idx_marketplace_order_transaction_link_transaction
+    ON marketplace_order_transaction_link (transaction_id);
+CREATE INDEX idx_marketplace_order_transaction_link_order_item
+    ON marketplace_order_transaction_link (marketplace_order_item_id);
+CREATE INDEX idx_marketplace_order_transaction_link_transaction_item
+    ON marketplace_order_transaction_link (transaction_item_id);
+CREATE INDEX idx_marketplace_order_transaction_link_type_status
+    ON marketplace_order_transaction_link (link_type_code, link_status_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -447,6 +588,36 @@ ALTER TABLE ebay_listing_item_specific
     FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
+ALTER TABLE marketplace_order
+    ADD CONSTRAINT fk_marketplace_order_sync_run1
+    FOREIGN KEY (last_sync_run_id) REFERENCES marketplace_order_sync_run (marketplace_order_sync_run_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_item
+    ADD CONSTRAINT fk_marketplace_order_item_item_inventory1
+    FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_payload
+    ADD CONSTRAINT fk_marketplace_order_payload_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_payload
+    ADD CONSTRAINT fk_marketplace_order_payload_sync_run1
+    FOREIGN KEY (marketplace_order_sync_run_id) REFERENCES marketplace_order_sync_run (marketplace_order_sync_run_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
 ALTER TABLE item_inventory_photo
     ADD CONSTRAINT fk_item_inventory_photo_item_inventory1
     FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
@@ -510,6 +681,26 @@ ALTER TABLE transaction_item
 ALTER TABLE transaction_item
     ADD CONSTRAINT fk_transaction_item_item_inventory1
     FOREIGN KEY (item_inventory_id) REFERENCES item_inventory (item_inventory_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_order1
+    FOREIGN KEY (marketplace_order_id) REFERENCES marketplace_order (marketplace_order_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_transaction1
+    FOREIGN KEY (transaction_id) REFERENCES transactions (transaction_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_order_item1
+    FOREIGN KEY (marketplace_order_item_id) REFERENCES marketplace_order_item (marketplace_order_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE marketplace_order_transaction_link
+    ADD CONSTRAINT fk_marketplace_order_transaction_link_transaction_item1
+    FOREIGN KEY (transaction_item_id) REFERENCES transaction_item (transaction_item_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE transaction_cost


### PR DESCRIPTION
## Summary
- Add DTOs for marketplace order sync runs, orders, order items, payload audit records, and transaction links.
- Add one MyBatis mapper interface and XML result map per new marketplace sync table with findAll, primary-key lookup, unique-key order lookup, insert, update, delete, and native MySQL upsert methods.
- Add DAO wrappers exposing the corresponding mapper methods without introducing workflow-specific marketplace sync queries.
- Extend both MyBatis and DAO H2 schemas with the new marketplace sync tables, indexes, unique constraints, and foreign keys.
- Add integration tests covering all new mapper and DAO methods.

## Verification
- mvn test
- mvn clean install