### PR TITLE
Add Pricing Plane Phase 2 listing lookup

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -25,6 +25,18 @@ public class MarketplaceListingDao {
         return marketplaceListingMapper.findByItemInventoryId(itemInventoryId);
     }
 
+    public Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit
+        );
+    }
+
     public Optional<MarketplaceListing> findByListingExternalServiceIdAndExternalListingId(Integer listingExternalServiceId, String externalListingId) {
         return marketplaceListingMapper.findByListingExternalServiceIdAndExternalListingId(listingExternalServiceId, externalListingId);
     }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -1,0 +1,55 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class PricingCrawlWorkItemDao {
+    private final PricingCrawlWorkItemMapper pricingCrawlWorkItemMapper;
+
+    public Set<PricingCrawlWorkItem> findAll() {
+        return pricingCrawlWorkItemMapper.findAll();
+    }
+
+    public Optional<PricingCrawlWorkItem> findByPricingCrawlWorkItemId(Long pricingCrawlWorkItemId) {
+        return pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(pricingCrawlWorkItemId);
+    }
+
+    public Set<PricingCrawlWorkItem> findByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingCrawlWorkItemMapper.findByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingCrawlWorkItem> findByWorkStatusCode(String workStatusCode) {
+        return pricingCrawlWorkItemMapper.findByWorkStatusCode(workStatusCode);
+    }
+
+    public Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+        return pricingCrawlWorkItemMapper.findDueByWorkStatusCode(workStatusCode, dueAt, limit);
+    }
+
+    public PricingCrawlWorkItem insert(PricingCrawlWorkItem pricingCrawlWorkItem) {
+        pricingCrawlWorkItemMapper.insert(pricingCrawlWorkItem);
+        return findByPricingCrawlWorkItemId(pricingCrawlWorkItem.getPricingCrawlWorkItemId()).orElseThrow();
+    }
+
+    public PricingCrawlWorkItem update(PricingCrawlWorkItem pricingCrawlWorkItem) {
+        pricingCrawlWorkItemMapper.update(pricingCrawlWorkItem);
+        return findByPricingCrawlWorkItemId(pricingCrawlWorkItem.getPricingCrawlWorkItemId()).orElseThrow();
+    }
+
+    public void delete(Long pricingCrawlWorkItemId) {
+        pricingCrawlWorkItemMapper.delete(pricingCrawlWorkItemId);
+    }
+
+    public PricingCrawlWorkItem upsert(PricingCrawlWorkItem pricingCrawlWorkItem) {
+        pricingCrawlWorkItemMapper.upsert(pricingCrawlWorkItem);
+        return findByPricingCrawlWorkItemId(pricingCrawlWorkItem.getPricingCrawlWorkItemId()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -1,0 +1,58 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class PricingDecisionDao {
+    private final PricingDecisionMapper pricingDecisionMapper;
+
+    public Set<PricingDecision> findAll() {
+        return pricingDecisionMapper.findAll();
+    }
+
+    public Optional<PricingDecision> findByPricingDecisionId(Long pricingDecisionId) {
+        return pricingDecisionMapper.findByPricingDecisionId(pricingDecisionId);
+    }
+
+    public Set<PricingDecision> findByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingDecisionMapper.findByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingDecision> findByDecisionStatusCode(String decisionStatusCode) {
+        return pricingDecisionMapper.findByDecisionStatusCode(decisionStatusCode);
+    }
+
+    public Set<PricingDecision> findByReasonCode(String reasonCode) {
+        return pricingDecisionMapper.findByReasonCode(reasonCode);
+    }
+
+    public Optional<PricingDecision> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingDecisionMapper.findLatestByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public PricingDecision insert(PricingDecision pricingDecision) {
+        pricingDecisionMapper.insert(pricingDecision);
+        return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();
+    }
+
+    public PricingDecision update(PricingDecision pricingDecision) {
+        pricingDecisionMapper.update(pricingDecision);
+        return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();
+    }
+
+    public void delete(Long pricingDecisionId) {
+        pricingDecisionMapper.delete(pricingDecisionId);
+    }
+
+    public PricingDecision upsert(PricingDecision pricingDecision) {
+        pricingDecisionMapper.upsert(pricingDecision);
+        return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotDao.java
@@ -33,6 +33,30 @@ public class PricingSnapshotDao {
         return pricingSnapshotMapper.findLatestByMarketplaceListingId(marketplaceListingId);
     }
 
+    public Optional<PricingSnapshot> findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+            Integer marketplaceListingId,
+            String itemConditionCode,
+            String completenessCode
+    ) {
+        return pricingSnapshotMapper.findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+                marketplaceListingId,
+                itemConditionCode,
+                completenessCode
+        );
+    }
+
+    public Optional<PricingSnapshot> findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+            Integer externalCatalogItemId,
+            String itemConditionCode,
+            String completenessCode
+    ) {
+        return pricingSnapshotMapper.findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+                externalCatalogItemId,
+                itemConditionCode,
+                completenessCode
+        );
+    }
+
     public PricingSnapshot insert(PricingSnapshot pricingSnapshot) {
         pricingSnapshotMapper.insert(pricingSnapshot);
         return findByPricingSnapshotId(pricingSnapshot.getPricingSnapshotId()).orElseThrow();

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotDao.java
@@ -1,0 +1,54 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PricingSnapshot;
+import io.legohunter.data.mybatis.mapper.PricingSnapshotMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class PricingSnapshotDao {
+    private final PricingSnapshotMapper pricingSnapshotMapper;
+
+    public Set<PricingSnapshot> findAll() {
+        return pricingSnapshotMapper.findAll();
+    }
+
+    public Optional<PricingSnapshot> findByPricingSnapshotId(Long pricingSnapshotId) {
+        return pricingSnapshotMapper.findByPricingSnapshotId(pricingSnapshotId);
+    }
+
+    public Set<PricingSnapshot> findByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingSnapshotMapper.findByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingSnapshot> findByExternalCatalogItemId(Integer externalCatalogItemId) {
+        return pricingSnapshotMapper.findByExternalCatalogItemId(externalCatalogItemId);
+    }
+
+    public Optional<PricingSnapshot> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingSnapshotMapper.findLatestByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public PricingSnapshot insert(PricingSnapshot pricingSnapshot) {
+        pricingSnapshotMapper.insert(pricingSnapshot);
+        return findByPricingSnapshotId(pricingSnapshot.getPricingSnapshotId()).orElseThrow();
+    }
+
+    public PricingSnapshot update(PricingSnapshot pricingSnapshot) {
+        pricingSnapshotMapper.update(pricingSnapshot);
+        return findByPricingSnapshotId(pricingSnapshot.getPricingSnapshotId()).orElseThrow();
+    }
+
+    public void delete(Long pricingSnapshotId) {
+        pricingSnapshotMapper.delete(pricingSnapshotId);
+    }
+
+    public PricingSnapshot upsert(PricingSnapshot pricingSnapshot) {
+        pricingSnapshotMapper.upsert(pricingSnapshot);
+        return findByPricingSnapshotId(pricingSnapshot.getPricingSnapshotId()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotListingDao.java
@@ -5,6 +5,7 @@ import io.legohunter.data.mybatis.mapper.PricingSnapshotListingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -27,6 +28,10 @@ public class PricingSnapshotListingDao {
 
     public Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(Long pricingSnapshotId, String externalListingId) {
         return pricingSnapshotListingMapper.findByPricingSnapshotIdAndExternalListingId(pricingSnapshotId, externalListingId);
+    }
+
+    public List<PricingSnapshotListing> findExactComparablesByPricingSnapshotId(Long pricingSnapshotId) {
+        return pricingSnapshotListingMapper.findExactComparablesByPricingSnapshotId(pricingSnapshotId);
     }
 
     public PricingSnapshotListing insert(PricingSnapshotListing pricingSnapshotListing) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingSnapshotListingDao.java
@@ -1,0 +1,50 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PricingSnapshotListing;
+import io.legohunter.data.mybatis.mapper.PricingSnapshotListingMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class PricingSnapshotListingDao {
+    private final PricingSnapshotListingMapper pricingSnapshotListingMapper;
+
+    public Set<PricingSnapshotListing> findAll() {
+        return pricingSnapshotListingMapper.findAll();
+    }
+
+    public Optional<PricingSnapshotListing> findByPricingSnapshotListingId(Long pricingSnapshotListingId) {
+        return pricingSnapshotListingMapper.findByPricingSnapshotListingId(pricingSnapshotListingId);
+    }
+
+    public Set<PricingSnapshotListing> findByPricingSnapshotId(Long pricingSnapshotId) {
+        return pricingSnapshotListingMapper.findByPricingSnapshotId(pricingSnapshotId);
+    }
+
+    public Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(Long pricingSnapshotId, String externalListingId) {
+        return pricingSnapshotListingMapper.findByPricingSnapshotIdAndExternalListingId(pricingSnapshotId, externalListingId);
+    }
+
+    public PricingSnapshotListing insert(PricingSnapshotListing pricingSnapshotListing) {
+        pricingSnapshotListingMapper.insert(pricingSnapshotListing);
+        return findByPricingSnapshotListingId(pricingSnapshotListing.getPricingSnapshotListingId()).orElseThrow();
+    }
+
+    public PricingSnapshotListing update(PricingSnapshotListing pricingSnapshotListing) {
+        pricingSnapshotListingMapper.update(pricingSnapshotListing);
+        return findByPricingSnapshotListingId(pricingSnapshotListing.getPricingSnapshotListingId()).orElseThrow();
+    }
+
+    public void delete(Long pricingSnapshotListingId) {
+        pricingSnapshotListingMapper.delete(pricingSnapshotListingId);
+    }
+
+    public PricingSnapshotListing upsert(PricingSnapshotListing pricingSnapshotListing) {
+        pricingSnapshotListingMapper.upsert(pricingSnapshotListing);
+        return findByPricingSnapshotListingId(pricingSnapshotListing.getPricingSnapshotListingId()).orElseThrow();
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -271,6 +271,11 @@ class CurrentDaoIntegrationTest {
                 .containsExactly(listing.getMarketplaceListingId(), "Natural Key Upserted listing");
         assertThat(marketplaceListingDao.findByMarketplaceListingId(listing.getMarketplaceListingId())).isPresent();
         assertThat(marketplaceListingDao.findByListingExternalServiceIdAndExternalListingId(2, "DAO-BL-1")).isPresent();
+        assertThat(marketplaceListingDao.findByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .hasSize(1)
+                .first()
+                .extracting(MarketplaceListing::getExternalListingId)
+                .isEqualTo("DAO-BL-1");
         assertThat(marketplaceListingDao.findByItemInventoryId(inventory.getItemInventoryId())).hasSize(1);
         assertThat(itemInventoryDao.findMarketplaceListings(inventory))
                 .hasSize(1)

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -1,0 +1,262 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.config.LegoDataDaoConfiguration;
+import io.legohunter.data.config.MyBatisV2Configuration;
+import io.legohunter.data.dto.Condition;
+import io.legohunter.data.dto.ExternalCatalogItem;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingSnapshot;
+import io.legohunter.data.dto.PricingSnapshotListing;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@Import({MyBatisV2Configuration.class, LegoDataDaoConfiguration.class})
+@Sql(scripts = {
+        "/scripts/db/h2/current_schema.ddl",
+        "/scripts/db/h2/current_lookup_data.sql"
+})
+class PricingPlaneDaoTest {
+    private static final ZonedDateTime CRAWL_AT = ZonedDateTime.parse("2026-06-18T14:00:00Z");
+    private static final ZonedDateTime SNAPSHOT_AT = ZonedDateTime.parse("2026-06-18T15:00:00Z");
+
+    @Autowired ConditionDao conditionDao;
+    @Autowired ExternalCatalogItemDao externalCatalogItemDao;
+    @Autowired ExternalServiceDao externalServiceDao;
+    @Autowired ItemInventoryDao itemInventoryDao;
+    @Autowired MarketplaceListingDao marketplaceListingDao;
+    @Autowired PricingCrawlWorkItemDao pricingCrawlWorkItemDao;
+    @Autowired PricingSnapshotDao pricingSnapshotDao;
+    @Autowired PricingSnapshotListingDao pricingSnapshotListingDao;
+    @Autowired PricingDecisionDao pricingDecisionDao;
+
+    @Test
+    void pricingDaosSupportPhaseOneCrudAndLookups() {
+        PricingFixture fixture = pricingFixture();
+
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItem(fixture);
+        workItem = pricingCrawlWorkItemDao.insert(workItem);
+        workItem.setWorkStatusCode("CLAIMED");
+        workItem = pricingCrawlWorkItemDao.update(workItem);
+        assertThat(workItem.getWorkStatusCode()).isEqualTo("CLAIMED");
+        assertThat(pricingCrawlWorkItemDao.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId())).isPresent();
+        assertThat(pricingCrawlWorkItemDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingCrawlWorkItemDao.findByWorkStatusCode("CLAIMED")).hasSize(1);
+        assertThat(pricingCrawlWorkItemDao.findDueByWorkStatusCode("CLAIMED", CRAWL_AT.plusMinutes(1), 5)).hasSize(1);
+        assertThat(pricingCrawlWorkItemDao.findAll()).hasSize(1);
+        workItem.setWorkStatusCode("SUCCEEDED");
+        assertThat(pricingCrawlWorkItemDao.upsert(workItem).getWorkStatusCode()).isEqualTo("SUCCEEDED");
+
+        PricingSnapshot snapshot = pricingSnapshot(workItem, fixture);
+        snapshot = pricingSnapshotDao.insert(snapshot);
+        snapshot.setComparableCount(3);
+        snapshot = pricingSnapshotDao.update(snapshot);
+        assertThat(snapshot.getComparableCount()).isEqualTo(3);
+        assertThat(pricingSnapshotDao.findByPricingSnapshotId(snapshot.getPricingSnapshotId())).isPresent();
+        assertThat(pricingSnapshotDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingSnapshotDao.findByExternalCatalogItemId(fixture.catalogItem().getExternalCatalogItemId())).hasSize(1);
+        assertThat(pricingSnapshotDao.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
+                .map(PricingSnapshot::getPricingSnapshotId)
+                .contains(snapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotDao.findAll()).hasSize(1);
+        snapshot.setComparableCount(4);
+        assertThat(pricingSnapshotDao.upsert(snapshot).getComparableCount()).isEqualTo(4);
+
+        PricingSnapshotListing snapshotListing = pricingSnapshotListing(snapshot);
+        snapshotListing = pricingSnapshotListingDao.insert(snapshotListing);
+        snapshotListing.setUnitPrice(new BigDecimal("215.00"));
+        snapshotListing = pricingSnapshotListingDao.update(snapshotListing);
+        assertThat(snapshotListing.getUnitPrice()).isEqualByComparingTo("215.00");
+        assertThat(pricingSnapshotListingDao.findByPricingSnapshotListingId(snapshotListing.getPricingSnapshotListingId())).isPresent();
+        assertThat(pricingSnapshotListingDao.findByPricingSnapshotId(snapshot.getPricingSnapshotId())).hasSize(1);
+        assertThat(pricingSnapshotListingDao.findByPricingSnapshotIdAndExternalListingId(snapshot.getPricingSnapshotId(), "remote-listing-1")).isPresent();
+        assertThat(pricingSnapshotListingDao.findAll()).hasSize(1);
+        snapshotListing.setQuantityAvailable(2);
+        assertThat(pricingSnapshotListingDao.upsert(snapshotListing).getQuantityAvailable()).isEqualTo(2);
+
+        PricingDecision decision = pricingDecision(snapshot, fixture);
+        decision = pricingDecisionDao.insert(decision);
+        decision.setDecisionStatusCode("APPLIED");
+        decision.setAppliedAt(SNAPSHOT_AT.plusMinutes(1));
+        decision = pricingDecisionDao.update(decision);
+        assertThat(decision.getDecisionStatusCode()).isEqualTo("APPLIED");
+        assertThat(pricingDecisionDao.findByPricingDecisionId(decision.getPricingDecisionId())).isPresent();
+        assertThat(pricingDecisionDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingDecisionDao.findByDecisionStatusCode("APPLIED")).hasSize(1);
+        assertThat(pricingDecisionDao.findByReasonCode("MATCHED_LOWEST_COMPETITOR")).hasSize(1);
+        assertThat(pricingDecisionDao.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
+                .map(PricingDecision::getPricingDecisionId)
+                .contains(decision.getPricingDecisionId());
+        assertThat(pricingDecisionDao.findAll()).hasSize(1);
+        decision.setReasonCode("FIXED_PRICE_OVERRIDE");
+        assertThat(pricingDecisionDao.upsert(decision).getReasonCode()).isEqualTo("FIXED_PRICE_OVERRIDE");
+
+        pricingDecisionDao.delete(decision.getPricingDecisionId());
+        pricingSnapshotListingDao.delete(snapshotListing.getPricingSnapshotListingId());
+        pricingSnapshotDao.delete(snapshot.getPricingSnapshotId());
+        pricingCrawlWorkItemDao.delete(workItem.getPricingCrawlWorkItemId());
+        assertThat(pricingDecisionDao.findAll()).isEmpty();
+        assertThat(pricingSnapshotListingDao.findAll()).isEmpty();
+        assertThat(pricingSnapshotDao.findAll()).isEmpty();
+        assertThat(pricingCrawlWorkItemDao.findAll()).isEmpty();
+    }
+
+    private PricingFixture pricingFixture() {
+        seedDefaultCondition();
+        ExternalService bricklink = externalServiceDao.findByServiceCode("BRICKLINK").orElseThrow();
+        ExternalCatalogItem catalogItem = ExternalCatalogItem.builder()
+                .externalServiceId(bricklink.getExternalServiceId())
+                .externalItemKey("6390-1")
+                .externalUniqueKey("4997")
+                .itemName("Main Street")
+                .itemTypeCode("SET")
+                .itemUrl("https://bricklink.example/6390-1")
+                .yearReleased(1980)
+                .build();
+        catalogItem = externalCatalogItemDao.insert(catalogItem);
+
+        ItemInventory inventory = new ItemInventory();
+        inventory.setUuid("pricing-dao-inventory");
+        inventory.setBoxNumber(1);
+        inventory.setPurchasePrice(new BigDecimal("100.00"));
+        inventory.setDescription("Pricing DAO inventory");
+        inventory.setActive(true);
+        inventory.setForSale(true);
+        inventory.setNewOrUsed("USED");
+        inventory.setCompleteness("COMPLETE");
+        inventory.setItemConditionId(1);
+        inventory.setBoxConditionId(1);
+        inventory.setInstructionsConditionId(1);
+        inventory.setSealed(false);
+        inventory.setBuiltOnce(true);
+        inventory = itemInventoryDao.insert(inventory);
+
+        MarketplaceListing listing = MarketplaceListing.builder()
+                .itemInventoryId(inventory.getItemInventoryId())
+                .listingExternalServiceId(bricklink.getExternalServiceId())
+                .externalCatalogItemId(catalogItem.getExternalCatalogItemId())
+                .externalListingId("BL-PRICING-1")
+                .externalListingUrl("https://bricklink.example/listing/BL-PRICING-1")
+                .listingStatusCode("ACTIVE")
+                .title("Main Street")
+                .description("Complete")
+                .unitPrice(new BigDecimal("225.00"))
+                .currencyCode("USD")
+                .fixedPrice(false)
+                .build();
+        listing = marketplaceListingDao.insert(listing);
+        return new PricingFixture(bricklink, catalogItem, inventory, listing);
+    }
+
+    private PricingCrawlWorkItem pricingCrawlWorkItem(PricingFixture fixture) {
+        return PricingCrawlWorkItem.builder()
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .externalCatalogItemId(fixture.catalogItem().getExternalCatalogItemId())
+                .sourceExternalServiceId(fixture.bricklink().getExternalServiceId())
+                .workStatusCode("PENDING")
+                .attemptCount(0)
+                .maxAttempts(3)
+                .nextAttemptAt(CRAWL_AT)
+                .sourceRequestUrl("https://bricklink.example/ajax/clone/catalogifs.ajax")
+                .sourceRequestParameters("itemid=4997&rpp=500&iconly=0")
+                .build();
+    }
+
+    private PricingSnapshot pricingSnapshot(PricingCrawlWorkItem workItem, PricingFixture fixture) {
+        return PricingSnapshot.builder()
+                .pricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId())
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .externalCatalogItemId(fixture.catalogItem().getExternalCatalogItemId())
+                .sourceExternalServiceId(fixture.bricklink().getExternalServiceId())
+                .sourceItemKey("6390-1")
+                .sourceUniqueKey("4997")
+                .itemConditionCode("U")
+                .completenessCode("COMPLETE")
+                .sourceRequestUrl("https://bricklink.example/ajax/clone/catalogifs.ajax")
+                .sourceRequestParameters("itemid=4997&rpp=500&iconly=0")
+                .rawPayloadHash("hash-1")
+                .comparableCount(2)
+                .capturedAt(SNAPSHOT_AT)
+                .build();
+    }
+
+    private PricingSnapshotListing pricingSnapshotListing(PricingSnapshot snapshot) {
+        return PricingSnapshotListing.builder()
+                .pricingSnapshotId(snapshot.getPricingSnapshotId())
+                .externalListingId("remote-listing-1")
+                .sellerName("seller-one")
+                .sellerCountryCode("US")
+                .itemConditionCode("U")
+                .completenessCode("COMPLETE")
+                .quantityAvailable(1)
+                .unitPrice(new BigDecimal("220.00"))
+                .currencyCode("USD")
+                .description("Main Street")
+                .extendedDescription("Complete with box")
+                .sourceListingPayload("{\"id\":\"remote-listing-1\"}")
+                .build();
+    }
+
+    private PricingDecision pricingDecision(PricingSnapshot snapshot, PricingFixture fixture) {
+        return PricingDecision.builder()
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .pricingSnapshotId(snapshot.getPricingSnapshotId())
+                .algorithmVersion("BRICKLINK_COMPETITIVE_V1")
+                .decisionStatusCode("PROPOSED")
+                .reasonCode("MATCHED_LOWEST_COMPETITOR")
+                .strategyCode("COMPETITIVE")
+                .computedPrice(new BigDecimal("219.00"))
+                .finalPrice(new BigDecimal("219.00"))
+                .previousPrice(new BigDecimal("225.00"))
+                .currencyCode("USD")
+                .comparableCount(2)
+                .confidence(new BigDecimal("0.7500"))
+                .sourceSummaryJson("{\"snapshot\":true}")
+                .notes("Initial recommendation")
+                .build();
+    }
+
+    private void seedDefaultCondition() {
+        conditionDao.findConditionById(1)
+                .orElseGet(() -> {
+                    Condition condition = Condition.builder()
+                            .conditionId(1)
+                            .conditionCode("G")
+                            .conditionDescription("Good")
+                            .conditionText("Good")
+                            .build();
+                    conditionDao.insert(condition);
+                    return condition;
+                });
+    }
+
+    private record PricingFixture(
+            ExternalService bricklink,
+            ExternalCatalogItem catalogItem,
+            ItemInventory inventory,
+            MarketplaceListing listing
+    ) {
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    @PropertySource("application.properties")
+    static class TestConfiguration {
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -117,6 +117,41 @@ class PricingPlaneDaoTest {
         assertThat(pricingCrawlWorkItemDao.findAll()).isEmpty();
     }
 
+    @Test
+    void pricingDaosExposeExactConditionAndCompletenessComparables() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        PricingSnapshot snapshot = pricingSnapshot(workItem, fixture);
+        snapshot.setItemConditionCode("N");
+        snapshot.setCompletenessCode("S");
+        snapshot = pricingSnapshotDao.insert(snapshot);
+
+        PricingSnapshotListing sealedComparable = pricingSnapshotListing(snapshot);
+        sealedComparable.setExternalListingId("sealed-comparable");
+        sealedComparable.setItemConditionCode("N");
+        sealedComparable.setCompletenessCode("S");
+        sealedComparable.setUnitPrice(new BigDecimal("30.00"));
+        pricingSnapshotListingDao.insert(sealedComparable);
+
+        PricingSnapshotListing completeComparable = pricingSnapshotListing(snapshot);
+        completeComparable.setExternalListingId("complete-comparable");
+        completeComparable.setItemConditionCode("N");
+        completeComparable.setCompletenessCode("C");
+        completeComparable.setUnitPrice(new BigDecimal("20.00"));
+        pricingSnapshotListingDao.insert(completeComparable);
+
+        assertThat(pricingSnapshotDao.findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+                fixture.listing().getMarketplaceListingId(), "N", "S"
+        )).map(PricingSnapshot::getPricingSnapshotId).contains(snapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotDao.findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+                fixture.catalogItem().getExternalCatalogItemId(), "N", "S"
+        )).map(PricingSnapshot::getPricingSnapshotId).contains(snapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotListingDao.findByPricingSnapshotId(snapshot.getPricingSnapshotId())).hasSize(2);
+        assertThat(pricingSnapshotListingDao.findExactComparablesByPricingSnapshotId(snapshot.getPricingSnapshotId()))
+                .extracting(PricingSnapshotListing::getExternalListingId)
+                .containsExactly("sealed-comparable");
+    }
+
     private PricingFixture pricingFixture() {
         seedDefaultCondition();
         ExternalService bricklink = externalServiceDao.findByServiceCode("BRICKLINK").orElseThrow();

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,10 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS pricing_decision;
+DROP TABLE IF EXISTS pricing_snapshot_listing;
+DROP TABLE IF EXISTS pricing_snapshot;
+DROP TABLE IF EXISTS pricing_crawl_work_item;
 DROP TABLE IF EXISTS ebay_listing_item_specific;
 DROP TABLE IF EXISTS ebay_marketplace_listing;
 DROP TABLE IF EXISTS bricklink_marketplace_listing;
@@ -192,6 +196,79 @@ CREATE TABLE marketplace_listing (
     ended_at TIMESTAMP,
     last_synchronized_at TIMESTAMP,
     UNIQUE (listing_external_service_id, external_listing_id)
+);
+
+CREATE TABLE pricing_crawl_work_item (
+    pricing_crawl_work_item_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    external_catalog_item_id INT NOT NULL,
+    source_external_service_id INT NOT NULL,
+    work_status_code VARCHAR(32) NOT NULL,
+    attempt_count INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    next_attempt_at TIMESTAMP NOT NULL,
+    claimed_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    source_request_url VARCHAR(1024),
+    source_request_parameters CLOB,
+    last_error_message CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_snapshot (
+    pricing_snapshot_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    pricing_crawl_work_item_id BIGINT,
+    marketplace_listing_id INT,
+    external_catalog_item_id INT NOT NULL,
+    source_external_service_id INT NOT NULL,
+    source_item_key VARCHAR(255) NOT NULL,
+    source_unique_key VARCHAR(255),
+    item_condition_code VARCHAR(32),
+    completeness_code VARCHAR(64),
+    source_request_url VARCHAR(1024),
+    source_request_parameters CLOB,
+    raw_payload_hash VARCHAR(64),
+    comparable_count INT,
+    captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_snapshot_listing (
+    pricing_snapshot_listing_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    pricing_snapshot_id BIGINT NOT NULL,
+    external_listing_id VARCHAR(255),
+    seller_name VARCHAR(255),
+    seller_country_code VARCHAR(8),
+    item_condition_code VARCHAR(32),
+    completeness_code VARCHAR(64),
+    quantity_available INT,
+    unit_price DECIMAL(12,2) NOT NULL,
+    currency_code VARCHAR(8) NOT NULL,
+    description CLOB,
+    extended_description CLOB,
+    source_listing_payload CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_decision (
+    pricing_decision_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    pricing_snapshot_id BIGINT,
+    algorithm_version VARCHAR(64) NOT NULL,
+    decision_status_code VARCHAR(32) NOT NULL,
+    reason_code VARCHAR(64) NOT NULL,
+    strategy_code VARCHAR(64),
+    computed_price DECIMAL(12,2),
+    final_price DECIMAL(12,2),
+    previous_price DECIMAL(12,2),
+    currency_code VARCHAR(8) NOT NULL,
+    comparable_count INT,
+    confidence DECIMAL(5,4),
+    source_summary_json CLOB,
+    notes CLOB,
+    applied_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE bricklink_marketplace_listing (
@@ -466,6 +543,22 @@ CREATE INDEX idx_marketplace_order_transaction_link_transaction_item
     ON marketplace_order_transaction_link (transaction_item_id);
 CREATE INDEX idx_marketplace_order_transaction_link_type_status
     ON marketplace_order_transaction_link (link_type_code, link_status_code);
+CREATE INDEX idx_pricing_crawl_work_item_status_due
+    ON pricing_crawl_work_item (work_status_code, next_attempt_at);
+CREATE INDEX idx_pricing_crawl_work_item_listing
+    ON pricing_crawl_work_item (marketplace_listing_id);
+CREATE INDEX idx_pricing_snapshot_listing
+    ON pricing_snapshot (marketplace_listing_id, captured_at);
+CREATE INDEX idx_pricing_snapshot_catalog
+    ON pricing_snapshot (external_catalog_item_id, captured_at);
+CREATE INDEX idx_pricing_snapshot_listing_snapshot
+    ON pricing_snapshot_listing (pricing_snapshot_id);
+CREATE INDEX idx_pricing_decision_listing
+    ON pricing_decision (marketplace_listing_id, created_at);
+CREATE INDEX idx_pricing_decision_status
+    ON pricing_decision (decision_status_code);
+CREATE INDEX idx_pricing_decision_reason
+    ON pricing_decision (reason_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -594,6 +687,56 @@ ALTER TABLE marketplace_listing
 ALTER TABLE marketplace_listing
     ADD CONSTRAINT fk_marketplace_listing_external_catalog_item1
     FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_catalog_item1
+    FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_source_service1
+    FOREIGN KEY (source_external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_work_item1
+    FOREIGN KEY (pricing_crawl_work_item_id) REFERENCES pricing_crawl_work_item (pricing_crawl_work_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_catalog_item1
+    FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_source_service1
+    FOREIGN KEY (source_external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot_listing
+    ADD CONSTRAINT fk_pricing_snapshot_listing_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_decision
+    ADD CONSTRAINT fk_pricing_decision_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_decision
+    ADD CONSTRAINT fk_pricing_decision_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE bricklink_marketplace_listing

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItem.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItem.java
@@ -1,0 +1,30 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingCrawlWorkItem {
+    private Long pricingCrawlWorkItemId;
+    private Integer marketplaceListingId;
+    private Integer externalCatalogItemId;
+    private Integer sourceExternalServiceId;
+    private String workStatusCode;
+    private Integer attemptCount;
+    private Integer maxAttempts;
+    private ZonedDateTime nextAttemptAt;
+    private ZonedDateTime claimedAt;
+    private ZonedDateTime completedAt;
+    private String sourceRequestUrl;
+    private String sourceRequestParameters;
+    private String lastErrorMessage;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecision.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecision.java
@@ -1,0 +1,33 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingDecision {
+    private Long pricingDecisionId;
+    private Integer marketplaceListingId;
+    private Long pricingSnapshotId;
+    private String algorithmVersion;
+    private String decisionStatusCode;
+    private String reasonCode;
+    private String strategyCode;
+    private BigDecimal computedPrice;
+    private BigDecimal finalPrice;
+    private BigDecimal previousPrice;
+    private String currencyCode;
+    private Integer comparableCount;
+    private BigDecimal confidence;
+    private String sourceSummaryJson;
+    private String notes;
+    private ZonedDateTime appliedAt;
+    private ZonedDateTime createdAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingSnapshot.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingSnapshot.java
@@ -1,0 +1,30 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingSnapshot {
+    private Long pricingSnapshotId;
+    private Long pricingCrawlWorkItemId;
+    private Integer marketplaceListingId;
+    private Integer externalCatalogItemId;
+    private Integer sourceExternalServiceId;
+    private String sourceItemKey;
+    private String sourceUniqueKey;
+    private String itemConditionCode;
+    private String completenessCode;
+    private String sourceRequestUrl;
+    private String sourceRequestParameters;
+    private String rawPayloadHash;
+    private Integer comparableCount;
+    private ZonedDateTime capturedAt;
+    private ZonedDateTime createdAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingSnapshotListing.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingSnapshotListing.java
@@ -1,0 +1,30 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingSnapshotListing {
+    private Long pricingSnapshotListingId;
+    private Long pricingSnapshotId;
+    private String externalListingId;
+    private String sellerName;
+    private String sellerCountryCode;
+    private String itemConditionCode;
+    private String completenessCode;
+    private Integer quantityAvailable;
+    private BigDecimal unitPrice;
+    private String currencyCode;
+    private String description;
+    private String extendedDescription;
+    private String sourceListingPayload;
+    private ZonedDateTime createdAt;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -76,6 +76,38 @@ public interface MarketplaceListingMapper {
             SELECT ${columns}
             ${fromClause}
             WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND ml.external_catalog_item_id IS NOT NULL
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceListingResultMap")
+    Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return findByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
               AND ml.external_listing_id = #{externalListingId}
             """)
     @ResultMap("marketplaceListingResultMap")

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -1,0 +1,182 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+public interface PricingCrawlWorkItemMapper {
+    String ALL_COLUMNS = """
+            pricing_crawl_work_item_id,
+            marketplace_listing_id,
+            external_catalog_item_id,
+            source_external_service_id,
+            work_status_code,
+            attempt_count,
+            max_attempts,
+            next_attempt_at,
+            claimed_at,
+            completed_at,
+            source_request_url,
+            source_request_parameters,
+            last_error_message,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_crawl_work_item")
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    Set<PricingCrawlWorkItem> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_crawl_work_item WHERE pricing_crawl_work_item_id = #{pricingCrawlWorkItemId}")
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    Optional<PricingCrawlWorkItem> findByPricingCrawlWorkItemId(Long pricingCrawlWorkItemId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_crawl_work_item WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    Set<PricingCrawlWorkItem> findByMarketplaceListingId(Integer marketplaceListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_crawl_work_item WHERE work_status_code = #{workStatusCode}")
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    Set<PricingCrawlWorkItem> findByWorkStatusCode(String workStatusCode);
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_crawl_work_item
+            WHERE work_status_code = #{workStatusCode}
+              AND next_attempt_at <= #{dueAt}
+            ORDER BY next_attempt_at, pricing_crawl_work_item_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    Set<PricingCrawlWorkItem> findDueByWorkStatusCode(
+            @Param("workStatusCode") String workStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+        return findDueByWorkStatusCode(workStatusCode, dueAt, limit, ALL_COLUMNS);
+    }
+
+    @Insert("""
+            INSERT INTO pricing_crawl_work_item (
+                marketplace_listing_id,
+                external_catalog_item_id,
+                source_external_service_id,
+                work_status_code,
+                attempt_count,
+                max_attempts,
+                next_attempt_at,
+                claimed_at,
+                completed_at,
+                source_request_url,
+                source_request_parameters,
+                last_error_message,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceListingId},
+                #{externalCatalogItemId},
+                #{sourceExternalServiceId},
+                #{workStatusCode},
+                COALESCE(#{attemptCount}, 0),
+                COALESCE(#{maxAttempts}, 3),
+                #{nextAttemptAt},
+                #{claimedAt},
+                #{completedAt},
+                #{sourceRequestUrl},
+                #{sourceRequestParameters},
+                #{lastErrorMessage},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_crawl_work_item_id", keyProperty = "pricingCrawlWorkItemId")
+    void insert(PricingCrawlWorkItem pricingCrawlWorkItem);
+
+    @Update("""
+            UPDATE pricing_crawl_work_item
+            SET marketplace_listing_id = #{marketplaceListingId},
+                external_catalog_item_id = #{externalCatalogItemId},
+                source_external_service_id = #{sourceExternalServiceId},
+                work_status_code = #{workStatusCode},
+                attempt_count = #{attemptCount},
+                max_attempts = #{maxAttempts},
+                next_attempt_at = #{nextAttemptAt},
+                claimed_at = #{claimedAt},
+                completed_at = #{completedAt},
+                source_request_url = #{sourceRequestUrl},
+                source_request_parameters = #{sourceRequestParameters},
+                last_error_message = #{lastErrorMessage},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE pricing_crawl_work_item_id = #{pricingCrawlWorkItemId}
+            """)
+    int update(PricingCrawlWorkItem pricingCrawlWorkItem);
+
+    @Delete("DELETE FROM pricing_crawl_work_item WHERE pricing_crawl_work_item_id = #{pricingCrawlWorkItemId}")
+    int delete(Long pricingCrawlWorkItemId);
+
+    @Insert("""
+            INSERT INTO pricing_crawl_work_item (
+                pricing_crawl_work_item_id,
+                marketplace_listing_id,
+                external_catalog_item_id,
+                source_external_service_id,
+                work_status_code,
+                attempt_count,
+                max_attempts,
+                next_attempt_at,
+                claimed_at,
+                completed_at,
+                source_request_url,
+                source_request_parameters,
+                last_error_message,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{pricingCrawlWorkItemId},
+                #{marketplaceListingId},
+                #{externalCatalogItemId},
+                #{sourceExternalServiceId},
+                #{workStatusCode},
+                COALESCE(#{attemptCount}, 0),
+                COALESCE(#{maxAttempts}, 3),
+                #{nextAttemptAt},
+                #{claimedAt},
+                #{completedAt},
+                #{sourceRequestUrl},
+                #{sourceRequestParameters},
+                #{lastErrorMessage},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_listing_id = VALUES(marketplace_listing_id),
+                external_catalog_item_id = VALUES(external_catalog_item_id),
+                source_external_service_id = VALUES(source_external_service_id),
+                work_status_code = VALUES(work_status_code),
+                attempt_count = VALUES(attempt_count),
+                max_attempts = VALUES(max_attempts),
+                next_attempt_at = VALUES(next_attempt_at),
+                claimed_at = VALUES(claimed_at),
+                completed_at = VALUES(completed_at),
+                source_request_url = VALUES(source_request_url),
+                source_request_parameters = VALUES(source_request_parameters),
+                last_error_message = VALUES(last_error_message),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_crawl_work_item_id", keyProperty = "pricingCrawlWorkItemId")
+    void upsert(PricingCrawlWorkItem pricingCrawlWorkItem);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -1,0 +1,196 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PricingDecision;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface PricingDecisionMapper {
+    String ALL_COLUMNS = """
+            pricing_decision_id,
+            marketplace_listing_id,
+            pricing_snapshot_id,
+            algorithm_version,
+            decision_status_code,
+            reason_code,
+            strategy_code,
+            computed_price,
+            final_price,
+            previous_price,
+            currency_code,
+            comparable_count,
+            confidence,
+            source_summary_json,
+            notes,
+            applied_at,
+            created_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision")
+    @ResultMap("pricingDecisionResultMap")
+    Set<PricingDecision> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision WHERE pricing_decision_id = #{pricingDecisionId}")
+    @ResultMap("pricingDecisionResultMap")
+    Optional<PricingDecision> findByPricingDecisionId(Long pricingDecisionId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @ResultMap("pricingDecisionResultMap")
+    Set<PricingDecision> findByMarketplaceListingId(Integer marketplaceListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision WHERE decision_status_code = #{decisionStatusCode}")
+    @ResultMap("pricingDecisionResultMap")
+    Set<PricingDecision> findByDecisionStatusCode(String decisionStatusCode);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision WHERE reason_code = #{reasonCode}")
+    @ResultMap("pricingDecisionResultMap")
+    Set<PricingDecision> findByReasonCode(String reasonCode);
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_decision
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+            ORDER BY created_at DESC, pricing_decision_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("pricingDecisionResultMap")
+    Optional<PricingDecision> findLatestByMarketplaceListingId(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingDecision> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return findLatestByMarketplaceListingId(marketplaceListingId, ALL_COLUMNS);
+    }
+
+    @Insert("""
+            INSERT INTO pricing_decision (
+                marketplace_listing_id,
+                pricing_snapshot_id,
+                algorithm_version,
+                decision_status_code,
+                reason_code,
+                strategy_code,
+                computed_price,
+                final_price,
+                previous_price,
+                currency_code,
+                comparable_count,
+                confidence,
+                source_summary_json,
+                notes,
+                applied_at,
+                created_at
+            )
+            VALUES (
+                #{marketplaceListingId},
+                #{pricingSnapshotId},
+                #{algorithmVersion},
+                #{decisionStatusCode},
+                #{reasonCode},
+                #{strategyCode},
+                #{computedPrice},
+                #{finalPrice},
+                #{previousPrice},
+                #{currencyCode},
+                #{comparableCount},
+                #{confidence},
+                #{sourceSummaryJson},
+                #{notes},
+                #{appliedAt},
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_decision_id", keyProperty = "pricingDecisionId")
+    void insert(PricingDecision pricingDecision);
+
+    @Update("""
+            UPDATE pricing_decision
+            SET marketplace_listing_id = #{marketplaceListingId},
+                pricing_snapshot_id = #{pricingSnapshotId},
+                algorithm_version = #{algorithmVersion},
+                decision_status_code = #{decisionStatusCode},
+                reason_code = #{reasonCode},
+                strategy_code = #{strategyCode},
+                computed_price = #{computedPrice},
+                final_price = #{finalPrice},
+                previous_price = #{previousPrice},
+                currency_code = #{currencyCode},
+                comparable_count = #{comparableCount},
+                confidence = #{confidence},
+                source_summary_json = #{sourceSummaryJson},
+                notes = #{notes},
+                applied_at = #{appliedAt}
+            WHERE pricing_decision_id = #{pricingDecisionId}
+            """)
+    int update(PricingDecision pricingDecision);
+
+    @Delete("DELETE FROM pricing_decision WHERE pricing_decision_id = #{pricingDecisionId}")
+    int delete(Long pricingDecisionId);
+
+    @Insert("""
+            INSERT INTO pricing_decision (
+                pricing_decision_id,
+                marketplace_listing_id,
+                pricing_snapshot_id,
+                algorithm_version,
+                decision_status_code,
+                reason_code,
+                strategy_code,
+                computed_price,
+                final_price,
+                previous_price,
+                currency_code,
+                comparable_count,
+                confidence,
+                source_summary_json,
+                notes,
+                applied_at,
+                created_at
+            )
+            VALUES (
+                #{pricingDecisionId},
+                #{marketplaceListingId},
+                #{pricingSnapshotId},
+                #{algorithmVersion},
+                #{decisionStatusCode},
+                #{reasonCode},
+                #{strategyCode},
+                #{computedPrice},
+                #{finalPrice},
+                #{previousPrice},
+                #{currencyCode},
+                #{comparableCount},
+                #{confidence},
+                #{sourceSummaryJson},
+                #{notes},
+                #{appliedAt},
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_listing_id = VALUES(marketplace_listing_id),
+                pricing_snapshot_id = VALUES(pricing_snapshot_id),
+                algorithm_version = VALUES(algorithm_version),
+                decision_status_code = VALUES(decision_status_code),
+                reason_code = VALUES(reason_code),
+                strategy_code = VALUES(strategy_code),
+                computed_price = VALUES(computed_price),
+                final_price = VALUES(final_price),
+                previous_price = VALUES(previous_price),
+                currency_code = VALUES(currency_code),
+                comparable_count = VALUES(comparable_count),
+                confidence = VALUES(confidence),
+                source_summary_json = VALUES(source_summary_json),
+                notes = VALUES(notes),
+                applied_at = VALUES(applied_at)
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_decision_id", keyProperty = "pricingDecisionId")
+    void upsert(PricingDecision pricingDecision);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
@@ -1,0 +1,167 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PricingSnapshotListing;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface PricingSnapshotListingMapper {
+    String ALL_COLUMNS = """
+            pricing_snapshot_listing_id,
+            pricing_snapshot_id,
+            external_listing_id,
+            seller_name,
+            seller_country_code,
+            item_condition_code,
+            completeness_code,
+            quantity_available,
+            unit_price,
+            currency_code,
+            description,
+            extended_description,
+            source_listing_payload,
+            created_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing")
+    @ResultMap("pricingSnapshotListingResultMap")
+    Set<PricingSnapshotListing> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing WHERE pricing_snapshot_listing_id = #{pricingSnapshotListingId}")
+    @ResultMap("pricingSnapshotListingResultMap")
+    Optional<PricingSnapshotListing> findByPricingSnapshotListingId(Long pricingSnapshotListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing WHERE pricing_snapshot_id = #{pricingSnapshotId}")
+    @ResultMap("pricingSnapshotListingResultMap")
+    Set<PricingSnapshotListing> findByPricingSnapshotId(Long pricingSnapshotId);
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_snapshot_listing
+            WHERE pricing_snapshot_id = #{pricingSnapshotId}
+              AND external_listing_id = #{externalListingId}
+            """)
+    @ResultMap("pricingSnapshotListingResultMap")
+    Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(
+            @Param("pricingSnapshotId") Long pricingSnapshotId,
+            @Param("externalListingId") String externalListingId,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(Long pricingSnapshotId, String externalListingId) {
+        return findByPricingSnapshotIdAndExternalListingId(pricingSnapshotId, externalListingId, ALL_COLUMNS);
+    }
+
+    @Insert("""
+            INSERT INTO pricing_snapshot_listing (
+                pricing_snapshot_id,
+                external_listing_id,
+                seller_name,
+                seller_country_code,
+                item_condition_code,
+                completeness_code,
+                quantity_available,
+                unit_price,
+                currency_code,
+                description,
+                extended_description,
+                source_listing_payload,
+                created_at
+            )
+            VALUES (
+                #{pricingSnapshotId},
+                #{externalListingId},
+                #{sellerName},
+                #{sellerCountryCode},
+                #{itemConditionCode},
+                #{completenessCode},
+                #{quantityAvailable},
+                #{unitPrice},
+                #{currencyCode},
+                #{description},
+                #{extendedDescription},
+                #{sourceListingPayload},
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_snapshot_listing_id", keyProperty = "pricingSnapshotListingId")
+    void insert(PricingSnapshotListing pricingSnapshotListing);
+
+    @Update("""
+            UPDATE pricing_snapshot_listing
+            SET pricing_snapshot_id = #{pricingSnapshotId},
+                external_listing_id = #{externalListingId},
+                seller_name = #{sellerName},
+                seller_country_code = #{sellerCountryCode},
+                item_condition_code = #{itemConditionCode},
+                completeness_code = #{completenessCode},
+                quantity_available = #{quantityAvailable},
+                unit_price = #{unitPrice},
+                currency_code = #{currencyCode},
+                description = #{description},
+                extended_description = #{extendedDescription},
+                source_listing_payload = #{sourceListingPayload}
+            WHERE pricing_snapshot_listing_id = #{pricingSnapshotListingId}
+            """)
+    int update(PricingSnapshotListing pricingSnapshotListing);
+
+    @Delete("DELETE FROM pricing_snapshot_listing WHERE pricing_snapshot_listing_id = #{pricingSnapshotListingId}")
+    int delete(Long pricingSnapshotListingId);
+
+    @Insert("""
+            INSERT INTO pricing_snapshot_listing (
+                pricing_snapshot_listing_id,
+                pricing_snapshot_id,
+                external_listing_id,
+                seller_name,
+                seller_country_code,
+                item_condition_code,
+                completeness_code,
+                quantity_available,
+                unit_price,
+                currency_code,
+                description,
+                extended_description,
+                source_listing_payload,
+                created_at
+            )
+            VALUES (
+                #{pricingSnapshotListingId},
+                #{pricingSnapshotId},
+                #{externalListingId},
+                #{sellerName},
+                #{sellerCountryCode},
+                #{itemConditionCode},
+                #{completenessCode},
+                #{quantityAvailable},
+                #{unitPrice},
+                #{currencyCode},
+                #{description},
+                #{extendedDescription},
+                #{sourceListingPayload},
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                pricing_snapshot_id = VALUES(pricing_snapshot_id),
+                external_listing_id = VALUES(external_listing_id),
+                seller_name = VALUES(seller_name),
+                seller_country_code = VALUES(seller_country_code),
+                item_condition_code = VALUES(item_condition_code),
+                completeness_code = VALUES(completeness_code),
+                quantity_available = VALUES(quantity_available),
+                unit_price = VALUES(unit_price),
+                currency_code = VALUES(currency_code),
+                description = VALUES(description),
+                extended_description = VALUES(extended_description),
+                source_listing_payload = VALUES(source_listing_payload)
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_snapshot_listing_id", keyProperty = "pricingSnapshotListingId")
+    void upsert(PricingSnapshotListing pricingSnapshotListing);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
@@ -9,6 +9,7 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -28,6 +29,22 @@ public interface PricingSnapshotListingMapper {
             extended_description,
             source_listing_payload,
             created_at
+            """;
+    String QUALIFIED_COLUMNS = """
+            psl.pricing_snapshot_listing_id,
+            psl.pricing_snapshot_id,
+            psl.external_listing_id,
+            psl.seller_name,
+            psl.seller_country_code,
+            psl.item_condition_code,
+            psl.completeness_code,
+            psl.quantity_available,
+            psl.unit_price,
+            psl.currency_code,
+            psl.description,
+            psl.extended_description,
+            psl.source_listing_payload,
+            psl.created_at
             """;
 
     @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing")
@@ -57,6 +74,29 @@ public interface PricingSnapshotListingMapper {
 
     default Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(Long pricingSnapshotId, String externalListingId) {
         return findByPricingSnapshotIdAndExternalListingId(pricingSnapshotId, externalListingId, ALL_COLUMNS);
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_snapshot_listing psl
+            JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = psl.pricing_snapshot_id
+            WHERE psl.pricing_snapshot_id = #{pricingSnapshotId}
+              AND psl.item_condition_code = ps.item_condition_code
+              AND (
+                    psl.completeness_code = ps.completeness_code
+                    OR (psl.completeness_code IS NULL AND ps.completeness_code IS NULL)
+                  )
+            ORDER BY psl.unit_price, psl.pricing_snapshot_listing_id
+            """)
+    @ResultMap("pricingSnapshotListingResultMap")
+    List<PricingSnapshotListing> findExactComparablesByPricingSnapshotId(
+            @Param("pricingSnapshotId") Long pricingSnapshotId,
+            @Param("columns") String columns
+    );
+
+    default List<PricingSnapshotListing> findExactComparablesByPricingSnapshotId(Long pricingSnapshotId) {
+        return findExactComparablesByPricingSnapshotId(pricingSnapshotId, QUALIFIED_COLUMNS);
     }
 
     @Insert("""

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.java
@@ -15,22 +15,6 @@ import java.util.Set;
 
 public interface PricingSnapshotListingMapper {
     String ALL_COLUMNS = """
-            pricing_snapshot_listing_id,
-            pricing_snapshot_id,
-            external_listing_id,
-            seller_name,
-            seller_country_code,
-            item_condition_code,
-            completeness_code,
-            quantity_available,
-            unit_price,
-            currency_code,
-            description,
-            extended_description,
-            source_listing_payload,
-            created_at
-            """;
-    String QUALIFIED_COLUMNS = """
             psl.pricing_snapshot_listing_id,
             psl.pricing_snapshot_id,
             psl.external_listing_id,
@@ -47,23 +31,23 @@ public interface PricingSnapshotListingMapper {
             psl.created_at
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing")
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing psl")
     @ResultMap("pricingSnapshotListingResultMap")
     Set<PricingSnapshotListing> findAll();
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing WHERE pricing_snapshot_listing_id = #{pricingSnapshotListingId}")
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing psl WHERE psl.pricing_snapshot_listing_id = #{pricingSnapshotListingId}")
     @ResultMap("pricingSnapshotListingResultMap")
     Optional<PricingSnapshotListing> findByPricingSnapshotListingId(Long pricingSnapshotListingId);
 
-    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing WHERE pricing_snapshot_id = #{pricingSnapshotId}")
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot_listing psl WHERE psl.pricing_snapshot_id = #{pricingSnapshotId}")
     @ResultMap("pricingSnapshotListingResultMap")
     Set<PricingSnapshotListing> findByPricingSnapshotId(Long pricingSnapshotId);
 
     @Select("""
             SELECT ${columns}
-            FROM pricing_snapshot_listing
-            WHERE pricing_snapshot_id = #{pricingSnapshotId}
-              AND external_listing_id = #{externalListingId}
+            FROM pricing_snapshot_listing psl
+            WHERE psl.pricing_snapshot_id = #{pricingSnapshotId}
+              AND psl.external_listing_id = #{externalListingId}
             """)
     @ResultMap("pricingSnapshotListingResultMap")
     Optional<PricingSnapshotListing> findByPricingSnapshotIdAndExternalListingId(
@@ -96,7 +80,7 @@ public interface PricingSnapshotListingMapper {
     );
 
     default List<PricingSnapshotListing> findExactComparablesByPricingSnapshotId(Long pricingSnapshotId) {
-        return findExactComparablesByPricingSnapshotId(pricingSnapshotId, QUALIFIED_COLUMNS);
+        return findExactComparablesByPricingSnapshotId(pricingSnapshotId, ALL_COLUMNS);
     }
 
     @Insert("""

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.java
@@ -64,6 +64,72 @@ public interface PricingSnapshotMapper {
         return findLatestByMarketplaceListingId(marketplaceListingId, ALL_COLUMNS);
     }
 
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_snapshot
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+              AND item_condition_code = #{itemConditionCode}
+              AND (
+                    completeness_code = #{completenessCode}
+                    OR (completeness_code IS NULL AND #{completenessCode} IS NULL)
+                  )
+            ORDER BY captured_at DESC, pricing_snapshot_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("pricingSnapshotResultMap")
+    Optional<PricingSnapshot> findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("itemConditionCode") String itemConditionCode,
+            @Param("completenessCode") String completenessCode,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingSnapshot> findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+            Integer marketplaceListingId,
+            String itemConditionCode,
+            String completenessCode
+    ) {
+        return findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+                marketplaceListingId,
+                itemConditionCode,
+                completenessCode,
+                ALL_COLUMNS
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_snapshot
+            WHERE external_catalog_item_id = #{externalCatalogItemId}
+              AND item_condition_code = #{itemConditionCode}
+              AND (
+                    completeness_code = #{completenessCode}
+                    OR (completeness_code IS NULL AND #{completenessCode} IS NULL)
+                  )
+            ORDER BY captured_at DESC, pricing_snapshot_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("pricingSnapshotResultMap")
+    Optional<PricingSnapshot> findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+            @Param("externalCatalogItemId") Integer externalCatalogItemId,
+            @Param("itemConditionCode") String itemConditionCode,
+            @Param("completenessCode") String completenessCode,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingSnapshot> findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+            Integer externalCatalogItemId,
+            String itemConditionCode,
+            String completenessCode
+    ) {
+        return findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+                externalCatalogItemId,
+                itemConditionCode,
+                completenessCode,
+                ALL_COLUMNS
+        );
+    }
+
     @Insert("""
             INSERT INTO pricing_snapshot (
                 pricing_crawl_work_item_id,

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.java
@@ -1,0 +1,178 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PricingSnapshot;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface PricingSnapshotMapper {
+    String ALL_COLUMNS = """
+            pricing_snapshot_id,
+            pricing_crawl_work_item_id,
+            marketplace_listing_id,
+            external_catalog_item_id,
+            source_external_service_id,
+            source_item_key,
+            source_unique_key,
+            item_condition_code,
+            completeness_code,
+            source_request_url,
+            source_request_parameters,
+            raw_payload_hash,
+            comparable_count,
+            captured_at,
+            created_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot")
+    @ResultMap("pricingSnapshotResultMap")
+    Set<PricingSnapshot> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot WHERE pricing_snapshot_id = #{pricingSnapshotId}")
+    @ResultMap("pricingSnapshotResultMap")
+    Optional<PricingSnapshot> findByPricingSnapshotId(Long pricingSnapshotId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @ResultMap("pricingSnapshotResultMap")
+    Set<PricingSnapshot> findByMarketplaceListingId(Integer marketplaceListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_snapshot WHERE external_catalog_item_id = #{externalCatalogItemId}")
+    @ResultMap("pricingSnapshotResultMap")
+    Set<PricingSnapshot> findByExternalCatalogItemId(Integer externalCatalogItemId);
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_snapshot
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+            ORDER BY captured_at DESC, pricing_snapshot_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("pricingSnapshotResultMap")
+    Optional<PricingSnapshot> findLatestByMarketplaceListingId(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingSnapshot> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return findLatestByMarketplaceListingId(marketplaceListingId, ALL_COLUMNS);
+    }
+
+    @Insert("""
+            INSERT INTO pricing_snapshot (
+                pricing_crawl_work_item_id,
+                marketplace_listing_id,
+                external_catalog_item_id,
+                source_external_service_id,
+                source_item_key,
+                source_unique_key,
+                item_condition_code,
+                completeness_code,
+                source_request_url,
+                source_request_parameters,
+                raw_payload_hash,
+                comparable_count,
+                captured_at,
+                created_at
+            )
+            VALUES (
+                #{pricingCrawlWorkItemId},
+                #{marketplaceListingId},
+                #{externalCatalogItemId},
+                #{sourceExternalServiceId},
+                #{sourceItemKey},
+                #{sourceUniqueKey},
+                #{itemConditionCode},
+                #{completenessCode},
+                #{sourceRequestUrl},
+                #{sourceRequestParameters},
+                #{rawPayloadHash},
+                #{comparableCount},
+                COALESCE(#{capturedAt}, CURRENT_TIMESTAMP),
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_snapshot_id", keyProperty = "pricingSnapshotId")
+    void insert(PricingSnapshot pricingSnapshot);
+
+    @Update("""
+            UPDATE pricing_snapshot
+            SET pricing_crawl_work_item_id = #{pricingCrawlWorkItemId},
+                marketplace_listing_id = #{marketplaceListingId},
+                external_catalog_item_id = #{externalCatalogItemId},
+                source_external_service_id = #{sourceExternalServiceId},
+                source_item_key = #{sourceItemKey},
+                source_unique_key = #{sourceUniqueKey},
+                item_condition_code = #{itemConditionCode},
+                completeness_code = #{completenessCode},
+                source_request_url = #{sourceRequestUrl},
+                source_request_parameters = #{sourceRequestParameters},
+                raw_payload_hash = #{rawPayloadHash},
+                comparable_count = #{comparableCount},
+                captured_at = #{capturedAt}
+            WHERE pricing_snapshot_id = #{pricingSnapshotId}
+            """)
+    int update(PricingSnapshot pricingSnapshot);
+
+    @Delete("DELETE FROM pricing_snapshot WHERE pricing_snapshot_id = #{pricingSnapshotId}")
+    int delete(Long pricingSnapshotId);
+
+    @Insert("""
+            INSERT INTO pricing_snapshot (
+                pricing_snapshot_id,
+                pricing_crawl_work_item_id,
+                marketplace_listing_id,
+                external_catalog_item_id,
+                source_external_service_id,
+                source_item_key,
+                source_unique_key,
+                item_condition_code,
+                completeness_code,
+                source_request_url,
+                source_request_parameters,
+                raw_payload_hash,
+                comparable_count,
+                captured_at,
+                created_at
+            )
+            VALUES (
+                #{pricingSnapshotId},
+                #{pricingCrawlWorkItemId},
+                #{marketplaceListingId},
+                #{externalCatalogItemId},
+                #{sourceExternalServiceId},
+                #{sourceItemKey},
+                #{sourceUniqueKey},
+                #{itemConditionCode},
+                #{completenessCode},
+                #{sourceRequestUrl},
+                #{sourceRequestParameters},
+                #{rawPayloadHash},
+                #{comparableCount},
+                COALESCE(#{capturedAt}, CURRENT_TIMESTAMP),
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                pricing_crawl_work_item_id = VALUES(pricing_crawl_work_item_id),
+                marketplace_listing_id = VALUES(marketplace_listing_id),
+                external_catalog_item_id = VALUES(external_catalog_item_id),
+                source_external_service_id = VALUES(source_external_service_id),
+                source_item_key = VALUES(source_item_key),
+                source_unique_key = VALUES(source_unique_key),
+                item_condition_code = VALUES(item_condition_code),
+                completeness_code = VALUES(completeness_code),
+                source_request_url = VALUES(source_request_url),
+                source_request_parameters = VALUES(source_request_parameters),
+                raw_payload_hash = VALUES(raw_payload_hash),
+                comparable_count = VALUES(comparable_count),
+                captured_at = VALUES(captured_at)
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_snapshot_id", keyProperty = "pricingSnapshotId")
+    void upsert(PricingSnapshot pricingSnapshot);
+}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper">
+  <resultMap type="io.legohunter.data.dto.PricingCrawlWorkItem" id="pricingCrawlWorkItemResultMap">
+    <id     column="pricing_crawl_work_item_id" property="pricingCrawlWorkItemId"/>
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="external_catalog_item_id"   property="externalCatalogItemId"/>
+    <result column="source_external_service_id" property="sourceExternalServiceId"/>
+    <result column="work_status_code"           property="workStatusCode"/>
+    <result column="attempt_count"              property="attemptCount"/>
+    <result column="max_attempts"               property="maxAttempts"/>
+    <result column="next_attempt_at"            property="nextAttemptAt"/>
+    <result column="claimed_at"                 property="claimedAt"/>
+    <result column="completed_at"               property="completedAt"/>
+    <result column="source_request_url"         property="sourceRequestUrl"/>
+    <result column="source_request_parameters"  property="sourceRequestParameters"/>
+    <result column="last_error_message"         property="lastErrorMessage"/>
+    <result column="created_at"                 property="createdAt"/>
+    <result column="updated_at"                 property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
@@ -1,0 +1,22 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PricingDecisionMapper">
+  <resultMap type="io.legohunter.data.dto.PricingDecision" id="pricingDecisionResultMap">
+    <id     column="pricing_decision_id"    property="pricingDecisionId"/>
+    <result column="marketplace_listing_id" property="marketplaceListingId"/>
+    <result column="pricing_snapshot_id"    property="pricingSnapshotId"/>
+    <result column="algorithm_version"      property="algorithmVersion"/>
+    <result column="decision_status_code"   property="decisionStatusCode"/>
+    <result column="reason_code"            property="reasonCode"/>
+    <result column="strategy_code"          property="strategyCode"/>
+    <result column="computed_price"         property="computedPrice"/>
+    <result column="final_price"            property="finalPrice"/>
+    <result column="previous_price"         property="previousPrice"/>
+    <result column="currency_code"          property="currencyCode"/>
+    <result column="comparable_count"       property="comparableCount"/>
+    <result column="confidence"             property="confidence"/>
+    <result column="source_summary_json"    property="sourceSummaryJson"/>
+    <result column="notes"                  property="notes"/>
+    <result column="applied_at"             property="appliedAt"/>
+    <result column="created_at"             property="createdAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingSnapshotListingMapper.xml
@@ -1,0 +1,19 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PricingSnapshotListingMapper">
+  <resultMap type="io.legohunter.data.dto.PricingSnapshotListing" id="pricingSnapshotListingResultMap">
+    <id     column="pricing_snapshot_listing_id" property="pricingSnapshotListingId"/>
+    <result column="pricing_snapshot_id"         property="pricingSnapshotId"/>
+    <result column="external_listing_id"         property="externalListingId"/>
+    <result column="seller_name"                 property="sellerName"/>
+    <result column="seller_country_code"         property="sellerCountryCode"/>
+    <result column="item_condition_code"         property="itemConditionCode"/>
+    <result column="completeness_code"           property="completenessCode"/>
+    <result column="quantity_available"          property="quantityAvailable"/>
+    <result column="unit_price"                  property="unitPrice"/>
+    <result column="currency_code"               property="currencyCode"/>
+    <result column="description"                 property="description"/>
+    <result column="extended_description"        property="extendedDescription"/>
+    <result column="source_listing_payload"      property="sourceListingPayload"/>
+    <result column="created_at"                  property="createdAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingSnapshotMapper.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PricingSnapshotMapper">
+  <resultMap type="io.legohunter.data.dto.PricingSnapshot" id="pricingSnapshotResultMap">
+    <id     column="pricing_snapshot_id"        property="pricingSnapshotId"/>
+    <result column="pricing_crawl_work_item_id" property="pricingCrawlWorkItemId"/>
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="external_catalog_item_id"   property="externalCatalogItemId"/>
+    <result column="source_external_service_id" property="sourceExternalServiceId"/>
+    <result column="source_item_key"            property="sourceItemKey"/>
+    <result column="source_unique_key"          property="sourceUniqueKey"/>
+    <result column="item_condition_code"        property="itemConditionCode"/>
+    <result column="completeness_code"          property="completenessCode"/>
+    <result column="source_request_url"         property="sourceRequestUrl"/>
+    <result column="source_request_parameters"  property="sourceRequestParameters"/>
+    <result column="raw_payload_hash"           property="rawPayloadHash"/>
+    <result column="comparable_count"           property="comparableCount"/>
+    <result column="captured_at"                property="capturedAt"/>
+    <result column="created_at"                 property="createdAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -18,6 +18,10 @@ import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventoryPhoto;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.Party;
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingSnapshot;
+import io.legohunter.data.dto.PricingSnapshotListing;
 import io.legohunter.data.dto.TransactionPlatform;
 import io.legohunter.data.dto.TransactionType;
 import io.legohunter.data.dto.Transactions;
@@ -53,6 +57,10 @@ abstract class MapperTestSupport {
     @Autowired BricklinkMarketplaceListingMapper bricklinkMarketplaceListingMapper;
     @Autowired EbayMarketplaceListingMapper ebayMarketplaceListingMapper;
     @Autowired EbayListingItemSpecificMapper ebayListingItemSpecificMapper;
+    @Autowired PricingCrawlWorkItemMapper pricingCrawlWorkItemMapper;
+    @Autowired PricingSnapshotMapper pricingSnapshotMapper;
+    @Autowired PricingSnapshotListingMapper pricingSnapshotListingMapper;
+    @Autowired PricingDecisionMapper pricingDecisionMapper;
     @Autowired PartyMapper partyMapper;
     @Autowired PaymentPlatformMapper paymentPlatformMapper;
     @Autowired TransactionCostMapper transactionCostMapper;
@@ -285,6 +293,85 @@ abstract class MapperTestSupport {
                 .marketplaceListingId(marketplaceListingId)
                 .name(name)
                 .value(value)
+                .build();
+    }
+
+    PricingCrawlWorkItem pricingCrawlWorkItem(
+            Integer marketplaceListingId,
+            Integer externalCatalogItemId,
+            Integer sourceExternalServiceId,
+            ZonedDateTime nextAttemptAt
+    ) {
+        return PricingCrawlWorkItem.builder()
+                .marketplaceListingId(marketplaceListingId)
+                .externalCatalogItemId(externalCatalogItemId)
+                .sourceExternalServiceId(sourceExternalServiceId)
+                .workStatusCode("PENDING")
+                .attemptCount(0)
+                .maxAttempts(3)
+                .nextAttemptAt(nextAttemptAt)
+                .sourceRequestUrl("https://bricklink.example/ajax/clone/catalogifs.ajax")
+                .sourceRequestParameters("itemid=4997&rpp=500&iconly=0")
+                .build();
+    }
+
+    PricingSnapshot pricingSnapshot(
+            Long pricingCrawlWorkItemId,
+            Integer marketplaceListingId,
+            Integer externalCatalogItemId,
+            Integer sourceExternalServiceId,
+            ZonedDateTime capturedAt
+    ) {
+        return PricingSnapshot.builder()
+                .pricingCrawlWorkItemId(pricingCrawlWorkItemId)
+                .marketplaceListingId(marketplaceListingId)
+                .externalCatalogItemId(externalCatalogItemId)
+                .sourceExternalServiceId(sourceExternalServiceId)
+                .sourceItemKey("6390-1")
+                .sourceUniqueKey("4997")
+                .itemConditionCode("U")
+                .completenessCode("COMPLETE")
+                .sourceRequestUrl("https://bricklink.example/ajax/clone/catalogifs.ajax")
+                .sourceRequestParameters("itemid=4997&rpp=500&iconly=0")
+                .rawPayloadHash("payload-hash")
+                .comparableCount(2)
+                .capturedAt(capturedAt)
+                .build();
+    }
+
+    PricingSnapshotListing pricingSnapshotListing(Long pricingSnapshotId, String externalListingId) {
+        return PricingSnapshotListing.builder()
+                .pricingSnapshotId(pricingSnapshotId)
+                .externalListingId(externalListingId)
+                .sellerName("seller-one")
+                .sellerCountryCode("US")
+                .itemConditionCode("U")
+                .completenessCode("COMPLETE")
+                .quantityAvailable(1)
+                .unitPrice(new BigDecimal("220.00"))
+                .currencyCode("USD")
+                .description("Main Street")
+                .extendedDescription("Complete with box")
+                .sourceListingPayload("{\"listing\":\"" + externalListingId + "\"}")
+                .build();
+    }
+
+    PricingDecision pricingDecision(Integer marketplaceListingId, Long pricingSnapshotId) {
+        return PricingDecision.builder()
+                .marketplaceListingId(marketplaceListingId)
+                .pricingSnapshotId(pricingSnapshotId)
+                .algorithmVersion("BRICKLINK_COMPETITIVE_V1")
+                .decisionStatusCode("PROPOSED")
+                .reasonCode("MATCHED_LOWEST_COMPETITOR")
+                .strategyCode("COMPETITIVE")
+                .computedPrice(new BigDecimal("219.00"))
+                .finalPrice(new BigDecimal("219.00"))
+                .previousPrice(new BigDecimal("225.00"))
+                .currencyCode("USD")
+                .comparableCount(2)
+                .confidence(new BigDecimal("0.7500"))
+                .sourceSummaryJson("{\"snapshot\":true}")
+                .notes("Initial recommendation")
                 .build();
     }
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -39,6 +39,10 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
                 .hasSize(1)
                 .first()
                 .satisfies(this::assertHydratedCatalogItem);
+        assertThat(marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .hasSize(1)
+                .first()
+                .satisfies(found -> assertThat(found.getExternalListingId()).isEqualTo("BL-1"));
         assertThat(marketplaceListingMapper.findAll()).hasSize(1);
 
         listing.setListingStatusCode("ENDED");

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -123,6 +123,79 @@ class PricingPlaneMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void pricingSnapshotListingsCanBeQueriedAsExactConditionAndCompletenessComparables() {
+        PricingFixture fixture = pricingFixture("pricing-exact-comparables");
+        PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);
+        PricingSnapshot olderSealedSnapshot = pricingSnapshot(
+                workItem.getPricingCrawlWorkItemId(),
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                SNAPSHOT_AT.minusHours(1)
+        );
+        olderSealedSnapshot.setItemConditionCode("N");
+        olderSealedSnapshot.setCompletenessCode("S");
+        pricingSnapshotMapper.insert(olderSealedSnapshot);
+
+        PricingSnapshot latestSealedSnapshot = pricingSnapshot(
+                workItem.getPricingCrawlWorkItemId(),
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                SNAPSHOT_AT
+        );
+        latestSealedSnapshot.setItemConditionCode("N");
+        latestSealedSnapshot.setCompletenessCode("S");
+        pricingSnapshotMapper.insert(latestSealedSnapshot);
+
+        PricingSnapshot latestCompleteSnapshot = pricingSnapshot(
+                workItem.getPricingCrawlWorkItemId(),
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                SNAPSHOT_AT.plusHours(1)
+        );
+        latestCompleteSnapshot.setItemConditionCode("N");
+        latestCompleteSnapshot.setCompletenessCode("C");
+        pricingSnapshotMapper.insert(latestCompleteSnapshot);
+
+        PricingSnapshotListing exactHigh = pricingSnapshotListing(latestSealedSnapshot.getPricingSnapshotId(), "exact-high");
+        exactHigh.setItemConditionCode("N");
+        exactHigh.setCompletenessCode("S");
+        exactHigh.setUnitPrice(new BigDecimal("25.00"));
+        pricingSnapshotListingMapper.insert(exactHigh);
+
+        PricingSnapshotListing exactLow = pricingSnapshotListing(latestSealedSnapshot.getPricingSnapshotId(), "exact-low");
+        exactLow.setItemConditionCode("N");
+        exactLow.setCompletenessCode("S");
+        exactLow.setUnitPrice(new BigDecimal("20.00"));
+        pricingSnapshotListingMapper.insert(exactLow);
+
+        PricingSnapshotListing completenessMismatch = pricingSnapshotListing(latestSealedSnapshot.getPricingSnapshotId(), "complete-mismatch");
+        completenessMismatch.setItemConditionCode("N");
+        completenessMismatch.setCompletenessCode("C");
+        completenessMismatch.setUnitPrice(new BigDecimal("15.00"));
+        pricingSnapshotListingMapper.insert(completenessMismatch);
+
+        PricingSnapshotListing conditionMismatch = pricingSnapshotListing(latestSealedSnapshot.getPricingSnapshotId(), "condition-mismatch");
+        conditionMismatch.setItemConditionCode("U");
+        conditionMismatch.setCompletenessCode("S");
+        conditionMismatch.setUnitPrice(new BigDecimal("10.00"));
+        pricingSnapshotListingMapper.insert(conditionMismatch);
+
+        assertThat(pricingSnapshotMapper.findLatestByMarketplaceListingIdAndConditionAndCompleteness(
+                fixture.listing().getMarketplaceListingId(), "N", "S"
+        )).map(PricingSnapshot::getPricingSnapshotId).contains(latestSealedSnapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotMapper.findLatestByExternalCatalogItemIdAndConditionAndCompleteness(
+                fixture.catalogItem().getExternalCatalogItemId(), "N", "S"
+        )).map(PricingSnapshot::getPricingSnapshotId).contains(latestSealedSnapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotId(latestSealedSnapshot.getPricingSnapshotId())).hasSize(4);
+        assertThat(pricingSnapshotListingMapper.findExactComparablesByPricingSnapshotId(latestSealedSnapshot.getPricingSnapshotId()))
+                .extracting(PricingSnapshotListing::getExternalListingId)
+                .containsExactly("exact-low", "exact-high");
+    }
+
+    @Test
     void pricingDecisionSupportsCrudAndReasonLookups() {
         PricingFixture fixture = pricingFixture("pricing-decision");
         PricingSnapshot snapshot = insertedSnapshot(fixture);

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -1,0 +1,205 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.ExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingSnapshot;
+import io.legohunter.data.dto.PricingSnapshotListing;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class PricingPlaneMapperTest extends MapperTestSupport {
+    private static final ZonedDateTime CRAWL_AT = ZonedDateTime.parse("2026-06-18T14:00:00Z");
+    private static final ZonedDateTime SNAPSHOT_AT = ZonedDateTime.parse("2026-06-18T15:00:00Z");
+
+    @Test
+    void pricingCrawlWorkItemSupportsCrudAndDueLookup() {
+        PricingFixture fixture = pricingFixture("pricing-work-item");
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItem(
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT
+        );
+
+        pricingCrawlWorkItemMapper.insert(workItem);
+        workItem.setWorkStatusCode("CLAIMED");
+        workItem.setAttemptCount(1);
+        workItem.setClaimedAt(CRAWL_AT.plusMinutes(1));
+        assertThat(pricingCrawlWorkItemMapper.update(workItem)).isOne();
+
+        assertThat(pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getWorkStatusCode()).isEqualTo("CLAIMED");
+                    assertThat(found.getAttemptCount()).isOne();
+                });
+        assertThat(pricingCrawlWorkItemMapper.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingCrawlWorkItemMapper.findByWorkStatusCode("CLAIMED")).hasSize(1);
+        assertThat(pricingCrawlWorkItemMapper.findDueByWorkStatusCode("CLAIMED", CRAWL_AT.plusMinutes(2), 10)).hasSize(1);
+        assertThat(pricingCrawlWorkItemMapper.findDueByWorkStatusCode("CLAIMED", CRAWL_AT.minusMinutes(1), 10)).isEmpty();
+        assertThat(pricingCrawlWorkItemMapper.findAll()).hasSize(1);
+
+        workItem.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.upsert(workItem);
+        assertThat(pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> assertThat(found.getWorkStatusCode()).isEqualTo("SUCCEEDED"));
+
+        assertThat(pricingCrawlWorkItemMapper.delete(workItem.getPricingCrawlWorkItemId())).isOne();
+        assertThat(pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId())).isEmpty();
+    }
+
+    @Test
+    void pricingSnapshotSupportsCrudAndLatestLookup() {
+        PricingFixture fixture = pricingFixture("pricing-snapshot");
+        PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);
+        PricingSnapshot snapshot = pricingSnapshot(
+                workItem.getPricingCrawlWorkItemId(),
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                SNAPSHOT_AT
+        );
+
+        pricingSnapshotMapper.insert(snapshot);
+        snapshot.setComparableCount(3);
+        snapshot.setRawPayloadHash("updated-hash");
+        assertThat(pricingSnapshotMapper.update(snapshot)).isOne();
+
+        assertThat(pricingSnapshotMapper.findByPricingSnapshotId(snapshot.getPricingSnapshotId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getComparableCount()).isEqualTo(3);
+                    assertThat(found.getRawPayloadHash()).isEqualTo("updated-hash");
+                });
+        assertThat(pricingSnapshotMapper.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingSnapshotMapper.findByExternalCatalogItemId(fixture.catalogItem().getExternalCatalogItemId())).hasSize(1);
+        assertThat(pricingSnapshotMapper.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
+                .map(PricingSnapshot::getPricingSnapshotId)
+                .contains(snapshot.getPricingSnapshotId());
+        assertThat(pricingSnapshotMapper.findAll()).hasSize(1);
+
+        snapshot.setComparableCount(4);
+        pricingSnapshotMapper.upsert(snapshot);
+        assertThat(pricingSnapshotMapper.findByPricingSnapshotId(snapshot.getPricingSnapshotId()))
+                .hasValueSatisfying(found -> assertThat(found.getComparableCount()).isEqualTo(4));
+
+        assertThat(pricingSnapshotMapper.delete(snapshot.getPricingSnapshotId())).isOne();
+        assertThat(pricingSnapshotMapper.findByPricingSnapshotId(snapshot.getPricingSnapshotId())).isEmpty();
+    }
+
+    @Test
+    void pricingSnapshotListingSupportsCrudAndSnapshotLookup() {
+        PricingFixture fixture = pricingFixture("pricing-snapshot-listing");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingSnapshotListing listing = pricingSnapshotListing(snapshot.getPricingSnapshotId(), "remote-listing-1");
+
+        pricingSnapshotListingMapper.insert(listing);
+        listing.setUnitPrice(new BigDecimal("215.00"));
+        listing.setSellerCountryCode("CA");
+        assertThat(pricingSnapshotListingMapper.update(listing)).isOne();
+
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotListingId(listing.getPricingSnapshotListingId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getUnitPrice()).isEqualByComparingTo("215.00");
+                    assertThat(found.getSellerCountryCode()).isEqualTo("CA");
+                });
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotId(snapshot.getPricingSnapshotId())).hasSize(1);
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotIdAndExternalListingId(snapshot.getPricingSnapshotId(), "remote-listing-1")).isPresent();
+        assertThat(pricingSnapshotListingMapper.findAll()).hasSize(1);
+
+        listing.setQuantityAvailable(2);
+        pricingSnapshotListingMapper.upsert(listing);
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotListingId(listing.getPricingSnapshotListingId()))
+                .hasValueSatisfying(found -> assertThat(found.getQuantityAvailable()).isEqualTo(2));
+
+        assertThat(pricingSnapshotListingMapper.delete(listing.getPricingSnapshotListingId())).isOne();
+        assertThat(pricingSnapshotListingMapper.findByPricingSnapshotListingId(listing.getPricingSnapshotListingId())).isEmpty();
+    }
+
+    @Test
+    void pricingDecisionSupportsCrudAndReasonLookups() {
+        PricingFixture fixture = pricingFixture("pricing-decision");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingDecision decision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+
+        pricingDecisionMapper.insert(decision);
+        decision.setDecisionStatusCode("APPLIED");
+        decision.setAppliedAt(SNAPSHOT_AT.plusMinutes(5));
+        decision.setFinalPrice(new BigDecimal("218.50"));
+        assertThat(pricingDecisionMapper.update(decision)).isOne();
+
+        assertThat(pricingDecisionMapper.findByPricingDecisionId(decision.getPricingDecisionId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getDecisionStatusCode()).isEqualTo("APPLIED");
+                    assertThat(found.getFinalPrice()).isEqualByComparingTo("218.50");
+                });
+        assertThat(pricingDecisionMapper.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingDecisionMapper.findByDecisionStatusCode("APPLIED")).hasSize(1);
+        assertThat(pricingDecisionMapper.findByReasonCode("MATCHED_LOWEST_COMPETITOR")).hasSize(1);
+        assertThat(pricingDecisionMapper.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
+                .map(PricingDecision::getPricingDecisionId)
+                .contains(decision.getPricingDecisionId());
+        assertThat(pricingDecisionMapper.findAll()).hasSize(1);
+
+        decision.setReasonCode("FIXED_PRICE_OVERRIDE");
+        pricingDecisionMapper.upsert(decision);
+        assertThat(pricingDecisionMapper.findByPricingDecisionId(decision.getPricingDecisionId()))
+                .hasValueSatisfying(found -> assertThat(found.getReasonCode()).isEqualTo("FIXED_PRICE_OVERRIDE"));
+
+        assertThat(pricingDecisionMapper.delete(decision.getPricingDecisionId())).isOne();
+        assertThat(pricingDecisionMapper.findByPricingDecisionId(decision.getPricingDecisionId())).isEmpty();
+    }
+
+    private PricingSnapshot insertedSnapshot(PricingFixture fixture) {
+        PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);
+        PricingSnapshot snapshot = pricingSnapshot(
+                workItem.getPricingCrawlWorkItemId(),
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                SNAPSHOT_AT
+        );
+        pricingSnapshotMapper.insert(snapshot);
+        return snapshot;
+    }
+
+    private PricingCrawlWorkItem insertedWorkItem(PricingFixture fixture, ZonedDateTime nextAttemptAt) {
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItem(
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                nextAttemptAt
+        );
+        pricingCrawlWorkItemMapper.insert(workItem);
+        return workItem;
+    }
+
+    private PricingFixture pricingFixture(String key) {
+        seedExternalCatalog();
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "MARKETPLACE_LISTING"));
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "PRICE_GUIDE"));
+        ExternalCatalogItem catalogItem = insertExternalCatalogItem(key);
+        ItemInventory inventory = insertItemInventory("inventory-" + key);
+        MarketplaceListing listing = marketplaceListing(
+                inventory.getItemInventoryId(),
+                catalogItem.getExternalCatalogItemId(),
+                2,
+                "listing-" + key
+        );
+        marketplaceListingMapper.insert(listing);
+        return new PricingFixture(catalogItem, inventory, listing);
+    }
+
+    private record PricingFixture(
+            ExternalCatalogItem catalogItem,
+            ItemInventory inventory,
+            MarketplaceListing listing
+    ) {
+    }
+}

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,10 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS pricing_decision;
+DROP TABLE IF EXISTS pricing_snapshot_listing;
+DROP TABLE IF EXISTS pricing_snapshot;
+DROP TABLE IF EXISTS pricing_crawl_work_item;
 DROP TABLE IF EXISTS ebay_listing_item_specific;
 DROP TABLE IF EXISTS ebay_marketplace_listing;
 DROP TABLE IF EXISTS bricklink_marketplace_listing;
@@ -192,6 +196,79 @@ CREATE TABLE marketplace_listing (
     ended_at TIMESTAMP,
     last_synchronized_at TIMESTAMP,
     UNIQUE (listing_external_service_id, external_listing_id)
+);
+
+CREATE TABLE pricing_crawl_work_item (
+    pricing_crawl_work_item_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    external_catalog_item_id INT NOT NULL,
+    source_external_service_id INT NOT NULL,
+    work_status_code VARCHAR(32) NOT NULL,
+    attempt_count INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    next_attempt_at TIMESTAMP NOT NULL,
+    claimed_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    source_request_url VARCHAR(1024),
+    source_request_parameters CLOB,
+    last_error_message CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_snapshot (
+    pricing_snapshot_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    pricing_crawl_work_item_id BIGINT,
+    marketplace_listing_id INT,
+    external_catalog_item_id INT NOT NULL,
+    source_external_service_id INT NOT NULL,
+    source_item_key VARCHAR(255) NOT NULL,
+    source_unique_key VARCHAR(255),
+    item_condition_code VARCHAR(32),
+    completeness_code VARCHAR(64),
+    source_request_url VARCHAR(1024),
+    source_request_parameters CLOB,
+    raw_payload_hash VARCHAR(64),
+    comparable_count INT,
+    captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_snapshot_listing (
+    pricing_snapshot_listing_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    pricing_snapshot_id BIGINT NOT NULL,
+    external_listing_id VARCHAR(255),
+    seller_name VARCHAR(255),
+    seller_country_code VARCHAR(8),
+    item_condition_code VARCHAR(32),
+    completeness_code VARCHAR(64),
+    quantity_available INT,
+    unit_price DECIMAL(12,2) NOT NULL,
+    currency_code VARCHAR(8) NOT NULL,
+    description CLOB,
+    extended_description CLOB,
+    source_listing_payload CLOB,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_decision (
+    pricing_decision_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    pricing_snapshot_id BIGINT,
+    algorithm_version VARCHAR(64) NOT NULL,
+    decision_status_code VARCHAR(32) NOT NULL,
+    reason_code VARCHAR(64) NOT NULL,
+    strategy_code VARCHAR(64),
+    computed_price DECIMAL(12,2),
+    final_price DECIMAL(12,2),
+    previous_price DECIMAL(12,2),
+    currency_code VARCHAR(8) NOT NULL,
+    comparable_count INT,
+    confidence DECIMAL(5,4),
+    source_summary_json CLOB,
+    notes CLOB,
+    applied_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE bricklink_marketplace_listing (
@@ -466,6 +543,22 @@ CREATE INDEX idx_marketplace_order_transaction_link_transaction_item
     ON marketplace_order_transaction_link (transaction_item_id);
 CREATE INDEX idx_marketplace_order_transaction_link_type_status
     ON marketplace_order_transaction_link (link_type_code, link_status_code);
+CREATE INDEX idx_pricing_crawl_work_item_status_due
+    ON pricing_crawl_work_item (work_status_code, next_attempt_at);
+CREATE INDEX idx_pricing_crawl_work_item_listing
+    ON pricing_crawl_work_item (marketplace_listing_id);
+CREATE INDEX idx_pricing_snapshot_listing
+    ON pricing_snapshot (marketplace_listing_id, captured_at);
+CREATE INDEX idx_pricing_snapshot_catalog
+    ON pricing_snapshot (external_catalog_item_id, captured_at);
+CREATE INDEX idx_pricing_snapshot_listing_snapshot
+    ON pricing_snapshot_listing (pricing_snapshot_id);
+CREATE INDEX idx_pricing_decision_listing
+    ON pricing_decision (marketplace_listing_id, created_at);
+CREATE INDEX idx_pricing_decision_status
+    ON pricing_decision (decision_status_code);
+CREATE INDEX idx_pricing_decision_reason
+    ON pricing_decision (reason_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -594,6 +687,56 @@ ALTER TABLE marketplace_listing
 ALTER TABLE marketplace_listing
     ADD CONSTRAINT fk_marketplace_listing_external_catalog_item1
     FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_catalog_item1
+    FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_crawl_work_item
+    ADD CONSTRAINT fk_pricing_crawl_work_item_source_service1
+    FOREIGN KEY (source_external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_work_item1
+    FOREIGN KEY (pricing_crawl_work_item_id) REFERENCES pricing_crawl_work_item (pricing_crawl_work_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_catalog_item1
+    FOREIGN KEY (external_catalog_item_id) REFERENCES external_catalog_item (external_catalog_item_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot
+    ADD CONSTRAINT fk_pricing_snapshot_source_service1
+    FOREIGN KEY (source_external_service_id) REFERENCES external_service (external_service_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_snapshot_listing
+    ADD CONSTRAINT fk_pricing_snapshot_listing_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_decision
+    ADD CONSTRAINT fk_pricing_decision_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_decision
+    ADD CONSTRAINT fk_pricing_decision_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE bricklink_marketplace_listing

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <mybatis-spring-boot-starter.version>3.0.3</mybatis-spring-boot-starter.version>
         <github.organization>LegoHunter</github.organization>
         <github.repo.url>https://github.com/${github.organization}/lego-data.git</github.repo.url>
+        <surefire.argLine></surefire.argLine>
     </properties>
 
     <scm>
@@ -101,7 +102,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
                     <configuration>
-                        <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar -Xshare:off</argLine>
+                        <argLine>@{surefire.argLine} -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar -Xshare:off</argLine>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Summary
- Add a bounded MarketplaceListing DAO/MyBatis lookup for active listings by external service and status.
- Require an attached external catalog item so Pricing Plane crawl work can safely key work items and snapshots to catalog rows.
- Cover the new mapper and DAO path with H2-backed tests.

## Dependency / merge order
- Depends on Pricing Plane Phase 1 data foundation: https://github.com/LegoHunter/lego-data/pull/25
- This branch was updated with current origin/develop so it includes the latest image-hosting baseline needed by lego-data-ingress.

## Verification
- mvn test
- mvn install -DskipTests, used locally by lego-data-ingress Phase 2 tests