### PR TITLE
Add item inventory state and sale intent columns

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
@@ -8,6 +8,8 @@ import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -58,6 +60,36 @@ public class ItemInventoryDao {
     public ItemInventory update(ItemInventory itemInventory) {
         itemInventoryMapper.update(itemInventory);
         return findByItemInventoryId(itemInventory.getItemInventoryId()).orElseThrow();
+    }
+
+    public ItemInventory updateInventoryState(Integer itemInventoryId, String inventoryStateCode, ZonedDateTime inventoryStateChangedAt) {
+        ItemInventory existing = findByItemInventoryId(itemInventoryId).orElseThrow();
+        if (Objects.equals(existing.getInventoryStateCode(), inventoryStateCode)) {
+            return existing;
+        }
+
+        itemInventoryMapper.updateInventoryState(
+                itemInventoryId,
+                inventoryStateCode,
+                Objects.requireNonNullElseGet(inventoryStateChangedAt, () -> ZonedDateTime.now(ZoneOffset.UTC))
+        );
+        return findByItemInventoryId(itemInventoryId).orElseThrow();
+    }
+
+    public ItemInventory updateSaleIntent(Integer itemInventoryId, String saleIntentCode, ZonedDateTime saleIntentUpdatedAt, String saleIntentNote) {
+        ItemInventory existing = findByItemInventoryId(itemInventoryId).orElseThrow();
+        if (Objects.equals(existing.getSaleIntentCode(), saleIntentCode)
+                && Objects.equals(existing.getSaleIntentNote(), saleIntentNote)) {
+            return existing;
+        }
+
+        itemInventoryMapper.updateSaleIntent(
+                itemInventoryId,
+                saleIntentCode,
+                Objects.requireNonNullElseGet(saleIntentUpdatedAt, () -> ZonedDateTime.now(ZoneOffset.UTC)),
+                saleIntentNote
+        );
+        return findByItemInventoryId(itemInventoryId).orElseThrow();
     }
 
     public void delete(Integer itemInventoryId) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventorySaleIntentDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventorySaleIntentDao.java
@@ -1,0 +1,42 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ItemInventorySaleIntent;
+import io.legohunter.data.mybatis.mapper.ItemInventorySaleIntentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ItemInventorySaleIntentDao {
+    private final ItemInventorySaleIntentMapper itemInventorySaleIntentMapper;
+
+    public Set<ItemInventorySaleIntent> findAll() {
+        return itemInventorySaleIntentMapper.findAll();
+    }
+
+    public Optional<ItemInventorySaleIntent> findBySaleIntentCode(final String saleIntentCode) {
+        return itemInventorySaleIntentMapper.findBySaleIntentCode(saleIntentCode);
+    }
+
+    public ItemInventorySaleIntent insert(ItemInventorySaleIntent itemInventorySaleIntent) {
+        itemInventorySaleIntentMapper.insert(itemInventorySaleIntent);
+        return itemInventorySaleIntent;
+    }
+
+    public ItemInventorySaleIntent update(ItemInventorySaleIntent itemInventorySaleIntent) {
+        itemInventorySaleIntentMapper.update(itemInventorySaleIntent);
+        return findBySaleIntentCode(itemInventorySaleIntent.getSaleIntentCode()).orElseThrow();
+    }
+
+    public void delete(String saleIntentCode) {
+        itemInventorySaleIntentMapper.delete(saleIntentCode);
+    }
+
+    public ItemInventorySaleIntent upsert(ItemInventorySaleIntent itemInventorySaleIntent) {
+        itemInventorySaleIntentMapper.upsert(itemInventorySaleIntent);
+        return findBySaleIntentCode(itemInventorySaleIntent.getSaleIntentCode()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryStateDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryStateDao.java
@@ -1,0 +1,42 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ItemInventoryState;
+import io.legohunter.data.mybatis.mapper.ItemInventoryStateMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ItemInventoryStateDao {
+    private final ItemInventoryStateMapper itemInventoryStateMapper;
+
+    public Set<ItemInventoryState> findAll() {
+        return itemInventoryStateMapper.findAll();
+    }
+
+    public Optional<ItemInventoryState> findByInventoryStateCode(final String inventoryStateCode) {
+        return itemInventoryStateMapper.findByInventoryStateCode(inventoryStateCode);
+    }
+
+    public ItemInventoryState insert(ItemInventoryState itemInventoryState) {
+        itemInventoryStateMapper.insert(itemInventoryState);
+        return itemInventoryState;
+    }
+
+    public ItemInventoryState update(ItemInventoryState itemInventoryState) {
+        itemInventoryStateMapper.update(itemInventoryState);
+        return findByInventoryStateCode(itemInventoryState.getInventoryStateCode()).orElseThrow();
+    }
+
+    public void delete(String inventoryStateCode) {
+        itemInventoryStateMapper.delete(inventoryStateCode);
+    }
+
+    public ItemInventoryState upsert(ItemInventoryState itemInventoryState) {
+        itemInventoryStateMapper.upsert(itemInventoryState);
+        return findByInventoryStateCode(itemInventoryState.getInventoryStateCode()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -212,6 +212,17 @@ class CurrentDaoIntegrationTest {
         assertThat(itemInventoryDao.findByUuid("dao-inventory-1")).isPresent();
         assertThat(itemInventoryDao.findAll()).extracting(ItemInventory::getUuid).contains("dao-inventory-1");
         assertThat(itemInventoryDao.getPrimaryExternalCatalogItem(inventory)).isEmpty();
+        assertThat(itemInventoryDao.updateInventoryState(
+                inventory.getItemInventoryId(),
+                "RESERVED_FOR_ORDER",
+                ZonedDateTime.parse("2026-06-16T10:00:00Z")
+        ).getInventoryStateCode()).isEqualTo("RESERVED_FOR_ORDER");
+        assertThat(itemInventoryDao.updateSaleIntent(
+                inventory.getItemInventoryId(),
+                "KEEP",
+                ZonedDateTime.parse("2026-06-16T11:00:00Z"),
+                "Collection hold"
+        ).getSaleIntentNote()).isEqualTo("Collection hold");
 
         ItemInventoryExternalCatalogItem inventoryCatalogItem = ItemInventoryExternalCatalogItem.builder()
                 .itemInventoryId(inventory.getItemInventoryId())

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -14,6 +14,8 @@ import io.legohunter.data.dto.ExternalServiceCapability;
 import io.legohunter.data.dto.ExternalServiceType;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventorySaleIntent;
+import io.legohunter.data.dto.ItemInventoryState;
 import io.legohunter.data.dto.MarketplaceListing;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +49,8 @@ class CurrentDaoIntegrationTest {
     @Autowired ExternalCatalogItemCategoryDao externalCatalogItemCategoryDao;
     @Autowired ItemInventoryDao itemInventoryDao;
     @Autowired ItemInventoryExternalCatalogItemDao itemInventoryExternalCatalogItemDao;
+    @Autowired ItemInventorySaleIntentDao itemInventorySaleIntentDao;
+    @Autowired ItemInventoryStateDao itemInventoryStateDao;
     @Autowired MarketplaceListingDao marketplaceListingDao;
     @Autowired BricklinkMarketplaceListingDao bricklinkMarketplaceListingDao;
     @Autowired EbayMarketplaceListingDao ebayMarketplaceListingDao;
@@ -61,6 +65,10 @@ class CurrentDaoIntegrationTest {
                 .contains("BRICKLINK", "EBAY", "FLICKR");
         assertThat(externalServiceCapabilityDao.findAll()).extracting(ExternalServiceCapability::getCapabilityCode)
                 .contains("CATALOG", "PRICE_GUIDE", "IMAGE_HOSTING");
+        assertThat(itemInventoryStateDao.findAll()).extracting(ItemInventoryState::getInventoryStateCode)
+                .contains("AVAILABLE", "RESERVED_FOR_ORDER", "SOLD", "REMOVED", "LOST");
+        assertThat(itemInventorySaleIntentDao.findAll()).extracting(ItemInventorySaleIntent::getSaleIntentCode)
+                .contains("SELLABLE", "KEEP", "UNDECIDED");
 
         ExternalServiceType serviceType = ExternalServiceType.builder()
                 .externalServiceTypeId(100)
@@ -102,6 +110,36 @@ class CurrentDaoIntegrationTest {
         externalServiceCapabilityDao.delete(100, "UNIT_TEST_CAPABILITY");
         externalServiceDao.delete(100);
         externalServiceTypeDao.delete(100);
+
+        ItemInventoryState state = ItemInventoryState.builder()
+                .inventoryStateCode("UNIT_TEST_STATE")
+                .inventoryStateName("Unit Test State")
+                .inventoryStateDescription("Unit test state")
+                .active(true)
+                .sortOrder(100)
+                .build();
+        assertThat(itemInventoryStateDao.insert(state)).isSameAs(state);
+        state.setInventoryStateDescription("Updated");
+        assertThat(itemInventoryStateDao.update(state).getInventoryStateDescription()).isEqualTo("Updated");
+        state.setInventoryStateDescription("Upserted");
+        assertThat(itemInventoryStateDao.upsert(state).getInventoryStateDescription()).isEqualTo("Upserted");
+        assertThat(itemInventoryStateDao.findByInventoryStateCode("UNIT_TEST_STATE")).isPresent();
+        itemInventoryStateDao.delete("UNIT_TEST_STATE");
+
+        ItemInventorySaleIntent saleIntent = ItemInventorySaleIntent.builder()
+                .saleIntentCode("UNIT_TEST_INTENT")
+                .saleIntentName("Unit Test Intent")
+                .saleIntentDescription("Unit test intent")
+                .active(true)
+                .sortOrder(100)
+                .build();
+        assertThat(itemInventorySaleIntentDao.insert(saleIntent)).isSameAs(saleIntent);
+        saleIntent.setSaleIntentDescription("Updated");
+        assertThat(itemInventorySaleIntentDao.update(saleIntent).getSaleIntentDescription()).isEqualTo("Updated");
+        saleIntent.setSaleIntentDescription("Upserted");
+        assertThat(itemInventorySaleIntentDao.upsert(saleIntent).getSaleIntentDescription()).isEqualTo("Upserted");
+        assertThat(itemInventorySaleIntentDao.findBySaleIntentCode("UNIT_TEST_INTENT")).isPresent();
+        itemInventorySaleIntentDao.delete("UNIT_TEST_INTENT");
     }
 
     @Test

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,5 +93,88 @@ class ItemInventoryDaoUnitTest {
         assertThat(itemInventoryDao.findMarketplaceListings(inventory)).containsExactly(marketplaceListing);
 
         verify(marketplaceListingDao).findByItemInventoryId(200);
+    }
+
+    @Test
+    void updateInventoryStateSkipsMapperUpdateWhenStateIsUnchanged() {
+        ItemInventory inventory = new ItemInventory();
+        inventory.setItemInventoryId(200);
+        inventory.setInventoryStateCode("AVAILABLE");
+        when(itemInventoryMapper.findByItemInventoryId(200)).thenReturn(Optional.of(inventory));
+
+        assertThat(itemInventoryDao.updateInventoryState(200, "AVAILABLE", ZonedDateTime.parse("2026-06-16T10:00:00Z")))
+                .isSameAs(inventory);
+
+        verify(itemInventoryMapper, never()).updateInventoryState(any(), any(), any());
+    }
+
+    @Test
+    void updateInventoryStateUpdatesMapperWhenStateChanges() {
+        ItemInventory existing = new ItemInventory();
+        existing.setItemInventoryId(200);
+        existing.setInventoryStateCode("AVAILABLE");
+        ItemInventory updated = new ItemInventory();
+        updated.setItemInventoryId(200);
+        updated.setInventoryStateCode("RESERVED_FOR_ORDER");
+        ZonedDateTime changedAt = ZonedDateTime.parse("2026-06-16T10:00:00Z");
+        when(itemInventoryMapper.findByItemInventoryId(200))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated));
+
+        assertThat(itemInventoryDao.updateInventoryState(200, "RESERVED_FOR_ORDER", changedAt))
+                .isSameAs(updated);
+
+        verify(itemInventoryMapper).updateInventoryState(200, "RESERVED_FOR_ORDER", changedAt);
+    }
+
+    @Test
+    void updateSaleIntentSkipsMapperUpdateWhenIntentAndNoteAreUnchanged() {
+        ItemInventory inventory = new ItemInventory();
+        inventory.setItemInventoryId(200);
+        inventory.setSaleIntentCode("KEEP");
+        inventory.setSaleIntentNote("Collection hold");
+        when(itemInventoryMapper.findByItemInventoryId(200)).thenReturn(Optional.of(inventory));
+
+        assertThat(itemInventoryDao.updateSaleIntent(200, "KEEP", ZonedDateTime.parse("2026-06-16T10:00:00Z"), "Collection hold"))
+                .isSameAs(inventory);
+
+        verify(itemInventoryMapper, never()).updateSaleIntent(any(), any(), any(), any());
+    }
+
+    @Test
+    void updateSaleIntentUpdatesMapperWhenIntentChanges() {
+        ItemInventory existing = new ItemInventory();
+        existing.setItemInventoryId(200);
+        existing.setSaleIntentCode("UNDECIDED");
+        ItemInventory updated = new ItemInventory();
+        updated.setItemInventoryId(200);
+        updated.setSaleIntentCode("KEEP");
+        updated.setSaleIntentNote("Collection hold");
+        ZonedDateTime updatedAt = ZonedDateTime.parse("2026-06-16T11:00:00Z");
+        when(itemInventoryMapper.findByItemInventoryId(200))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated));
+
+        assertThat(itemInventoryDao.updateSaleIntent(200, "KEEP", updatedAt, "Collection hold"))
+                .isSameAs(updated);
+
+        verify(itemInventoryMapper).updateSaleIntent(200, "KEEP", updatedAt, "Collection hold");
+    }
+
+    @Test
+    void updateSaleIntentSuppliesTimestampWhenIntentChangesWithoutOne() {
+        ItemInventory existing = new ItemInventory();
+        existing.setItemInventoryId(200);
+        existing.setSaleIntentCode("UNDECIDED");
+        ItemInventory updated = new ItemInventory();
+        updated.setItemInventoryId(200);
+        updated.setSaleIntentCode("KEEP");
+        when(itemInventoryMapper.findByItemInventoryId(200))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated));
+
+        itemInventoryDao.updateSaleIntent(200, "KEEP", null, null);
+
+        verify(itemInventoryMapper).updateSaleIntent(eq(200), eq("KEEP"), any(ZonedDateTime.class), eq(null));
     }
 }

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_lookup_data.sql
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_lookup_data.sql
@@ -25,6 +25,18 @@ INSERT INTO cost_type (cost_type_code, cost_type_name, cost_type_description) VA
     ('SHIPPING', 'Shipping', 'The cost of shipping an item or an entire order'),
     ('TAX', 'Tax', 'The sales tax amount added to an item or entire order');
 
+INSERT INTO item_inventory_state (inventory_state_code, inventory_state_name, inventory_state_description, active, sort_order) VALUES
+    ('AVAILABLE', 'Available', 'Owned item is available for normal inventory workflows and may be listed when sale intent allows it.', TRUE, 10),
+    ('RESERVED_FOR_ORDER', 'Reserved for Order', 'Owned item is temporarily reserved for an external marketplace order and should not be listed again.', TRUE, 20),
+    ('SOLD', 'Sold', 'Owned item has been sold and should not be listed.', TRUE, 30),
+    ('REMOVED', 'Removed', 'Owned item has been intentionally removed from the collection outside a marketplace sale.', TRUE, 40),
+    ('LOST', 'Lost', 'Owned item cannot currently be located and should not be listed.', TRUE, 50);
+
+INSERT INTO item_inventory_sale_intent (sale_intent_code, sale_intent_name, sale_intent_description, active, sort_order) VALUES
+    ('SELLABLE', 'Sellable', 'May be listed for sale when inventory state is AVAILABLE.', TRUE, 10),
+    ('KEEP', 'Keep', 'Personal collection item that should not be listed for sale.', TRUE, 20),
+    ('UNDECIDED', 'Undecided', 'Sale intent has not been classified; item should not be listed automatically.', TRUE, 30);
+
 INSERT INTO transaction_type (transaction_type_code, transaction_type_description, conversion_factor) VALUES
     ('A', 'Auction Purchase', 1),
     ('B', 'Built from Loose Pieces', 1),

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -29,6 +29,8 @@ DROP TABLE IF EXISTS category;
 DROP TABLE IF EXISTS external_service;
 DROP TABLE IF EXISTS external_service_type;
 DROP TABLE IF EXISTS item_inventory;
+DROP TABLE IF EXISTS item_inventory_sale_intent;
+DROP TABLE IF EXISTS item_inventory_state;
 DROP TABLE IF EXISTS inventory_index;
 DROP TABLE IF EXISTS item;
 DROP TABLE IF EXISTS carrier;
@@ -55,6 +57,22 @@ CREATE TABLE cost_type (
     cost_type_code VARCHAR(32) PRIMARY KEY,
     cost_type_name VARCHAR(255),
     cost_type_description VARCHAR(1024)
+);
+
+CREATE TABLE item_inventory_state (
+    inventory_state_code VARCHAR(30) PRIMARY KEY,
+    inventory_state_name VARCHAR(100) NOT NULL,
+    inventory_state_description VARCHAR(500),
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    sort_order INT
+);
+
+CREATE TABLE item_inventory_sale_intent (
+    sale_intent_code VARCHAR(30) PRIMARY KEY,
+    sale_intent_name VARCHAR(100) NOT NULL,
+    sale_intent_description VARCHAR(500),
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    sort_order INT
 );
 
 CREATE TABLE transaction_type (

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -156,7 +156,12 @@ CREATE TABLE item_inventory (
     box_condition_id INT,
     instructions_condition_id INT,
     sealed BOOLEAN,
-    built_once BOOLEAN
+    built_once BOOLEAN,
+    inventory_state_code VARCHAR(30) NOT NULL DEFAULT 'AVAILABLE',
+    inventory_state_changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sale_intent_code VARCHAR(30) NOT NULL DEFAULT 'UNDECIDED',
+    sale_intent_updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sale_intent_note VARCHAR(500)
 );
 
 CREATE TABLE item_inventory_external_catalog_item (

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventory.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventory.java
@@ -3,6 +3,7 @@ package io.legohunter.data.dto;
 import lombok.Data;
 
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 import java.util.Set;
 
 @Data
@@ -21,5 +22,10 @@ public class ItemInventory {
     private Integer instructionsConditionId;
     private Boolean sealed;
     private Boolean builtOnce;
+    private String inventoryStateCode;
+    private ZonedDateTime inventoryStateChangedAt;
+    private String saleIntentCode;
+    private ZonedDateTime saleIntentUpdatedAt;
+    private String saleIntentNote;
     private Set<ItemInventoryExternalCatalogItem> externalCatalogItems;
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySaleIntent.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySaleIntent.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ItemInventorySaleIntent {
+    private String saleIntentCode;
+    private String saleIntentName;
+    private String saleIntentDescription;
+    private Boolean active;
+    private Integer sortOrder;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventoryState.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventoryState.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ItemInventoryState {
+    private String inventoryStateCode;
+    private String inventoryStateName;
+    private String inventoryStateDescription;
+    private Boolean active;
+    private Integer sortOrder;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
@@ -9,6 +9,7 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
@@ -28,6 +29,11 @@ public interface ItemInventoryMapper {
             ii.instructions_condition_id,
             ii.sealed,
             ii.built_once,
+            ii.inventory_state_code,
+            ii.inventory_state_changed_at,
+            ii.sale_intent_code,
+            ii.sale_intent_updated_at,
+            ii.sale_intent_note,
             iieci.item_inventory_id AS iieci_item_inventory_id,
             iieci.external_catalog_item_id AS iieci_external_catalog_item_id,
             iieci.is_primary AS iieci_is_primary,
@@ -112,7 +118,12 @@ public interface ItemInventoryMapper {
                 box_condition_id,
                 instructions_condition_id,
                 sealed,
-                built_once
+                built_once,
+                inventory_state_code,
+                inventory_state_changed_at,
+                sale_intent_code,
+                sale_intent_updated_at,
+                sale_intent_note
             )
             VALUES (
                 #{uuid},
@@ -127,7 +138,12 @@ public interface ItemInventoryMapper {
                 #{boxConditionId},
                 #{instructionsConditionId},
                 #{sealed},
-                #{builtOnce}
+                #{builtOnce},
+                COALESCE(#{inventoryStateCode}, 'AVAILABLE'),
+                COALESCE(#{inventoryStateChangedAt}, CURRENT_TIMESTAMP),
+                COALESCE(#{saleIntentCode}, 'UNDECIDED'),
+                COALESCE(#{saleIntentUpdatedAt}, CURRENT_TIMESTAMP),
+                #{saleIntentNote}
             )
             """)
     @Options(useGeneratedKeys = true, keyColumn = "item_inventory_id", keyProperty = "itemInventoryId")
@@ -147,10 +163,41 @@ public interface ItemInventoryMapper {
                 box_condition_id = #{boxConditionId},
                 instructions_condition_id = #{instructionsConditionId},
                 sealed = #{sealed},
-                built_once = #{builtOnce}
+                built_once = #{builtOnce},
+                inventory_state_code = COALESCE(#{inventoryStateCode}, inventory_state_code, 'AVAILABLE'),
+                inventory_state_changed_at = COALESCE(#{inventoryStateChangedAt}, inventory_state_changed_at, CURRENT_TIMESTAMP),
+                sale_intent_code = COALESCE(#{saleIntentCode}, sale_intent_code, 'UNDECIDED'),
+                sale_intent_updated_at = COALESCE(#{saleIntentUpdatedAt}, sale_intent_updated_at, CURRENT_TIMESTAMP),
+                sale_intent_note = #{saleIntentNote}
             WHERE item_inventory_id = #{itemInventoryId}
             """)
     int update(ItemInventory itemInventory);
+
+    @Update("""
+            UPDATE item_inventory
+            SET inventory_state_code = #{inventoryStateCode},
+                inventory_state_changed_at = COALESCE(#{inventoryStateChangedAt}, CURRENT_TIMESTAMP)
+            WHERE item_inventory_id = #{itemInventoryId}
+            """)
+    int updateInventoryState(
+            @Param("itemInventoryId") Integer itemInventoryId,
+            @Param("inventoryStateCode") String inventoryStateCode,
+            @Param("inventoryStateChangedAt") ZonedDateTime inventoryStateChangedAt
+    );
+
+    @Update("""
+            UPDATE item_inventory
+            SET sale_intent_code = #{saleIntentCode},
+                sale_intent_updated_at = COALESCE(#{saleIntentUpdatedAt}, CURRENT_TIMESTAMP),
+                sale_intent_note = #{saleIntentNote}
+            WHERE item_inventory_id = #{itemInventoryId}
+            """)
+    int updateSaleIntent(
+            @Param("itemInventoryId") Integer itemInventoryId,
+            @Param("saleIntentCode") String saleIntentCode,
+            @Param("saleIntentUpdatedAt") ZonedDateTime saleIntentUpdatedAt,
+            @Param("saleIntentNote") String saleIntentNote
+    );
 
     @Delete("DELETE FROM item_inventory WHERE item_inventory_id = #{itemInventoryId}")
     int delete(Integer itemInventoryId);
@@ -170,7 +217,12 @@ public interface ItemInventoryMapper {
                 box_condition_id,
                 instructions_condition_id,
                 sealed,
-                built_once
+                built_once,
+                inventory_state_code,
+                inventory_state_changed_at,
+                sale_intent_code,
+                sale_intent_updated_at,
+                sale_intent_note
             )
             VALUES (
                 #{itemInventoryId},
@@ -186,7 +238,12 @@ public interface ItemInventoryMapper {
                 #{boxConditionId},
                 #{instructionsConditionId},
                 #{sealed},
-                #{builtOnce}
+                #{builtOnce},
+                COALESCE(#{inventoryStateCode}, 'AVAILABLE'),
+                COALESCE(#{inventoryStateChangedAt}, CURRENT_TIMESTAMP),
+                COALESCE(#{saleIntentCode}, 'UNDECIDED'),
+                COALESCE(#{saleIntentUpdatedAt}, CURRENT_TIMESTAMP),
+                #{saleIntentNote}
             )
             ON DUPLICATE KEY UPDATE
                 uuid = VALUES(uuid),
@@ -201,7 +258,12 @@ public interface ItemInventoryMapper {
                 box_condition_id = VALUES(box_condition_id),
                 instructions_condition_id = VALUES(instructions_condition_id),
                 sealed = VALUES(sealed),
-                built_once = VALUES(built_once)
+                built_once = VALUES(built_once),
+                inventory_state_code = COALESCE(VALUES(inventory_state_code), inventory_state_code, 'AVAILABLE'),
+                inventory_state_changed_at = COALESCE(VALUES(inventory_state_changed_at), inventory_state_changed_at, CURRENT_TIMESTAMP),
+                sale_intent_code = COALESCE(VALUES(sale_intent_code), sale_intent_code, 'UNDECIDED'),
+                sale_intent_updated_at = COALESCE(VALUES(sale_intent_updated_at), sale_intent_updated_at, CURRENT_TIMESTAMP),
+                sale_intent_note = VALUES(sale_intent_note)
             """)
     @Options(useGeneratedKeys = true, keyColumn = "item_inventory_id", keyProperty = "itemInventoryId")
     int upsert(ItemInventory itemInventory);

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapper.java
@@ -1,0 +1,85 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ItemInventorySaleIntent;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ItemInventorySaleIntentMapper {
+    @Select("""
+            SELECT sale_intent_code,
+                   sale_intent_name,
+                   sale_intent_description,
+                   active,
+                   sort_order
+            FROM item_inventory_sale_intent
+            """)
+    @ResultMap("itemInventorySaleIntentResultMap")
+    Set<ItemInventorySaleIntent> findAll();
+
+    @Select("""
+            SELECT sale_intent_code,
+                   sale_intent_name,
+                   sale_intent_description,
+                   active,
+                   sort_order
+            FROM item_inventory_sale_intent
+            WHERE sale_intent_code = #{saleIntentCode}
+            """)
+    @ResultMap("itemInventorySaleIntentResultMap")
+    Optional<ItemInventorySaleIntent> findBySaleIntentCode(String saleIntentCode);
+
+    @Insert("""
+            INSERT INTO item_inventory_sale_intent (sale_intent_code,
+                                                   sale_intent_name,
+                                                   sale_intent_description,
+                                                   active,
+                                                   sort_order)
+            VALUES (#{saleIntentCode},
+                    #{saleIntentName},
+                    #{saleIntentDescription},
+                    #{active},
+                    #{sortOrder})
+            """)
+    int insert(ItemInventorySaleIntent itemInventorySaleIntent);
+
+    @Update("""
+            UPDATE item_inventory_sale_intent
+            SET sale_intent_name = #{saleIntentName},
+                sale_intent_description = #{saleIntentDescription},
+                active = #{active},
+                sort_order = #{sortOrder}
+            WHERE sale_intent_code = #{saleIntentCode}
+            """)
+    int update(ItemInventorySaleIntent itemInventorySaleIntent);
+
+    @Delete("""
+            DELETE FROM item_inventory_sale_intent
+            WHERE sale_intent_code = #{saleIntentCode}
+            """)
+    int delete(String saleIntentCode);
+
+    @Insert("""
+            INSERT INTO item_inventory_sale_intent (sale_intent_code,
+                                                   sale_intent_name,
+                                                   sale_intent_description,
+                                                   active,
+                                                   sort_order)
+            VALUES (#{saleIntentCode},
+                    #{saleIntentName},
+                    #{saleIntentDescription},
+                    #{active},
+                    #{sortOrder})
+            ON DUPLICATE KEY UPDATE
+                sale_intent_name = VALUES(sale_intent_name),
+                sale_intent_description = VALUES(sale_intent_description),
+                active = VALUES(active),
+                sort_order = VALUES(sort_order)
+            """)
+    int upsert(ItemInventorySaleIntent itemInventorySaleIntent);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapper.java
@@ -1,0 +1,85 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ItemInventoryState;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ItemInventoryStateMapper {
+    @Select("""
+            SELECT inventory_state_code,
+                   inventory_state_name,
+                   inventory_state_description,
+                   active,
+                   sort_order
+            FROM item_inventory_state
+            """)
+    @ResultMap("itemInventoryStateResultMap")
+    Set<ItemInventoryState> findAll();
+
+    @Select("""
+            SELECT inventory_state_code,
+                   inventory_state_name,
+                   inventory_state_description,
+                   active,
+                   sort_order
+            FROM item_inventory_state
+            WHERE inventory_state_code = #{inventoryStateCode}
+            """)
+    @ResultMap("itemInventoryStateResultMap")
+    Optional<ItemInventoryState> findByInventoryStateCode(String inventoryStateCode);
+
+    @Insert("""
+            INSERT INTO item_inventory_state (inventory_state_code,
+                                              inventory_state_name,
+                                              inventory_state_description,
+                                              active,
+                                              sort_order)
+            VALUES (#{inventoryStateCode},
+                    #{inventoryStateName},
+                    #{inventoryStateDescription},
+                    #{active},
+                    #{sortOrder})
+            """)
+    int insert(ItemInventoryState itemInventoryState);
+
+    @Update("""
+            UPDATE item_inventory_state
+            SET inventory_state_name = #{inventoryStateName},
+                inventory_state_description = #{inventoryStateDescription},
+                active = #{active},
+                sort_order = #{sortOrder}
+            WHERE inventory_state_code = #{inventoryStateCode}
+            """)
+    int update(ItemInventoryState itemInventoryState);
+
+    @Delete("""
+            DELETE FROM item_inventory_state
+            WHERE inventory_state_code = #{inventoryStateCode}
+            """)
+    int delete(String inventoryStateCode);
+
+    @Insert("""
+            INSERT INTO item_inventory_state (inventory_state_code,
+                                              inventory_state_name,
+                                              inventory_state_description,
+                                              active,
+                                              sort_order)
+            VALUES (#{inventoryStateCode},
+                    #{inventoryStateName},
+                    #{inventoryStateDescription},
+                    #{active},
+                    #{sortOrder})
+            ON DUPLICATE KEY UPDATE
+                inventory_state_name = VALUES(inventory_state_name),
+                inventory_state_description = VALUES(inventory_state_description),
+                active = VALUES(active),
+                sort_order = VALUES(sort_order)
+            """)
+    int upsert(ItemInventoryState itemInventoryState);
+}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.xml
@@ -15,6 +15,11 @@
         <result column="instructions_condition_id" property="instructionsConditionId"/>
         <result column="sealed"                    property="sealed"/>
         <result column="built_once"                property="builtOnce"/>
+        <result column="inventory_state_code"      property="inventoryStateCode"/>
+        <result column="inventory_state_changed_at" property="inventoryStateChangedAt"/>
+        <result column="sale_intent_code"          property="saleIntentCode"/>
+        <result column="sale_intent_updated_at"    property="saleIntentUpdatedAt"/>
+        <result column="sale_intent_note"          property="saleIntentNote"/>
         <collection property="externalCatalogItems"
                     resultMap="io.legohunter.data.mybatis.mapper.ItemInventoryExternalCatalogItemMapper.itemInventoryExternalCatalogItemResultMap"
                     columnPrefix="iieci_"

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapper.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ItemInventorySaleIntentMapper">
+  <resultMap type="io.legohunter.data.dto.ItemInventorySaleIntent" id="itemInventorySaleIntentResultMap">
+    <id     column="sale_intent_code"        property="saleIntentCode"/>
+    <result column="sale_intent_name"        property="saleIntentName"/>
+    <result column="sale_intent_description" property="saleIntentDescription"/>
+    <result column="active"                  property="active"/>
+    <result column="sort_order"              property="sortOrder"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapper.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ItemInventoryStateMapper">
+  <resultMap type="io.legohunter.data.dto.ItemInventoryState" id="itemInventoryStateResultMap">
+    <id     column="inventory_state_code"        property="inventoryStateCode"/>
+    <result column="inventory_state_name"        property="inventoryStateName"/>
+    <result column="inventory_state_description" property="inventoryStateDescription"/>
+    <result column="active"                      property="active"/>
+    <result column="sort_order"                  property="sortOrder"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
@@ -6,6 +6,8 @@ import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZonedDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @MapperIntegrationTest
@@ -37,11 +39,42 @@ class ItemInventoryMapperTest extends MapperTestSupport {
                 .hasValueSatisfying(found -> {
                     assertThat(found.getDescription()).isEqualTo("Updated inventory");
                     assertThat(found.getPurchasePrice()).isEqualByComparingTo("12.34");
+                    assertThat(found.getInventoryStateCode()).isEqualTo("AVAILABLE");
+                    assertThat(found.getInventoryStateChangedAt()).isNotNull();
+                    assertThat(found.getSaleIntentCode()).isEqualTo("UNDECIDED");
+                    assertThat(found.getSaleIntentUpdatedAt()).isNotNull();
                     assertThat(found.getExternalCatalogItems())
                             .hasSize(1)
                             .first()
                             .satisfies(this::assertHydratedCatalogLink);
                 });
+
+        ZonedDateTime stateChangedAt = ZonedDateTime.parse("2026-06-16T10:00:00Z");
+        assertThat(itemInventoryMapper.updateInventoryState(
+                itemInventory.getItemInventoryId(),
+                "RESERVED_FOR_ORDER",
+                stateChangedAt
+        )).isOne();
+        assertThat(itemInventoryMapper.findByItemInventoryId(itemInventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getInventoryStateCode()).isEqualTo("RESERVED_FOR_ORDER");
+                    assertThat(found.getInventoryStateChangedAt()).isEqualTo(stateChangedAt);
+                });
+
+        ZonedDateTime saleIntentUpdatedAt = ZonedDateTime.parse("2026-06-16T11:00:00Z");
+        assertThat(itemInventoryMapper.updateSaleIntent(
+                itemInventory.getItemInventoryId(),
+                "KEEP",
+                saleIntentUpdatedAt,
+                "Personal collection"
+        )).isOne();
+        assertThat(itemInventoryMapper.findByItemInventoryId(itemInventory.getItemInventoryId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getSaleIntentCode()).isEqualTo("KEEP");
+                    assertThat(found.getSaleIntentUpdatedAt()).isEqualTo(saleIntentUpdatedAt);
+                    assertThat(found.getSaleIntentNote()).isEqualTo("Personal collection");
+                });
+
         assertThat(itemInventoryMapper.findByUuid("uuid-inventory"))
                 .hasValueSatisfying(found -> assertThat(found.getItemInventoryId()).isEqualTo(itemInventory.getItemInventoryId()));
         assertThat(itemInventoryMapper.findAll()).hasSize(1);

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventorySaleIntentMapperTest.java
@@ -1,0 +1,35 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ItemInventorySaleIntent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class ItemInventorySaleIntentMapperTest extends MapperTestSupport {
+
+    @Test
+    void insertUpdateFindByCodeFindAllUpsertAndDelete() {
+        ItemInventorySaleIntent saleIntent = ItemInventorySaleIntent.builder()
+                .saleIntentCode("SELLABLE")
+                .saleIntentName("Sellable")
+                .saleIntentDescription("Eligible for marketplace listing")
+                .active(true)
+                .sortOrder(10)
+                .build();
+
+        itemInventorySaleIntentMapper.insert(saleIntent);
+        saleIntent.setSaleIntentDescription("Eligible for automated marketplace listing");
+        itemInventorySaleIntentMapper.update(saleIntent);
+
+        assertThat(itemInventorySaleIntentMapper.findBySaleIntentCode("SELLABLE"))
+                .hasValueSatisfying(found -> assertThat(found.getSaleIntentDescription()).isEqualTo("Eligible for automated marketplace listing"));
+        assertThat(itemInventorySaleIntentMapper.findAll()).extracting(ItemInventorySaleIntent::getSaleIntentCode).containsExactly("SELLABLE");
+
+        saleIntent.setSaleIntentName("List for sale");
+        itemInventorySaleIntentMapper.upsert(saleIntent);
+        assertThat(itemInventorySaleIntentMapper.findBySaleIntentCode("SELLABLE"))
+                .hasValueSatisfying(found -> assertThat(found.getSaleIntentName()).isEqualTo("List for sale"));
+        assertThat(itemInventorySaleIntentMapper.delete("SELLABLE")).isOne();
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryStateMapperTest.java
@@ -1,0 +1,35 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ItemInventoryState;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class ItemInventoryStateMapperTest extends MapperTestSupport {
+
+    @Test
+    void insertUpdateFindByCodeFindAllUpsertAndDelete() {
+        ItemInventoryState state = ItemInventoryState.builder()
+                .inventoryStateCode("AVAILABLE")
+                .inventoryStateName("Available")
+                .inventoryStateDescription("Available for inventory workflows")
+                .active(true)
+                .sortOrder(10)
+                .build();
+
+        itemInventoryStateMapper.insert(state);
+        state.setInventoryStateDescription("Available for marketplace listing");
+        itemInventoryStateMapper.update(state);
+
+        assertThat(itemInventoryStateMapper.findByInventoryStateCode("AVAILABLE"))
+                .hasValueSatisfying(found -> assertThat(found.getInventoryStateDescription()).isEqualTo("Available for marketplace listing"));
+        assertThat(itemInventoryStateMapper.findAll()).extracting(ItemInventoryState::getInventoryStateCode).containsExactly("AVAILABLE");
+
+        state.setInventoryStateName("Ready");
+        itemInventoryStateMapper.upsert(state);
+        assertThat(itemInventoryStateMapper.findByInventoryStateCode("AVAILABLE"))
+                .hasValueSatisfying(found -> assertThat(found.getInventoryStateName()).isEqualTo("Ready"));
+        assertThat(itemInventoryStateMapper.delete("AVAILABLE")).isOne();
+    }
+}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -47,6 +47,8 @@ abstract class MapperTestSupport {
     @Autowired ItemInventoryExternalCatalogItemMapper itemInventoryExternalCatalogItemMapper;
     @Autowired ItemInventoryMapper itemInventoryMapper;
     @Autowired ItemInventoryPhotoMapper itemInventoryPhotoMapper;
+    @Autowired ItemInventorySaleIntentMapper itemInventorySaleIntentMapper;
+    @Autowired ItemInventoryStateMapper itemInventoryStateMapper;
     @Autowired MarketplaceListingMapper marketplaceListingMapper;
     @Autowired BricklinkMarketplaceListingMapper bricklinkMarketplaceListingMapper;
     @Autowired EbayMarketplaceListingMapper ebayMarketplaceListingMapper;

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_lookup_data.sql
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_lookup_data.sql
@@ -25,6 +25,18 @@ INSERT INTO cost_type (cost_type_code, cost_type_name, cost_type_description) VA
     ('SHIPPING', 'Shipping', 'The cost of shipping an item or an entire order'),
     ('TAX', 'Tax', 'The sales tax amount added to an item or entire order');
 
+INSERT INTO item_inventory_state (inventory_state_code, inventory_state_name, inventory_state_description, active, sort_order) VALUES
+    ('AVAILABLE', 'Available', 'Owned item is available for normal inventory workflows and may be listed when sale intent allows it.', TRUE, 10),
+    ('RESERVED_FOR_ORDER', 'Reserved for Order', 'Owned item is temporarily reserved for an external marketplace order and should not be listed again.', TRUE, 20),
+    ('SOLD', 'Sold', 'Owned item has been sold and should not be listed.', TRUE, 30),
+    ('REMOVED', 'Removed', 'Owned item has been intentionally removed from the collection outside a marketplace sale.', TRUE, 40),
+    ('LOST', 'Lost', 'Owned item cannot currently be located and should not be listed.', TRUE, 50);
+
+INSERT INTO item_inventory_sale_intent (sale_intent_code, sale_intent_name, sale_intent_description, active, sort_order) VALUES
+    ('SELLABLE', 'Sellable', 'May be listed for sale when inventory state is AVAILABLE.', TRUE, 10),
+    ('KEEP', 'Keep', 'Personal collection item that should not be listed for sale.', TRUE, 20),
+    ('UNDECIDED', 'Undecided', 'Sale intent has not been classified; item should not be listed automatically.', TRUE, 30);
+
 INSERT INTO transaction_type (transaction_type_code, transaction_type_description, conversion_factor) VALUES
     ('A', 'Auction Purchase', 1),
     ('B', 'Built from Loose Pieces', 1),

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -29,6 +29,8 @@ DROP TABLE IF EXISTS category;
 DROP TABLE IF EXISTS external_service;
 DROP TABLE IF EXISTS external_service_type;
 DROP TABLE IF EXISTS item_inventory;
+DROP TABLE IF EXISTS item_inventory_sale_intent;
+DROP TABLE IF EXISTS item_inventory_state;
 DROP TABLE IF EXISTS inventory_index;
 DROP TABLE IF EXISTS item;
 DROP TABLE IF EXISTS carrier;
@@ -55,6 +57,22 @@ CREATE TABLE cost_type (
     cost_type_code VARCHAR(32) PRIMARY KEY,
     cost_type_name VARCHAR(255),
     cost_type_description VARCHAR(1024)
+);
+
+CREATE TABLE item_inventory_state (
+    inventory_state_code VARCHAR(30) PRIMARY KEY,
+    inventory_state_name VARCHAR(100) NOT NULL,
+    inventory_state_description VARCHAR(500),
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    sort_order INT
+);
+
+CREATE TABLE item_inventory_sale_intent (
+    sale_intent_code VARCHAR(30) PRIMARY KEY,
+    sale_intent_name VARCHAR(100) NOT NULL,
+    sale_intent_description VARCHAR(500),
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    sort_order INT
 );
 
 CREATE TABLE transaction_type (

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -156,7 +156,12 @@ CREATE TABLE item_inventory (
     box_condition_id INT,
     instructions_condition_id INT,
     sealed BOOLEAN,
-    built_once BOOLEAN
+    built_once BOOLEAN,
+    inventory_state_code VARCHAR(30) NOT NULL DEFAULT 'AVAILABLE',
+    inventory_state_changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sale_intent_code VARCHAR(30) NOT NULL DEFAULT 'UNDECIDED',
+    sale_intent_updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sale_intent_note VARCHAR(500)
 );
 
 CREATE TABLE item_inventory_external_catalog_item (


### PR DESCRIPTION
## Summary
- Extend ItemInventory with inventory lifecycle state and owner sale intent fields.
- Update MyBatis insert/update/upsert SQL and result mappings for the new fields.
- Add DAO transition helpers that update paired timestamps only when state/intent values change.
- Refresh H2 schemas and tests for defaults, state transitions, sale intent updates, and lookup DAO availability.

## Verification
- mvn clean install