### PR TITLE
Detect missing image album memberships

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ExternalImageDao.java
@@ -65,6 +65,13 @@ public class ExternalImageDao {
                 externalImageMapper::findItemInventoryIdsMissingExternalImageLinks,
                 externalServiceId
         );
+        addCandidates(
+                candidates,
+                effectiveLimit,
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_MEMBERSHIP,
+                externalImageMapper::findItemInventoryIdsMissingAlbumMemberships,
+                externalServiceId
+        );
         if (includeFailed) {
             addCandidates(
                     candidates,

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidateReason.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ImageHostingSyncCandidateReason.java
@@ -3,6 +3,7 @@ package io.legohunter.data.dao;
 public enum ImageHostingSyncCandidateReason {
     MISSING_ALBUM_LINK,
     MISSING_PHOTO_LINK,
+    MISSING_ALBUM_MEMBERSHIP,
     FAILED_SYNC,
     PENDING_SYNC,
     METADATA_CHANGED

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ExternalImageDaoUnitTest.java
@@ -34,29 +34,31 @@ class ExternalImageDaoUnitTest {
                 .thenReturn(List.of(100, 101));
         when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
                 .thenReturn(List.of(101, 102));
-        when(externalImageMapper.findItemInventoryIdsWithFailedSyncRows(10, 10))
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumMemberships(10, 10))
                 .thenReturn(List.of(102, 103));
-        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
+        when(externalImageMapper.findItemInventoryIdsWithFailedSyncRows(10, 10))
                 .thenReturn(List.of(103, 104));
-        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
                 .thenReturn(List.of(104, 105));
+        when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
+                .thenReturn(List.of(105, 106));
 
         List<ImageHostingSyncCandidate> candidates = externalImageDao.findItemInventorySyncCandidates(10, true, 10);
 
         assertThat(candidates)
                 .extracting(ImageHostingSyncCandidate::itemInventoryId)
-                .containsExactly(100, 101, 102, 103, 104, 105);
+                .containsExactly(100, 101, 102, 103, 104, 105, 106);
         assertThat(candidates.get(1).reasons()).containsExactlyInAnyOrder(
                 ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
                 ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK
         );
         assertThat(candidates.get(2).reasons()).containsExactlyInAnyOrder(
                 ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK,
-                ImageHostingSyncCandidateReason.FAILED_SYNC
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_MEMBERSHIP
         );
         assertThat(candidates.get(4).reasons()).containsExactlyInAnyOrder(
-                ImageHostingSyncCandidateReason.PENDING_SYNC,
-                ImageHostingSyncCandidateReason.METADATA_CHANGED
+                ImageHostingSyncCandidateReason.FAILED_SYNC,
+                ImageHostingSyncCandidateReason.PENDING_SYNC
         );
         verify(externalImageMapper).findItemInventoryIdsWithFailedSyncRows(10, 10);
     }
@@ -67,8 +69,10 @@ class ExternalImageDaoUnitTest {
                 .thenReturn(List.of(100, 101));
         when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 2))
                 .thenReturn(List.of(101, 102));
-        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 2))
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumMemberships(10, 2))
                 .thenReturn(List.of(100, 103));
+        when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 2))
+                .thenReturn(List.of(100, 104));
         when(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 2))
                 .thenReturn(List.of(104));
 
@@ -79,6 +83,7 @@ class ExternalImageDaoUnitTest {
                 .containsExactly(100, 101);
         assertThat(candidates.get(0).reasons()).containsExactlyInAnyOrder(
                 ImageHostingSyncCandidateReason.MISSING_ALBUM_LINK,
+                ImageHostingSyncCandidateReason.MISSING_ALBUM_MEMBERSHIP,
                 ImageHostingSyncCandidateReason.PENDING_SYNC
         );
         assertThat(candidates.get(1).reasons()).containsExactlyInAnyOrder(
@@ -92,6 +97,8 @@ class ExternalImageDaoUnitTest {
         when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 1))
                 .thenReturn(List.of(100, 101));
         when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 1))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumMemberships(10, 1))
                 .thenReturn(List.of());
         when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 1))
                 .thenReturn(List.of());
@@ -107,6 +114,8 @@ class ExternalImageDaoUnitTest {
         when(externalImageMapper.findItemInventoryIdsMissingAlbumLinks(10, 10))
                 .thenReturn(List.of());
         when(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
+                .thenReturn(List.of());
+        when(externalImageMapper.findItemInventoryIdsMissingAlbumMemberships(10, 10))
                 .thenReturn(List.of());
         when(externalImageMapper.findItemInventoryIdsWithPendingSyncRows(10, 10))
                 .thenReturn(List.of());

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ExternalImageMapper.java
@@ -110,6 +110,34 @@ public interface ExternalImageMapper {
             INNER JOIN external_image image
               ON image.item_inventory_photo_id = photo.item_inventory_photo_id
              AND image.external_service_id = #{externalServiceId}
+            INNER JOIN external_image_album album
+              ON album.item_inventory_id = photo.item_inventory_id
+             AND album.external_service_id = #{externalServiceId}
+            LEFT JOIN external_image_album_image membership
+              ON membership.external_image_album_id = album.external_image_album_id
+             AND membership.external_image_id = image.external_image_id
+            WHERE photo.status = 'PROCESSED'
+              AND image.sync_status = 'SYNCED'
+              AND image.external_service_image_id IS NOT NULL
+              AND image.external_service_image_id <> ''
+              AND album.sync_status = 'SYNCED'
+              AND album.external_album_id IS NOT NULL
+              AND album.external_album_id <> ''
+              AND membership.external_image_id IS NULL
+            ORDER BY photo.item_inventory_id
+            LIMIT #{limit}
+            """)
+    List<Integer> findItemInventoryIdsMissingAlbumMemberships(
+            @Param("externalServiceId") Integer externalServiceId,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT DISTINCT photo.item_inventory_id
+            FROM item_inventory_photo photo
+            INNER JOIN external_image image
+              ON image.item_inventory_photo_id = photo.item_inventory_photo_id
+             AND image.external_service_id = #{externalServiceId}
             WHERE photo.status = 'PROCESSED'
               AND (
                     image.sync_status = 'PENDING'

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ExternalImageMapperTest.java
@@ -87,6 +87,12 @@ class ExternalImageMapperTest extends MapperTestSupport {
         ExternalImageAlbum metadataMismatchAlbum = externalImageAlbum(10, metadataMismatchInventory.getItemInventoryId(), "album-metadata-mismatch");
         metadataMismatchAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(metadataMismatchAlbum);
+        externalImageAlbumImageMapper.insert(externalImageAlbumImage(
+                metadataMismatchAlbum.getExternalImageAlbumId(),
+                metadataMismatchImage.getExternalImageId(),
+                1,
+                true
+        ));
 
         ItemInventory missingAlbumLinkInventory = insertItemInventory("uuid-missing-album-link");
         ItemInventoryPhoto missingAlbumLinkPhoto = insertItemInventoryPhoto(missingAlbumLinkInventory.getItemInventoryId(), "33333333333333333333333333333333");
@@ -141,6 +147,15 @@ class ExternalImageMapperTest extends MapperTestSupport {
         pendingAlbum.setSyncStatus(ExternalSyncStatus.PENDING);
         externalImageAlbumMapper.insert(pendingAlbum);
 
+        ItemInventory missingAlbumMembershipInventory = insertItemInventory("uuid-missing-album-membership");
+        ItemInventoryPhoto missingAlbumMembershipPhoto = insertItemInventoryPhoto(missingAlbumMembershipInventory.getItemInventoryId(), "12121212121212121212121212121212");
+        ExternalImage missingAlbumMembershipImage = externalImage(10, missingAlbumMembershipPhoto.getItemInventoryPhotoId(), "image-missing-album-membership", "12121212121212121212121212121212");
+        missingAlbumMembershipImage.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageMapper.insert(missingAlbumMembershipImage);
+        ExternalImageAlbum missingAlbumMembershipAlbum = externalImageAlbum(10, missingAlbumMembershipInventory.getItemInventoryId(), "album-missing-album-membership");
+        missingAlbumMembershipAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
+        externalImageAlbumMapper.insert(missingAlbumMembershipAlbum);
+
         ItemInventory syncedInventory = insertItemInventory("uuid-synced");
         ItemInventoryPhoto syncedPhoto = insertItemInventoryPhoto(syncedInventory.getItemInventoryId(), "55555555555555555555555555555555");
         ExternalImage syncedImage = externalImage(10, syncedPhoto.getItemInventoryPhotoId(), "image-synced", "55555555555555555555555555555555");
@@ -149,6 +164,12 @@ class ExternalImageMapperTest extends MapperTestSupport {
         ExternalImageAlbum syncedAlbum = externalImageAlbum(10, syncedInventory.getItemInventoryId(), "album-synced");
         syncedAlbum.setSyncStatus(ExternalSyncStatus.SYNCED);
         externalImageAlbumMapper.insert(syncedAlbum);
+        externalImageAlbumImageMapper.insert(externalImageAlbumImage(
+                syncedAlbum.getExternalImageAlbumId(),
+                syncedImage.getExternalImageId(),
+                1,
+                true
+        ));
 
         assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 10))
                 .containsExactly(
@@ -170,6 +191,8 @@ class ExternalImageMapperTest extends MapperTestSupport {
                         failedImageInventory.getItemInventoryId(),
                         failedAlbumInventory.getItemInventoryId()
                 );
+        assertThat(externalImageMapper.findItemInventoryIdsMissingAlbumMemberships(10, 10))
+                .containsExactly(missingAlbumMembershipInventory.getItemInventoryId());
         assertThat(externalImageMapper.findItemInventoryIdsWithMetadataDrift(10, 10))
                 .containsExactly(metadataMismatchInventory.getItemInventoryId());
         assertThat(externalImageMapper.findItemInventoryIdsMissingExternalImageLinks(10, 1))


### PR DESCRIPTION
## Summary
- Add a MISSING_ALBUM_MEMBERSHIP image-hosting sync candidate reason
- Add a MyBatis candidate query for synced Flickr images missing external_image_album_image rows
- Wire the new query into ExternalImageDao candidate aggregation
- Cover the stranded uploaded-photo case with DAO and mapper tests

## Verification
- mvn clean install