### PR TITLE
Pricing Plane Phase 4: crawl queue DAO support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -5,6 +5,7 @@ import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,6 +46,24 @@ public class MarketplaceListingDao {
         return marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
                 listingExternalServiceId,
                 listingStatusCode,
+                limit
+        );
+    }
+
+    public Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            String pendingStatusCode,
+            String claimedStatusCode,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        return marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                pendingStatusCode,
+                claimedStatusCode,
+                asOf,
                 limit
         );
     }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -4,8 +4,11 @@ import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -32,6 +35,51 @@ public class PricingCrawlWorkItemDao {
 
     public Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
         return pricingCrawlWorkItemMapper.findDueByWorkStatusCode(workStatusCode, dueAt, limit);
+    }
+
+    public List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+        return pricingCrawlWorkItemMapper.findClaimableByWorkStatusCode(workStatusCode, dueAt, limit);
+    }
+
+    @Transactional
+    public List<PricingCrawlWorkItem> claimDueWorkItems(
+            String pendingStatusCode,
+            String claimedStatusCode,
+            ZonedDateTime dueAt,
+            ZonedDateTime claimedAt,
+            int limit
+    ) {
+        List<PricingCrawlWorkItem> candidates = findClaimableByWorkStatusCode(pendingStatusCode, dueAt, limit);
+        List<PricingCrawlWorkItem> claimed = new ArrayList<>();
+        for (PricingCrawlWorkItem candidate : candidates) {
+            int updated = pricingCrawlWorkItemMapper.claim(
+                    candidate.getPricingCrawlWorkItemId(),
+                    pendingStatusCode,
+                    claimedStatusCode,
+                    dueAt,
+                    claimedAt
+            );
+            if (updated == 1) {
+                findByPricingCrawlWorkItemId(candidate.getPricingCrawlWorkItemId()).ifPresent(claimed::add);
+            }
+        }
+        return claimed;
+    }
+
+    public int requeueStaleClaimed(
+            String claimedStatusCode,
+            String pendingStatusCode,
+            ZonedDateTime claimedBefore,
+            ZonedDateTime nextAttemptAt,
+            String lastErrorMessage
+    ) {
+        return pricingCrawlWorkItemMapper.requeueStaleClaimed(
+                claimedStatusCode,
+                pendingStatusCode,
+                claimedBefore,
+                nextAttemptAt,
+                lastErrorMessage
+        );
     }
 
     public PricingCrawlWorkItem insert(PricingCrawlWorkItem pricingCrawlWorkItem) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,21 +37,21 @@ public class PricingCrawlWorkItemDao {
         return pricingCrawlWorkItemMapper.findDueByWorkStatusCode(workStatusCode, dueAt, limit);
     }
 
-    public List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+    public Set<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
         return pricingCrawlWorkItemMapper.findClaimableByWorkStatusCode(workStatusCode, dueAt, limit);
     }
 
     @Transactional
-    public List<PricingCrawlWorkItem> claimDueWorkItems(
+    public Set<PricingCrawlWorkItem> claimDueWorkItems(
             String pendingStatusCode,
             String claimedStatusCode,
             ZonedDateTime dueAt,
             ZonedDateTime claimedAt,
             int limit
     ) {
-        List<PricingCrawlWorkItem> candidates = findClaimableByWorkStatusCode(pendingStatusCode, dueAt, limit);
-        List<PricingCrawlWorkItem> claimed = new ArrayList<>();
-        for (PricingCrawlWorkItem candidate : candidates) {
+        Set<PricingCrawlWorkItem> candidates = findClaimableByWorkStatusCode(pendingStatusCode, dueAt, limit);
+        Set<PricingCrawlWorkItem> claimed = new LinkedHashSet<>();
+        for (PricingCrawlWorkItem candidate : sortedByDueOrder(candidates)) {
             int updated = pricingCrawlWorkItemMapper.claim(
                     candidate.getPricingCrawlWorkItemId(),
                     pendingStatusCode,
@@ -64,6 +64,14 @@ public class PricingCrawlWorkItemDao {
             }
         }
         return claimed;
+    }
+
+    private Set<PricingCrawlWorkItem> sortedByDueOrder(Set<PricingCrawlWorkItem> candidates) {
+        return candidates.stream()
+                .sorted(Comparator
+                        .comparing(PricingCrawlWorkItem::getNextAttemptAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(PricingCrawlWorkItem::getPricingCrawlWorkItemId, Comparator.nullsLast(Comparator.naturalOrder())))
+                .collect(LinkedHashSet::new, LinkedHashSet::add, LinkedHashSet::addAll);
     }
 
     public int requeueStaleClaimed(

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -118,6 +118,41 @@ class PricingPlaneDaoTest {
     }
 
     @Test
+    void pricingCrawlDaoClaimsDueWorkAndRequeuesStaleClaims() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItem(fixture);
+        workItem.setNextAttemptAt(CRAWL_AT.minusMinutes(1));
+        workItem = pricingCrawlWorkItemDao.insert(workItem);
+
+        assertThat(pricingCrawlWorkItemDao.claimDueWorkItems("PENDING", "CLAIMED", CRAWL_AT, CRAWL_AT, 5))
+                .extracting(PricingCrawlWorkItem::getPricingCrawlWorkItemId)
+                .containsExactly(workItem.getPricingCrawlWorkItemId());
+        assertThat(pricingCrawlWorkItemDao.claimDueWorkItems("PENDING", "CLAIMED", CRAWL_AT, CRAWL_AT.plusSeconds(1), 5))
+                .isEmpty();
+
+        assertThat(pricingCrawlWorkItemDao.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getWorkStatusCode()).isEqualTo("CLAIMED");
+                    assertThat(found.getAttemptCount()).isOne();
+                    assertThat(found.getClaimedAt()).isEqualTo(CRAWL_AT);
+                });
+
+        assertThat(pricingCrawlWorkItemDao.requeueStaleClaimed(
+                "CLAIMED",
+                "PENDING",
+                CRAWL_AT.plusMinutes(10),
+                CRAWL_AT.plusHours(1),
+                "Recovered stale pricing crawl claim"
+        )).isOne();
+        assertThat(pricingCrawlWorkItemDao.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getWorkStatusCode()).isEqualTo("PENDING");
+                    assertThat(found.getClaimedAt()).isNull();
+                    assertThat(found.getNextAttemptAt()).isEqualTo(CRAWL_AT.plusHours(1));
+                });
+    }
+
+    @Test
     void pricingDaosExposeExactConditionAndCompletenessComparables() {
         PricingFixture fixture = pricingFixture();
         PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -9,6 +9,7 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
@@ -98,6 +99,56 @@ public interface MarketplaceListingMapper {
         return findByListingExternalServiceIdAndListingStatusCode(
                 listingExternalServiceId,
                 listingStatusCode,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND ml.external_catalog_item_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM pricing_crawl_work_item pcwi
+                  WHERE pcwi.marketplace_listing_id = ml.marketplace_listing_id
+                    AND (
+                        pcwi.work_status_code IN (#{pendingStatusCode}, #{claimedStatusCode})
+                        OR pcwi.next_attempt_at > #{asOf}
+                    )
+              )
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceListingResultMap")
+    Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("asOf") ZonedDateTime asOf,
+            @Param("limit") int limit,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            String pendingStatusCode,
+            String claimedStatusCode,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        return findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                pendingStatusCode,
+                claimedStatusCode,
+                asOf,
                 limit,
                 ALL_COLUMNS,
                 FROM_CLAUSE

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -10,7 +10,6 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -79,14 +78,14 @@ public interface PricingCrawlWorkItemMapper {
             LIMIT #{limit}
             """)
     @ResultMap("pricingCrawlWorkItemResultMap")
-    List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(
+    Set<PricingCrawlWorkItem> findClaimableByWorkStatusCode(
             @Param("workStatusCode") String workStatusCode,
             @Param("dueAt") ZonedDateTime dueAt,
             @Param("limit") int limit,
             @Param("columns") String columns
     );
 
-    default List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+    default Set<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
         return findClaimableByWorkStatusCode(workStatusCode, dueAt, limit, ALL_COLUMNS);
     }
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -10,6 +10,7 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -67,6 +68,68 @@ public interface PricingCrawlWorkItemMapper {
     default Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
         return findDueByWorkStatusCode(workStatusCode, dueAt, limit, ALL_COLUMNS);
     }
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_crawl_work_item
+            WHERE work_status_code = #{workStatusCode}
+              AND next_attempt_at <= #{dueAt}
+              AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+            ORDER BY next_attempt_at, pricing_crawl_work_item_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingCrawlWorkItemResultMap")
+    List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(
+            @Param("workStatusCode") String workStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default List<PricingCrawlWorkItem> findClaimableByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
+        return findClaimableByWorkStatusCode(workStatusCode, dueAt, limit, ALL_COLUMNS);
+    }
+
+    @Update("""
+            UPDATE pricing_crawl_work_item
+            SET work_status_code = #{claimedStatusCode},
+                attempt_count = COALESCE(attempt_count, 0) + 1,
+                claimed_at = #{claimedAt},
+                completed_at = NULL,
+                last_error_message = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE pricing_crawl_work_item_id = #{pricingCrawlWorkItemId}
+              AND work_status_code = #{pendingStatusCode}
+              AND next_attempt_at <= #{dueAt}
+              AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+            """)
+    int claim(
+            @Param("pricingCrawlWorkItemId") Long pricingCrawlWorkItemId,
+            @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt,
+            @Param("claimedAt") ZonedDateTime claimedAt
+    );
+
+    @Update("""
+            UPDATE pricing_crawl_work_item
+            SET work_status_code = #{pendingStatusCode},
+                next_attempt_at = #{nextAttemptAt},
+                claimed_at = NULL,
+                completed_at = NULL,
+                last_error_message = #{lastErrorMessage},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE work_status_code = #{claimedStatusCode}
+              AND claimed_at <= #{claimedBefore}
+              AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+            """)
+    int requeueStaleClaimed(
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("claimedBefore") ZonedDateTime claimedBefore,
+            @Param("nextAttemptAt") ZonedDateTime nextAttemptAt,
+            @Param("lastErrorMessage") String lastErrorMessage
+    );
 
     @Insert("""
             INSERT INTO pricing_crawl_work_item (

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -7,14 +7,18 @@ import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ExternalCategory;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingCrawlWorkItem;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @MapperIntegrationTest
 class MarketplaceListingMapperTest extends MapperTestSupport {
+    private static final ZonedDateTime CRAWL_AT = ZonedDateTime.parse("2026-06-18T14:00:00Z");
+
 
     @Test
     void marketplaceListingSupportsCrudAndExternalListingLookup() {
@@ -86,6 +90,77 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 1))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactly("BL-PRICEABLE");
+    }
+
+    @Test
+    void pricingCrawlSchedulingCandidatesSkipOpenAndFutureScheduledWork() {
+        ListingFixture availableFixture = listingFixture("crawl-available");
+        MarketplaceListing availableListing = marketplaceListing(
+                availableFixture.inventory().getItemInventoryId(),
+                availableFixture.item().getExternalCatalogItemId(),
+                2,
+                "BL-CRAWL-AVAILABLE"
+        );
+        marketplaceListingMapper.insert(availableListing);
+
+        ListingFixture pendingFixture = listingFixture("crawl-pending");
+        MarketplaceListing pendingListing = marketplaceListing(
+                pendingFixture.inventory().getItemInventoryId(),
+                pendingFixture.item().getExternalCatalogItemId(),
+                2,
+                "BL-CRAWL-PENDING"
+        );
+        marketplaceListingMapper.insert(pendingListing);
+        pricingCrawlWorkItemMapper.insert(pricingCrawlWorkItem(
+                pendingListing.getMarketplaceListingId(),
+                pendingFixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusMinutes(1)
+        ));
+
+        ListingFixture futureFixture = listingFixture("crawl-future");
+        MarketplaceListing futureListing = marketplaceListing(
+                futureFixture.inventory().getItemInventoryId(),
+                futureFixture.item().getExternalCatalogItemId(),
+                2,
+                "BL-CRAWL-FUTURE"
+        );
+        marketplaceListingMapper.insert(futureListing);
+        PricingCrawlWorkItem futureWorkItem = pricingCrawlWorkItem(
+                futureListing.getMarketplaceListingId(),
+                futureFixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusHours(1)
+        );
+        futureWorkItem.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.insert(futureWorkItem);
+
+        ListingFixture dueFixture = listingFixture("crawl-due");
+        MarketplaceListing dueListing = marketplaceListing(
+                dueFixture.inventory().getItemInventoryId(),
+                dueFixture.item().getExternalCatalogItemId(),
+                2,
+                "BL-CRAWL-DUE"
+        );
+        marketplaceListingMapper.insert(dueListing);
+        PricingCrawlWorkItem dueWorkItem = pricingCrawlWorkItem(
+                dueListing.getMarketplaceListingId(),
+                dueFixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusHours(1)
+        );
+        dueWorkItem.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.insert(dueWorkItem);
+
+        assertThat(marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+                2,
+                "ACTIVE",
+                "PENDING",
+                "CLAIMED",
+                CRAWL_AT,
+                10
+        )).extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-CRAWL-AVAILABLE", "BL-CRAWL-DUE");
     }
 
     @Test

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -56,6 +56,62 @@ class PricingPlaneMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void pricingCrawlWorkItemSupportsClaimAndStaleRequeue() {
+        PricingFixture fixture = pricingFixture("pricing-work-claim");
+        PricingCrawlWorkItem dueWorkItem = insertedWorkItem(fixture, CRAWL_AT.minusMinutes(1));
+        PricingCrawlWorkItem maxedWorkItem = pricingCrawlWorkItem(
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusMinutes(1)
+        );
+        maxedWorkItem.setAttemptCount(3);
+        maxedWorkItem.setMaxAttempts(3);
+        pricingCrawlWorkItemMapper.insert(maxedWorkItem);
+
+        assertThat(pricingCrawlWorkItemMapper.findClaimableByWorkStatusCode("PENDING", CRAWL_AT, 10))
+                .extracting(PricingCrawlWorkItem::getPricingCrawlWorkItemId)
+                .containsExactly(dueWorkItem.getPricingCrawlWorkItemId());
+
+        assertThat(pricingCrawlWorkItemMapper.claim(
+                dueWorkItem.getPricingCrawlWorkItemId(),
+                "PENDING",
+                "CLAIMED",
+                CRAWL_AT,
+                CRAWL_AT
+        )).isOne();
+        assertThat(pricingCrawlWorkItemMapper.claim(
+                dueWorkItem.getPricingCrawlWorkItemId(),
+                "PENDING",
+                "CLAIMED",
+                CRAWL_AT,
+                CRAWL_AT.plusSeconds(1)
+        )).isZero();
+
+        assertThat(pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(dueWorkItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getWorkStatusCode()).isEqualTo("CLAIMED");
+                    assertThat(found.getAttemptCount()).isOne();
+                    assertThat(found.getClaimedAt()).isEqualTo(CRAWL_AT);
+                });
+
+        assertThat(pricingCrawlWorkItemMapper.requeueStaleClaimed(
+                "CLAIMED",
+                "PENDING",
+                CRAWL_AT.plusMinutes(5),
+                CRAWL_AT.plusHours(1),
+                "Recovered stale claim"
+        )).isOne();
+        assertThat(pricingCrawlWorkItemMapper.findByPricingCrawlWorkItemId(dueWorkItem.getPricingCrawlWorkItemId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getWorkStatusCode()).isEqualTo("PENDING");
+                    assertThat(found.getClaimedAt()).isNull();
+                    assertThat(found.getNextAttemptAt()).isEqualTo(CRAWL_AT.plusHours(1));
+                    assertThat(found.getLastErrorMessage()).isEqualTo("Recovered stale claim");
+                });
+    }
+
+    @Test
     void pricingSnapshotSupportsCrudAndLatestLookup() {
         PricingFixture fixture = pricingFixture("pricing-snapshot");
         PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);


### PR DESCRIPTION
## Summary
- Add Pricing Plane crawl queue DAO support for scheduler/worker hardening.
- Add marketplace listing scheduling candidate lookup that excludes listings with open `PENDING`/`CLAIMED` work or future `next_attempt_at` cooling windows.
- Add claimable work lookup, conditional `PENDING` to `CLAIMED` claim transition, and stale `CLAIMED` requeue support.
- Add mapper and DAO tests for candidate selection, claim behavior, attempt capacity, and stale claim recovery.

## Verification
- `mvn clean install`

## Review Notes
- Review and merge this PR before the matching `lego-data-ingress` Phase 4 PR because ingress uses the new DAO APIs.