### PR TITLE
Add Pricing Plane decision candidate query

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -37,6 +37,18 @@ public class MarketplaceListingDao {
         );
     }
 
+    public Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit
+        );
+    }
+
     public Optional<MarketplaceListing> findByListingExternalServiceIdAndExternalListingId(Integer listingExternalServiceId, String externalListingId) {
         return marketplaceListingMapper.findByListingExternalServiceIdAndExternalListingId(listingExternalServiceId, externalListingId);
     }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/CurrentDaoIntegrationTest.java
@@ -276,6 +276,11 @@ class CurrentDaoIntegrationTest {
                 .first()
                 .extracting(MarketplaceListing::getExternalListingId)
                 .isEqualTo("DAO-BL-1");
+        assertThat(marketplaceListingDao.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .hasSize(1)
+                .first()
+                .extracting(MarketplaceListing::getExternalListingId)
+                .isEqualTo("DAO-BL-1");
         assertThat(marketplaceListingDao.findByItemInventoryId(inventory.getItemInventoryId())).hasSize(1);
         assertThat(itemInventoryDao.findMarketplaceListings(inventory))
                 .hasSize(1)

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -107,6 +107,49 @@ public interface MarketplaceListingMapper {
     @Select("""
             SELECT ${columns}
             ${fromClause}
+            JOIN item_inventory ii
+                ON ii.item_inventory_id = ml.item_inventory_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND ml.external_catalog_item_id IS NOT NULL
+              AND (
+                  COALESCE(ml.fixed_price, FALSE) = TRUE
+                  OR (
+                      ii.new_or_used IS NOT NULL
+                      AND TRIM(ii.new_or_used) <> ''
+                      AND ii.completeness IS NOT NULL
+                      AND TRIM(ii.completeness) <> ''
+                  )
+              )
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceListingResultMap")
+    Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
             WHERE ml.listing_external_service_id = #{listingExternalServiceId}
               AND ml.external_listing_id = #{externalListingId}
             """)

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -55,6 +55,40 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void pricingDecisionCandidatesSkipNonFixedListingsWithoutConditionData() {
+        ListingFixture unpriceableFixture = listingFixture("listing-unpriceable");
+        unpriceableFixture.inventory().setNewOrUsed(null);
+        unpriceableFixture.inventory().setCompleteness(null);
+        itemInventoryMapper.update(unpriceableFixture.inventory());
+        MarketplaceListing unpriceableListing = marketplaceListing(unpriceableFixture.inventory().getItemInventoryId(), unpriceableFixture.item().getExternalCatalogItemId(), 2, "BL-UNPRICEABLE");
+        unpriceableListing.setFixedPrice(false);
+        marketplaceListingMapper.insert(unpriceableListing);
+
+        ListingFixture priceableFixture = listingFixture("listing-priceable");
+        MarketplaceListing priceableListing = marketplaceListing(priceableFixture.inventory().getItemInventoryId(), priceableFixture.item().getExternalCatalogItemId(), 2, "BL-PRICEABLE");
+        priceableListing.setFixedPrice(false);
+        marketplaceListingMapper.insert(priceableListing);
+
+        ListingFixture fixedPriceFixture = listingFixture("listing-fixed");
+        fixedPriceFixture.inventory().setNewOrUsed(null);
+        fixedPriceFixture.inventory().setCompleteness(null);
+        itemInventoryMapper.update(fixedPriceFixture.inventory());
+        MarketplaceListing fixedPriceListing = marketplaceListing(fixedPriceFixture.inventory().getItemInventoryId(), fixedPriceFixture.item().getExternalCatalogItemId(), 2, "BL-FIXED");
+        fixedPriceListing.setFixedPrice(true);
+        marketplaceListingMapper.insert(fixedPriceListing);
+
+        assertThat(marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-UNPRICEABLE", "BL-PRICEABLE", "BL-FIXED");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-PRICEABLE", "BL-FIXED");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 1))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-PRICEABLE");
+    }
+
+    @Test
     void bricklinkMarketplaceListingSupportsCrudAndInventoryLookup() {
         MarketplaceListing listing = insertedMarketplaceListing("bricklink-listing", "BL-2", 2);
         BricklinkMarketplaceListing bricklink = bricklinkMarketplaceListing(listing.getMarketplaceListingId(), 2001);


### PR DESCRIPTION
## Summary
- Add a dedicated marketplace listing selector for Pricing Plane decision calculation.
- Return active BrickLink listing candidates up to the requested batch size while excluding non-fixed listings that cannot be priced because inventory condition or completeness is missing.
- Preserve fixed-price listings as eligible candidates because fixed price is an explicit override.
- Leave the broader active-listing selector unchanged for pricing crawl workflows.

## Validation
- mvn -pl lego-data-mybatis,lego-data-dao -am -Dtest=MarketplaceListingMapperTest,CurrentDaoIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean install