### PR TITLE
Add fulfillment marketplace order read support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderDao.java
@@ -5,6 +5,10 @@ import io.legohunter.data.mybatis.mapper.MarketplaceOrderMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -23,6 +27,22 @@ public class MarketplaceOrderDao {
 
     public Optional<MarketplaceOrder> findByMarketplaceCodeAndExternalOrderId(String marketplaceCode, String externalOrderId) {
         return marketplaceOrderMapper.findByMarketplaceCodeAndExternalOrderId(marketplaceCode, externalOrderId);
+    }
+
+    public Set<MarketplaceOrder> findFulfillmentCandidates(String marketplaceCode, Collection<String> externalStatusCodes, int limit) {
+        int effectiveLimit = Math.max(limit, 1);
+        Map<Integer, MarketplaceOrder> ordersById = new LinkedHashMap<>();
+        for (String externalStatusCode : externalStatusCodes) {
+            if (externalStatusCode == null || externalStatusCode.isBlank() || ordersById.size() >= effectiveLimit) {
+                continue;
+            }
+            marketplaceOrderMapper.findFulfillmentCandidatesByStatus(
+                    marketplaceCode,
+                    externalStatusCode.trim(),
+                    effectiveLimit - ordersById.size()
+            ).forEach(order -> ordersById.putIfAbsent(order.getMarketplaceOrderId(), order));
+        }
+        return new LinkedHashSet<>(ordersById.values());
     }
 
     public MarketplaceOrder insert(MarketplaceOrder marketplaceOrder) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderPayloadDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderPayloadDao.java
@@ -21,6 +21,13 @@ public class MarketplaceOrderPayloadDao {
         return marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(marketplaceOrderPayloadId);
     }
 
+    public Optional<MarketplaceOrderPayload> findLatestByMarketplaceOrderIdAndPayloadTypeCode(
+            Integer marketplaceOrderId,
+            String payloadTypeCode
+    ) {
+        return marketplaceOrderPayloadMapper.findLatestByMarketplaceOrderIdAndPayloadTypeCode(marketplaceOrderId, payloadTypeCode);
+    }
+
     public MarketplaceOrderPayload insert(MarketplaceOrderPayload marketplaceOrderPayload) {
         marketplaceOrderPayloadMapper.insert(marketplaceOrderPayload);
         return marketplaceOrderPayload;

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -90,6 +91,22 @@ class MarketplaceOrderSyncDaoTest {
     }
 
     @Test
+    void marketplaceOrderDaoFindsFulfillmentCandidatesAcrossStatuses() {
+        MarketplaceOrder pending = insertedOrder("DAO-BL-CANDIDATE-1");
+        marketplaceOrderItemDao.insert(marketplaceOrderItem(pending.getMarketplaceOrderId()));
+        MarketplaceOrder ready = insertedOrder("DAO-BL-CANDIDATE-2");
+        ready.setExternalStatusCode("READY");
+        marketplaceOrderDao.update(ready);
+        marketplaceOrderItemDao.insert(marketplaceOrderItem(ready.getMarketplaceOrderId()));
+        MarketplaceOrder withoutItems = insertedOrder("DAO-BL-CANDIDATE-3");
+
+        assertThat(marketplaceOrderDao.findFulfillmentCandidates("BRICKLINK", List.of("PENDING", "READY"), 10))
+                .extracting(MarketplaceOrder::getMarketplaceOrderId)
+                .containsExactly(pending.getMarketplaceOrderId(), ready.getMarketplaceOrderId());
+        assertThat(withoutItems.getMarketplaceOrderId()).isNotNull();
+    }
+
+    @Test
     void marketplaceOrderItemDaoExposesMapperMethods() {
         MarketplaceOrder order = insertedOrder("DAO-BL-ITEM-1");
         MarketplaceOrderItem item = marketplaceOrderItemDao.insert(marketplaceOrderItem(order.getMarketplaceOrderId()));
@@ -143,6 +160,24 @@ class MarketplaceOrderSyncDaoTest {
 
         assertThat(marketplaceOrderPayloadDao.delete(payload.getMarketplaceOrderPayloadId())).isOne();
         assertThat(marketplaceOrderPayloadDao.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderPayloadDaoFindsLatestByOrderAndType() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), "DAO-BL-PAYLOAD-LATEST-1");
+        MarketplaceOrderPayload older = marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId());
+        older.setPayloadJson("{\"dao\":\"older\"}");
+        marketplaceOrderPayloadDao.insert(older);
+        MarketplaceOrderPayload latest = marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId());
+        latest.setPayloadJson("{\"dao\":\"latest\"}");
+        latest.setCapturedAt(STARTED_AT.plusMinutes(2));
+        marketplaceOrderPayloadDao.insert(latest);
+
+        assertThat(marketplaceOrderPayloadDao.findLatestByMarketplaceOrderIdAndPayloadTypeCode(
+                order.getMarketplaceOrderId(),
+                "ORDER_RESPONSE"
+        )).hasValueSatisfying(found -> assertThat(found.getPayloadJson()).isEqualTo("{\"dao\":\"latest\"}"));
     }
 
     @Test

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
@@ -68,6 +68,24 @@ public interface MarketplaceOrderMapper {
             @Param("marketplaceCode") String marketplaceCode,
             @Param("externalOrderId") String externalOrderId);
 
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM marketplace_order mo
+            WHERE mo.marketplace_code = #{marketplaceCode}
+              AND mo.external_status_code = #{externalStatusCode}
+              AND EXISTS (
+                  SELECT 1
+                  FROM marketplace_order_item moi
+                  WHERE moi.marketplace_order_id = mo.marketplace_order_id
+              )
+            ORDER BY mo.ordered_at, mo.marketplace_order_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceOrderResultMap")
+    Set<MarketplaceOrder> findFulfillmentCandidatesByStatus(
+            @Param("marketplaceCode") String marketplaceCode,
+            @Param("externalStatusCode") String externalStatusCode,
+            @Param("limit") int limit);
+
     @Insert("""
             INSERT INTO marketplace_order (
                 last_sync_run_id,

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderPayloadMapper.java
@@ -4,6 +4,7 @@ import io.legohunter.data.dto.MarketplaceOrderPayload;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
@@ -30,6 +31,18 @@ public interface MarketplaceOrderPayloadMapper {
     @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_payload WHERE marketplace_order_payload_id = #{marketplaceOrderPayloadId}")
     @ResultMap("marketplaceOrderPayloadResultMap")
     Optional<MarketplaceOrderPayload> findByMarketplaceOrderPayloadId(Integer marketplaceOrderPayloadId);
+
+    @Select("SELECT " + ALL_COLUMNS + """
+            FROM marketplace_order_payload
+            WHERE marketplace_order_id = #{marketplaceOrderId}
+              AND payload_type_code = #{payloadTypeCode}
+            ORDER BY captured_at DESC, marketplace_order_payload_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("marketplaceOrderPayloadResultMap")
+    Optional<MarketplaceOrderPayload> findLatestByMarketplaceOrderIdAndPayloadTypeCode(
+            @Param("marketplaceOrderId") Integer marketplaceOrderId,
+            @Param("payloadTypeCode") String payloadTypeCode);
 
     @Insert("""
             INSERT INTO marketplace_order_payload (

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
@@ -74,6 +74,25 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void marketplaceOrderFindsFulfillmentCandidatesWithOrderItems() {
+        MarketplaceOrder candidate = insertedOrder("BL-CANDIDATE-1");
+        insertedOrderItem(candidate.getMarketplaceOrderId());
+        MarketplaceOrder withoutItems = insertedOrder("BL-CANDIDATE-2");
+        MarketplaceOrder shipped = insertedOrder("BL-CANDIDATE-3");
+        shipped.setExternalStatusCode("SHIPPED");
+        marketplaceOrderMapper.update(shipped);
+        insertedOrderItem(shipped.getMarketplaceOrderId());
+
+        assertThat(marketplaceOrderMapper.findFulfillmentCandidatesByStatus("BRICKLINK", "PENDING", 10))
+                .extracting(MarketplaceOrder::getMarketplaceOrderId)
+                .containsExactly(candidate.getMarketplaceOrderId());
+        assertThat(marketplaceOrderMapper.findFulfillmentCandidatesByStatus("BRICKLINK", "SHIPPED", 10))
+                .extracting(MarketplaceOrder::getMarketplaceOrderId)
+                .containsExactly(shipped.getMarketplaceOrderId());
+        assertThat(withoutItems.getMarketplaceOrderId()).isNotNull();
+    }
+
+    @Test
     void marketplaceOrderItemSupportsCrudAndUpsert() {
         MarketplaceOrder order = insertedOrder("BL-ITEM-1");
         MarketplaceOrderItem item = marketplaceOrderItem(order.getMarketplaceOrderId());
@@ -131,6 +150,28 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
 
         assertThat(marketplaceOrderPayloadMapper.delete(payload.getMarketplaceOrderPayloadId())).isOne();
         assertThat(marketplaceOrderPayloadMapper.findByMarketplaceOrderPayloadId(payload.getMarketplaceOrderPayloadId())).isEmpty();
+    }
+
+    @Test
+    void marketplaceOrderPayloadFindsLatestByOrderAndType() {
+        MarketplaceOrderSyncRun syncRun = insertedSyncRun();
+        MarketplaceOrder order = insertedOrder(syncRun.getMarketplaceOrderSyncRunId(), "BL-PAYLOAD-LATEST-1");
+        MarketplaceOrderPayload older = marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId());
+        older.setPayloadJson("{\"version\":\"older\"}");
+        marketplaceOrderPayloadMapper.insert(older);
+        MarketplaceOrderPayload latest = marketplaceOrderPayload(order.getMarketplaceOrderId(), syncRun.getMarketplaceOrderSyncRunId());
+        latest.setPayloadJson("{\"version\":\"latest\"}");
+        latest.setCapturedAt(STARTED_AT.plusMinutes(2));
+        marketplaceOrderPayloadMapper.insert(latest);
+
+        assertThat(marketplaceOrderPayloadMapper.findLatestByMarketplaceOrderIdAndPayloadTypeCode(
+                order.getMarketplaceOrderId(),
+                "ORDER_RESPONSE"
+        )).hasValueSatisfying(found -> assertThat(found.getPayloadJson()).isEqualTo("{\"version\":\"latest\"}"));
+        assertThat(marketplaceOrderPayloadMapper.findLatestByMarketplaceOrderIdAndPayloadTypeCode(
+                order.getMarketplaceOrderId(),
+                "ORDER_ITEMS_RESPONSE"
+        )).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Adds DAO/MyBatis read support for fulfillment candidate selection and latest marketplace order payload lookup. Includes mapper and DAO tests covering candidate filtering and latest payload selection. Verification: mvn clean install.