### PR TITLE
Add marketplace order item reconciliation DAO support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderItemDao.java
@@ -21,6 +21,14 @@ public class MarketplaceOrderItemDao {
         return marketplaceOrderItemMapper.findByMarketplaceOrderItemId(marketplaceOrderItemId);
     }
 
+    public Set<MarketplaceOrderItem> findByMarketplaceOrderId(Integer marketplaceOrderId) {
+        return marketplaceOrderItemMapper.findByMarketplaceOrderId(marketplaceOrderId);
+    }
+
+    public Set<MarketplaceOrderItem> findByMarketplaceOrderIdAndExternalInventoryId(Integer marketplaceOrderId, String externalInventoryId) {
+        return marketplaceOrderItemMapper.findByMarketplaceOrderIdAndExternalInventoryId(marketplaceOrderId, externalInventoryId);
+    }
+
     public MarketplaceOrderItem insert(MarketplaceOrderItem marketplaceOrderItem) {
         marketplaceOrderItemMapper.insert(marketplaceOrderItem);
         return marketplaceOrderItem;
@@ -32,6 +40,10 @@ public class MarketplaceOrderItemDao {
 
     public int delete(Integer marketplaceOrderItemId) {
         return marketplaceOrderItemMapper.delete(marketplaceOrderItemId);
+    }
+
+    public int deleteByMarketplaceOrderId(Integer marketplaceOrderId) {
+        return marketplaceOrderItemMapper.deleteByMarketplaceOrderId(marketplaceOrderId);
     }
 
     public MarketplaceOrderItem upsert(MarketplaceOrderItem marketplaceOrderItem) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
@@ -104,6 +104,14 @@ class MarketplaceOrderSyncDaoTest {
                     assertThat(found.getRemarks()).isEqualTo("DAO updated remarks");
                     assertThat(found.getDescription()).isEqualTo("DAO updated description");
                 });
+        assertThat(marketplaceOrderItemDao.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .extracting(MarketplaceOrderItem::getMarketplaceOrderItemId)
+                .containsExactly(item.getMarketplaceOrderItemId());
+        assertThat(marketplaceOrderItemDao.findByMarketplaceOrderIdAndExternalInventoryId(
+                order.getMarketplaceOrderId(),
+                "dao-inventory-1"
+        )).extracting(MarketplaceOrderItem::getMarketplaceOrderItemId)
+                .containsExactly(item.getMarketplaceOrderItemId());
         assertThat(marketplaceOrderItemDao.findAll()).hasSize(1);
 
         item.setQuantity(6);
@@ -111,7 +119,7 @@ class MarketplaceOrderSyncDaoTest {
         assertThat(marketplaceOrderItemDao.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
                 .hasValueSatisfying(found -> assertThat(found.getQuantity()).isEqualTo(6));
 
-        assertThat(marketplaceOrderItemDao.delete(item.getMarketplaceOrderItemId())).isOne();
+        assertThat(marketplaceOrderItemDao.deleteByMarketplaceOrderId(order.getMarketplaceOrderId())).isOne();
         assertThat(marketplaceOrderItemDao.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId())).isEmpty();
     }
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderItemMapper.java
@@ -4,6 +4,7 @@ import io.legohunter.data.dto.MarketplaceOrderItem;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
@@ -44,6 +45,20 @@ public interface MarketplaceOrderItemMapper {
     @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_item WHERE marketplace_order_item_id = #{marketplaceOrderItemId}")
     @ResultMap("marketplaceOrderItemResultMap")
     Optional<MarketplaceOrderItem> findByMarketplaceOrderItemId(Integer marketplaceOrderItemId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_item WHERE marketplace_order_id = #{marketplaceOrderId}")
+    @ResultMap("marketplaceOrderItemResultMap")
+    Set<MarketplaceOrderItem> findByMarketplaceOrderId(Integer marketplaceOrderId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM marketplace_order_item
+            WHERE marketplace_order_id = #{marketplaceOrderId}
+              AND external_inventory_id = #{externalInventoryId}
+            """)
+    @ResultMap("marketplaceOrderItemResultMap")
+    Set<MarketplaceOrderItem> findByMarketplaceOrderIdAndExternalInventoryId(
+            @Param("marketplaceOrderId") Integer marketplaceOrderId,
+            @Param("externalInventoryId") String externalInventoryId);
 
     @Insert("""
             INSERT INTO marketplace_order_item (
@@ -125,6 +140,9 @@ public interface MarketplaceOrderItemMapper {
 
     @Delete("DELETE FROM marketplace_order_item WHERE marketplace_order_item_id = #{marketplaceOrderItemId}")
     int delete(Integer marketplaceOrderItemId);
+
+    @Delete("DELETE FROM marketplace_order_item WHERE marketplace_order_id = #{marketplaceOrderId}")
+    int deleteByMarketplaceOrderId(Integer marketplaceOrderId);
 
     @Insert("""
             INSERT INTO marketplace_order_item (

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
@@ -90,6 +90,14 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
                     assertThat(found.getRemarks()).isEqualTo("Updated remarks");
                     assertThat(found.getDescription()).isEqualTo("Updated description");
                 });
+        assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .extracting(MarketplaceOrderItem::getMarketplaceOrderItemId)
+                .containsExactly(item.getMarketplaceOrderItemId());
+        assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderIdAndExternalInventoryId(
+                order.getMarketplaceOrderId(),
+                "inventory-1"
+        )).extracting(MarketplaceOrderItem::getMarketplaceOrderItemId)
+                .containsExactly(item.getMarketplaceOrderItemId());
         assertThat(marketplaceOrderItemMapper.findAll()).hasSize(1);
 
         item.setQuantity(5);
@@ -97,7 +105,7 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
         assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId()))
                 .hasValueSatisfying(found -> assertThat(found.getQuantity()).isEqualTo(5));
 
-        assertThat(marketplaceOrderItemMapper.delete(item.getMarketplaceOrderItemId())).isOne();
+        assertThat(marketplaceOrderItemMapper.deleteByMarketplaceOrderId(order.getMarketplaceOrderId())).isOne();
         assertThat(marketplaceOrderItemMapper.findByMarketplaceOrderItemId(item.getMarketplaceOrderItemId())).isEmpty();
     }
 


### PR DESCRIPTION
## Summary
- Adds marketplace_order_item mapper and DAO lookup support by marketplace_order_id.
- Adds lookup support by marketplace_order_id plus external_inventory_id for idempotent item reconciliation.
- Adds delete-by-marketplace-order support for stale item cleanup during open-order sync reconciliation.
- Extends mapper and DAO tests for the new methods.

## Validation
- mvn clean install passed locally during implementation.
- Targeted marketplace mapper/DAO tests passed locally during implementation.