### PR TITLE
Pricing Plane Phase 5: decision review data support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -50,6 +50,26 @@ public class MarketplaceListingDao {
         );
     }
 
+    public Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit,
+            boolean requireCurrentSnapshot
+    ) {
+        if (requireCurrentSnapshot) {
+            return marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+                    listingExternalServiceId,
+                    listingStatusCode,
+                    limit
+            );
+        }
+        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit
+        );
+    }
+
     public Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
             Integer listingExternalServiceId,
             String listingStatusCode,

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -1,6 +1,7 @@
 package io.legohunter.data.dao;
 
 import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingDecisionReview;
 import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -35,6 +36,18 @@ public class PricingDecisionDao {
 
     public Optional<PricingDecision> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
         return pricingDecisionMapper.findLatestByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingDecisionReview> findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return pricingDecisionMapper.findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit
+        );
     }
 
     public PricingDecision insert(PricingDecision pricingDecision) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoBranchCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoBranchCoverageTest.java
@@ -1,0 +1,203 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ExternalCatalogItem;
+import io.legohunter.data.dto.ExternalImage;
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.MarketplaceOrder;
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.enums.ExternalSyncStatus;
+import io.legohunter.data.mybatis.mapper.ExternalCatalogItemMapper;
+import io.legohunter.data.mybatis.mapper.ExternalImageMapper;
+import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderItemMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderMapper;
+import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DaoBranchCoverageTest {
+
+    @Test
+    void imageHostingSyncCandidateNormalizesNullEmptyAndNonEmptyReasons() {
+        assertThat(new ImageHostingSyncCandidate(1, null).reasons()).isEmpty();
+        assertThat(new ImageHostingSyncCandidate(1, Set.of()).reasons()).isEmpty();
+
+        ImageHostingSyncCandidate candidate = new ImageHostingSyncCandidate(
+                1,
+                Set.of(ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK)
+        );
+
+        assertThat(candidate.reasons()).containsExactly(ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK);
+    }
+
+    @Test
+    void externalImageDaoCoversNullCandidateAndQueryDelegations() {
+        ExternalImageMapper mapper = mock(ExternalImageMapper.class);
+        ExternalImageDao dao = new ExternalImageDao(mapper);
+        ExternalImage image = ExternalImage.builder()
+                .externalImageId(1L)
+                .externalServiceId(2)
+                .itemInventoryPhotoId(3)
+                .externalServiceImageId("remote-image")
+                .syncStatus(ExternalSyncStatus.SYNCED)
+                .md5AtUpload("md5")
+                .metadataHashAtSync("meta")
+                .build();
+
+        when(mapper.findAll()).thenReturn(Set.of(image));
+        when(mapper.findByExternalImageId(1L)).thenReturn(Optional.of(image));
+        when(mapper.findByExternalServiceIdAndItemInventoryPhotoId(2, 3)).thenReturn(Optional.of(image));
+        when(mapper.findByExternalServiceIdAndExternalServiceImageId(2, "remote-image")).thenReturn(Optional.of(image));
+        when(mapper.findByItemInventoryPhotoId(3)).thenReturn(Set.of(image));
+        when(mapper.findBySyncStatus(ExternalSyncStatus.SYNCED)).thenReturn(Set.of(image));
+        when(mapper.update(image)).thenReturn(1);
+        when(mapper.deleteByExternalImageId(1L)).thenReturn(1);
+        when(mapper.deleteByExternalServiceIdAndItemInventoryPhotoId(2, 3)).thenReturn(1);
+        when(mapper.findItemInventoryIdsMissingAlbumLinks(2, 1)).thenReturn(Arrays.asList((Integer) null));
+        when(mapper.findItemInventoryIdsMissingExternalImageLinks(2, 1)).thenReturn(List.of(10));
+        when(mapper.findItemInventoryIdsMissingAlbumMemberships(2, 1)).thenReturn(List.of(10));
+        when(mapper.findItemInventoryIdsWithPendingSyncRows(2, 1)).thenReturn(List.of(10));
+        when(mapper.findItemInventoryIdsWithMetadataDrift(2, 1)).thenReturn(List.of(11));
+
+        assertThat(dao.findAll()).containsExactly(image);
+        assertThat(dao.findByExternalImageId(1L)).contains(image);
+        assertThat(dao.findByExternalServiceIdAndItemInventoryPhotoId(2, 3)).contains(image);
+        assertThat(dao.findByExternalServiceIdAndExternalServiceImageId(2, "remote-image")).contains(image);
+        assertThat(dao.findByItemInventoryPhotoId(3)).containsExactly(image);
+        assertThat(dao.findBySyncStatus(ExternalSyncStatus.SYNCED)).containsExactly(image);
+        assertThat(dao.findItemInventoryIdsNeedingSync(2, false, 0)).containsExactly(10);
+        assertThat(dao.findItemInventorySyncCandidates(2, false, 1))
+                .singleElement()
+                .satisfies(candidate -> assertThat(candidate.reasons()).contains(
+                        ImageHostingSyncCandidateReason.MISSING_PHOTO_LINK,
+                        ImageHostingSyncCandidateReason.MISSING_ALBUM_MEMBERSHIP,
+                        ImageHostingSyncCandidateReason.PENDING_SYNC
+                ));
+        assertThat(dao.insert(image)).isSameAs(image);
+        assertThat(dao.update(image)).isOne();
+        assertThat(dao.upsert(image)).isSameAs(image);
+        assertThat(dao.deleteByExternalImageId(1L)).isOne();
+        assertThat(dao.deleteByExternalServiceIdAndItemInventoryPhotoId(2, 3)).isOne();
+        assertThat(dao.hasUploadedMd5(2, 3, "md5")).isTrue();
+        assertThat(dao.hasSyncedMetadataHash(2, 3, "meta")).isTrue();
+
+        verify(mapper, never()).findItemInventoryIdsWithFailedSyncRows(2, 1);
+    }
+
+    @Test
+    void marketplaceOrderDaoHandlesBlankStatusesLowLimitAndDuplicateCandidates() {
+        MarketplaceOrderMapper mapper = mock(MarketplaceOrderMapper.class);
+        MarketplaceOrderDao dao = new MarketplaceOrderDao(mapper);
+        MarketplaceOrder first = MarketplaceOrder.builder().marketplaceOrderId(1).build();
+        MarketplaceOrder duplicate = MarketplaceOrder.builder()
+                .marketplaceOrderId(1)
+                .externalOrderId("duplicate-row")
+                .build();
+        Set<MarketplaceOrder> duplicateRows = new LinkedHashSet<>();
+        duplicateRows.add(first);
+        duplicateRows.add(duplicate);
+
+        when(mapper.findFulfillmentCandidatesByStatus("BRICKLINK", "PAID", 1))
+                .thenReturn(duplicateRows);
+
+        assertThat(dao.findFulfillmentCandidates("BRICKLINK", Arrays.asList(null, " ", " PAID ", "PACKED"), 0))
+                .containsExactly(first);
+
+        verify(mapper).findFulfillmentCandidatesByStatus("BRICKLINK", "PAID", 1);
+        verify(mapper, never()).findFulfillmentCandidatesByStatus("BRICKLINK", "PACKED", 0);
+    }
+
+    @Test
+    void pricingCrawlWorkItemDaoSkipsCandidatesThatCannotBeClaimed() {
+        PricingCrawlWorkItemMapper mapper = mock(PricingCrawlWorkItemMapper.class);
+        PricingCrawlWorkItemDao dao = new PricingCrawlWorkItemDao(mapper);
+        ZonedDateTime dueAt = ZonedDateTime.parse("2026-06-24T10:00:00Z");
+        PricingCrawlWorkItem candidate = PricingCrawlWorkItem.builder()
+                .pricingCrawlWorkItemId(1L)
+                .nextAttemptAt(dueAt)
+                .build();
+
+        when(mapper.findClaimableByWorkStatusCode("PENDING", dueAt, 1)).thenReturn(Set.of(candidate));
+        when(mapper.claim(1L, "PENDING", "CLAIMED", dueAt, dueAt)).thenReturn(0);
+
+        assertThat(dao.claimDueWorkItems("PENDING", "CLAIMED", dueAt, dueAt, 1)).isEmpty();
+        verify(mapper, never()).findByPricingCrawlWorkItemId(1L);
+    }
+
+    @Test
+    void itemInventoryDaoCoversUpdateAndUpsertFallbackBranches() {
+        ItemInventoryMapper mapper = mock(ItemInventoryMapper.class);
+        MarketplaceListingDao marketplaceListingDao = mock(MarketplaceListingDao.class);
+        ItemInventoryDao dao = new ItemInventoryDao(mapper, marketplaceListingDao);
+        ItemInventory existing = new ItemInventory();
+        existing.setItemInventoryId(1);
+        existing.setInventoryStateCode("AVAILABLE");
+        existing.setSaleIntentCode("SELL");
+        existing.setSaleIntentNote("old");
+        ItemInventory updated = new ItemInventory();
+        updated.setItemInventoryId(1);
+        updated.setInventoryStateCode("SOLD");
+        updated.setSaleIntentCode("KEEP");
+        updated.setSaleIntentNote("new");
+        ItemInventory byUuid = new ItemInventory();
+        byUuid.setUuid("uuid-1");
+
+        when(mapper.findByItemInventoryId(1))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated));
+        when(mapper.findByUuid("uuid-1")).thenReturn(Optional.of(byUuid));
+
+        assertThat(dao.updateInventoryState(1, "SOLD", null)).isSameAs(updated);
+        assertThat(dao.updateSaleIntent(1, "KEEP", null, "new")).isSameAs(updated);
+        assertThat(dao.upsert(byUuid)).isSameAs(byUuid);
+
+        verify(mapper).upsert(byUuid);
+    }
+
+    @Test
+    void externalCatalogItemDaoUpsertFallsBackToUniqueKeyWhenItemKeyIsMissing() {
+        ExternalCatalogItemMapper mapper = mock(ExternalCatalogItemMapper.class);
+        ExternalCatalogItemDao dao = new ExternalCatalogItemDao(mapper);
+        ExternalCatalogItem catalogItem = ExternalCatalogItem.builder()
+                .externalServiceId(1)
+                .externalItemKey("missing")
+                .externalUniqueKey("4997")
+                .build();
+        ExternalCatalogItem hydrated = ExternalCatalogItem.builder()
+                .externalCatalogItemId(10)
+                .externalServiceId(1)
+                .externalUniqueKey("4997")
+                .build();
+
+        when(mapper.findByExternalServiceIdAndExternalItemKey(1, "missing")).thenReturn(Optional.empty());
+        when(mapper.findByExternalServiceIdAndExternalUniqueKey(1, "4997")).thenReturn(Optional.of(hydrated));
+
+        assertThat(dao.upsert(catalogItem)).isSameAs(hydrated);
+        verify(mapper).upsert(catalogItem);
+    }
+
+    @Test
+    void marketplaceOrderItemDaoDelegatesDeleteByMarketplaceOrderId() {
+        MarketplaceOrderItemMapper mapper = mock(MarketplaceOrderItemMapper.class);
+        MarketplaceOrderItemDao dao = new MarketplaceOrderItemDao(mapper);
+        when(mapper.deleteByMarketplaceOrderId(1)).thenReturn(2);
+
+        assertThat(dao.deleteByMarketplaceOrderId(1)).isEqualTo(2);
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -1,0 +1,303 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.Carrier;
+import io.legohunter.data.dto.Condition;
+import io.legohunter.data.dto.CostType;
+import io.legohunter.data.dto.InventoryIndex;
+import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PaymentPlatform;
+import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.TransactionCost;
+import io.legohunter.data.dto.TransactionItem;
+import io.legohunter.data.dto.TransactionItemCost;
+import io.legohunter.data.dto.TransactionPlatform;
+import io.legohunter.data.dto.TransactionType;
+import io.legohunter.data.dto.Transactions;
+import io.legohunter.data.dto.Party;
+import io.legohunter.data.enums.CurrencyCode;
+import io.legohunter.data.mybatis.mapper.CarrierMapper;
+import io.legohunter.data.mybatis.mapper.ConditionMapper;
+import io.legohunter.data.mybatis.mapper.CostTypeMapper;
+import io.legohunter.data.mybatis.mapper.InventoryIndexMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
+import io.legohunter.data.mybatis.mapper.PartyMapper;
+import io.legohunter.data.mybatis.mapper.PaymentPlatformMapper;
+import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
+import io.legohunter.data.mybatis.mapper.TransactionCostMapper;
+import io.legohunter.data.mybatis.mapper.TransactionItemCostMapper;
+import io.legohunter.data.mybatis.mapper.TransactionItemMapper;
+import io.legohunter.data.mybatis.mapper.TransactionPlatformMapper;
+import io.legohunter.data.mybatis.mapper.TransactionTypeMapper;
+import io.legohunter.data.mybatis.mapper.TransactionsMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DaoDelegationCoverageTest {
+
+    @Test
+    void transactionCostDaoDelegatesAllMapperOperationsAndSkipsEmptyCostLists() {
+        TransactionCostMapper transactionCostMapper = mock(TransactionCostMapper.class);
+        TransactionItemCostMapper transactionItemCostMapper = mock(TransactionItemCostMapper.class);
+        TransactionCostDao dao = new TransactionCostDao(transactionCostMapper, transactionItemCostMapper);
+        TransactionCost transactionCost = TransactionCost.builder()
+                .currencyCode(CurrencyCode.USD)
+                .build();
+        TransactionItemCost transactionItemCost = TransactionItemCost.builder().build();
+
+        dao.setTransactionCosts(10L, null);
+        dao.setTransactionItemCosts(20L, List.of());
+        verifyNoInteractions(transactionCostMapper, transactionItemCostMapper);
+
+        dao.setTransactionCosts(10L, List.of(transactionCost));
+        assertThat(transactionCost.getTransactionId()).isEqualTo(10L);
+        verify(transactionCostMapper).deleteTransactionCosts(10L);
+        verify(transactionCostMapper).insert(transactionCost);
+
+        dao.setTransactionItemCosts(20L, List.of(transactionItemCost));
+        assertThat(transactionItemCost.getTransactionItemId()).isEqualTo(20L);
+        verify(transactionItemCostMapper).deleteTransactionCosts(20L);
+        verify(transactionItemCostMapper).insert(transactionItemCost);
+
+        when(transactionCostMapper.findAll()).thenReturn(List.of(transactionCost));
+        when(transactionCostMapper.findById(30L)).thenReturn(Optional.of(transactionCost));
+        when(transactionCostMapper.findByTransactionIdAndCostTypeCode(10L, "SHIP")).thenReturn(List.of(transactionCost));
+
+        dao.deleteTransactionCosts(10L);
+        dao.deleteTransactionItemCosts(20L);
+        dao.delete(30L);
+        dao.insert(transactionCost);
+        dao.insert(transactionItemCost);
+        dao.migrate(transactionCost);
+        dao.update(transactionCost);
+
+        assertThat(dao.findAll()).containsExactly(transactionCost);
+        assertThat(dao.findById(30L)).contains(transactionCost);
+        assertThat(dao.findByTransactionIdAndCostTypeCode(10L, "SHIP")).contains(transactionCost);
+
+        verify(transactionCostMapper, times(2)).deleteTransactionCosts(10L);
+        verify(transactionItemCostMapper, times(2)).deleteTransactionCosts(20L);
+        verify(transactionCostMapper).delete(30L);
+        verify(transactionCostMapper).migrate(transactionCost);
+        verify(transactionCostMapper).update(transactionCost);
+    }
+
+    @Test
+    void lookupAndTransactionDaosDelegateToMappers() {
+        CarrierMapper carrierMapper = mock(CarrierMapper.class);
+        ConditionMapper conditionMapper = mock(ConditionMapper.class);
+        CostTypeMapper costTypeMapper = mock(CostTypeMapper.class);
+        PaymentPlatformMapper paymentPlatformMapper = mock(PaymentPlatformMapper.class);
+        TransactionPlatformMapper transactionPlatformMapper = mock(TransactionPlatformMapper.class);
+        TransactionTypeMapper transactionTypeMapper = mock(TransactionTypeMapper.class);
+        TransactionsMapper transactionsMapper = mock(TransactionsMapper.class);
+        TransactionItemMapper transactionItemMapper = mock(TransactionItemMapper.class);
+        PartyMapper partyMapper = mock(PartyMapper.class);
+
+        Carrier carrier = Carrier.builder().build();
+        Condition condition = Condition.builder().build();
+        CostType costType = CostType.builder().build();
+        PaymentPlatform paymentPlatform = PaymentPlatform.builder().build();
+        TransactionPlatform transactionPlatform = TransactionPlatform.builder().build();
+        TransactionType transactionType = TransactionType.builder().build();
+        Transactions transactions = Transactions.builder().build();
+        TransactionItem transactionItem = TransactionItem.builder().build();
+        Party party = Party.builder().build();
+
+        when(carrierMapper.findAll()).thenReturn(List.of(carrier));
+        when(carrierMapper.findCarrierByCode("UPS")).thenReturn(Optional.of(carrier));
+        CarrierDao carrierDao = new CarrierDao(carrierMapper);
+        assertThat(carrierDao.findAll()).containsExactly(carrier);
+        assertThat(carrierDao.findCarrierByCode("UPS")).contains(carrier);
+        carrierDao.insert(carrier);
+        carrierDao.update(carrier);
+        verify(carrierMapper).insertCarrier(carrier);
+        verify(carrierMapper).updateCarrier(carrier);
+
+        when(conditionMapper.findAll()).thenReturn(List.of(condition));
+        when(conditionMapper.findConditionById(1)).thenReturn(Optional.of(condition));
+        when(conditionMapper.findByConditionCode("G")).thenReturn(Optional.of(condition));
+        ConditionDao conditionDao = new ConditionDao(conditionMapper);
+        assertThat(conditionDao.findAll()).containsExactly(condition);
+        assertThat(conditionDao.findConditionById(1)).contains(condition);
+        assertThat(conditionDao.findByConditionCode("G")).contains(condition);
+        conditionDao.insert(condition);
+        conditionDao.update(condition);
+        verify(conditionMapper).insert(condition);
+        verify(conditionMapper).update(condition);
+
+        when(costTypeMapper.findAll()).thenReturn(List.of(costType));
+        when(costTypeMapper.findCostTypeByCode("SHIP")).thenReturn(Optional.of(costType));
+        CostTypeDao costTypeDao = new CostTypeDao(costTypeMapper);
+        assertThat(costTypeDao.findAll()).containsExactly(costType);
+        assertThat(costTypeDao.findCostTypeByCode("SHIP")).contains(costType);
+        costTypeDao.insert(costType);
+        costTypeDao.update(costType);
+        verify(costTypeMapper).insert(costType);
+        verify(costTypeMapper).update(costType);
+
+        when(paymentPlatformMapper.findAll()).thenReturn(List.of(paymentPlatform));
+        when(paymentPlatformMapper.findPaymentPlatformById(1)).thenReturn(Optional.of(paymentPlatform));
+        when(paymentPlatformMapper.findPaymentPlatformByName("PayPal")).thenReturn(Optional.of(paymentPlatform));
+        PaymentPlatformDao paymentPlatformDao = new PaymentPlatformDao(paymentPlatformMapper);
+        assertThat(paymentPlatformDao.findAll()).containsExactly(paymentPlatform);
+        assertThat(paymentPlatformDao.findPaymentPlatformById(1)).contains(paymentPlatform);
+        assertThat(paymentPlatformDao.findPaymentPlatformByName("PayPal")).contains(paymentPlatform);
+        paymentPlatformDao.insert(paymentPlatform);
+        paymentPlatformDao.update(paymentPlatform);
+        verify(paymentPlatformMapper).insert(paymentPlatform);
+        verify(paymentPlatformMapper).update(paymentPlatform);
+
+        when(transactionPlatformMapper.findAll()).thenReturn(List.of(transactionPlatform));
+        when(transactionPlatformMapper.findTransactionPlatformById(1)).thenReturn(Optional.of(transactionPlatform));
+        when(transactionPlatformMapper.findTransactionPlatformByName("BrickLink")).thenReturn(Optional.of(transactionPlatform));
+        TransactionPlatformDao transactionPlatformDao = new TransactionPlatformDao(transactionPlatformMapper);
+        assertThat(transactionPlatformDao.findAll()).containsExactly(transactionPlatform);
+        assertThat(transactionPlatformDao.findTransactionPlatformById(1)).contains(transactionPlatform);
+        assertThat(transactionPlatformDao.findTransactionPlatformByName("BrickLink")).contains(transactionPlatform);
+        transactionPlatformDao.insert(transactionPlatform);
+        transactionPlatformDao.update(transactionPlatform);
+        verify(transactionPlatformMapper).insert(transactionPlatform);
+        verify(transactionPlatformMapper).update(transactionPlatform);
+
+        when(transactionTypeMapper.findAll()).thenReturn(List.of(transactionType));
+        when(transactionTypeMapper.findTransactionTypeByCode("SALE")).thenReturn(Optional.of(transactionType));
+        TransactionTypeDao transactionTypeDao = new TransactionTypeDao(transactionTypeMapper);
+        assertThat(transactionTypeDao.findAll()).containsExactly(transactionType);
+        assertThat(transactionTypeDao.findTransactionTypeByCode("SALE")).contains(transactionType);
+        transactionTypeDao.insert(transactionType);
+        transactionTypeDao.udpate(transactionType);
+        verify(transactionTypeMapper).insert(transactionType);
+        verify(transactionTypeMapper).update(transactionType);
+
+        when(transactionsMapper.findAll()).thenReturn(List.of(transactions));
+        when(transactionsMapper.findById(40L)).thenReturn(Optional.of(transactions));
+        TransactionsDao transactionsDao = new TransactionsDao(transactionsMapper);
+        transactionsDao.insert(transactions);
+        transactionsDao.update(transactions);
+        assertThat(transactionsDao.findAll()).containsExactly(transactions);
+        assertThat(transactionsDao.findById(40L)).contains(transactions);
+        verify(transactionsMapper).insert(transactions);
+        verify(transactionsMapper).update(transactions);
+
+        when(transactionItemMapper.findAll()).thenReturn(List.of(transactionItem));
+        when(transactionItemMapper.findById(50L)).thenReturn(Optional.of(transactionItem));
+        TransactionItemDao transactionItemDao = new TransactionItemDao(transactionItemMapper);
+        transactionItemDao.insert(transactionItem);
+        transactionItemDao.migrate(transactionItem);
+        transactionItemDao.update(transactionItem);
+        assertThat(transactionItemDao.findAll()).containsExactly(transactionItem);
+        assertThat(transactionItemDao.findById(50L)).contains(transactionItem);
+        verify(transactionItemMapper).insert(transactionItem);
+        verify(transactionItemMapper).migrate(transactionItem);
+        verify(transactionItemMapper).update(transactionItem);
+
+        when(partyMapper.findAll()).thenReturn(List.of(party));
+        when(partyMapper.findPartyById(60L)).thenReturn(Optional.of(party));
+        PartyDao partyDao = new PartyDao(partyMapper);
+        partyDao.insert(party);
+        partyDao.migrate(party);
+        partyDao.setAutoIncrementMode();
+        partyDao.update(party);
+        partyDao.decrementPartyId(60L);
+        assertThat(partyDao.findAll()).containsExactly(party);
+        assertThat(partyDao.findPartyById(60L)).contains(party);
+        verify(partyMapper).insert(party);
+        verify(partyMapper).migrate(party);
+        verify(partyMapper).setAutoIncrementMode();
+        verify(partyMapper).update(party);
+        verify(partyMapper).decrementPartyId(60L);
+    }
+
+    @Test
+    void inventoryIndexDaoDelegatesAndWrapsMapperExceptions() {
+        InventoryIndexMapper mapper = mock(InventoryIndexMapper.class);
+        InventoryIndexDao dao = new InventoryIndexDao(mapper);
+        InventoryIndex inventoryIndex = InventoryIndex.builder().build();
+        RuntimeException mapperFailure = new RuntimeException("mapper failed");
+
+        when(mapper.getAll()).thenReturn(List.of(inventoryIndex));
+        when(mapper.getAllForBox(7)).thenReturn(List.of(inventoryIndex));
+        when(mapper.getAllWithNoItem()).thenReturn(List.of(inventoryIndex));
+        when(mapper.findByItemNumber("6390-1")).thenReturn(Optional.of(inventoryIndex));
+        when(mapper.findByBoxIdAndBoxIndex(7, 1)).thenReturn(Optional.of(inventoryIndex));
+        when(mapper.findByBoxIdAndBoxIndexAndItemNumber("6390-1", 7, 1)).thenReturn(Optional.of(inventoryIndex));
+
+        assertThat(dao.findAll()).containsExactly(inventoryIndex);
+        assertThat(dao.getAllForBox(7)).containsExactly(inventoryIndex);
+        assertThat(dao.getAllWithNoItem()).containsExactly(inventoryIndex);
+        assertThat(dao.findByItemNumber("6390-1")).contains(inventoryIndex);
+        assertThat(dao.findByBoxIdAndBoxIndex(7, 1)).contains(inventoryIndex);
+        assertThat(dao.findByBoxIdAndBoxIndexAndItemNumber(7, 1, "6390-1")).contains(inventoryIndex);
+        dao.insert(inventoryIndex);
+        dao.update(inventoryIndex);
+        verify(mapper).insert(inventoryIndex);
+        verify(mapper).update(inventoryIndex);
+
+        doThrow(mapperFailure).when(mapper).findByBoxIdAndBoxIndexAndItemNumber("bad", 7, 1);
+        assertThatThrownBy(() -> dao.findByBoxIdAndBoxIndexAndItemNumber(7, 1, "bad"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCause(mapperFailure);
+    }
+
+    @Test
+    void marketplaceListingDaoCoversSnapshotCandidateAndUpsertBranches() {
+        MarketplaceListingMapper mapper = mock(MarketplaceListingMapper.class);
+        MarketplaceListingDao dao = new MarketplaceListingDao(mapper);
+        MarketplaceListing listing = MarketplaceListing.builder()
+                .marketplaceListingId(100)
+                .listingExternalServiceId(1)
+                .externalListingId("remote-1")
+                .build();
+
+        when(mapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5))
+                .thenReturn(Set.of(listing));
+        assertThat(dao.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5, true))
+                .containsExactly(listing);
+
+        when(mapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+                1, "ACTIVE", "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
+        )).thenReturn(Set.of(listing));
+        assertThat(dao.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+                1, "ACTIVE", "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
+        )).containsExactly(listing);
+
+        MarketplaceListing missingIdListing = MarketplaceListing.builder()
+                .listingExternalServiceId(1)
+                .externalListingId("remote-2")
+                .build();
+        MarketplaceListing hydratedListing = MarketplaceListing.builder()
+                .marketplaceListingId(101)
+                .listingExternalServiceId(1)
+                .externalListingId("remote-2")
+                .build();
+        when(mapper.findByListingExternalServiceIdAndExternalListingId(1, "remote-2"))
+                .thenReturn(Optional.of(hydratedListing));
+
+        assertThat(dao.upsert(missingIdListing)).isSameAs(hydratedListing);
+        verify(mapper).upsert(missingIdListing);
+    }
+
+    @Test
+    void pricingDecisionDaoCoversLatestReviewLookup() {
+        PricingDecisionMapper mapper = mock(PricingDecisionMapper.class);
+        PricingDecisionDao dao = new PricingDecisionDao(mapper);
+
+        dao.findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
+
+        verify(mapper).findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/RemainingDaoCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/RemainingDaoCoverageTest.java
@@ -1,0 +1,138 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventoryPhoto;
+import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.MarketplaceOrderItem;
+import io.legohunter.data.enums.PhotoStatus;
+import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
+import io.legohunter.data.mybatis.mapper.ItemInventoryPhotoMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceOrderItemMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RemainingDaoCoverageTest {
+
+    @Test
+    void marketplaceListingDaoCoversNonSnapshotCandidateAndExternalListingLookupBranches() {
+        MarketplaceListingMapper mapper = mock(MarketplaceListingMapper.class);
+        MarketplaceListingDao dao = new MarketplaceListingDao(mapper);
+        MarketplaceListing listing = MarketplaceListing.builder()
+                .marketplaceListingId(100)
+                .listingExternalServiceId(1)
+                .externalListingId("remote-1")
+                .build();
+
+        when(mapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5))
+                .thenReturn(Set.of(listing));
+        when(mapper.findByListingExternalServiceIdAndExternalListingId(1, "remote-1"))
+                .thenReturn(Optional.of(listing));
+
+        assertThat(dao.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5, false))
+                .containsExactly(listing);
+        assertThat(dao.findByListingExternalServiceIdAndExternalListingId(1, "remote-1")).contains(listing);
+    }
+
+    @Test
+    void itemInventoryDaoCoversSaleIntentNoteOnlyChangeBranch() {
+        ItemInventoryMapper mapper = mock(ItemInventoryMapper.class);
+        MarketplaceListingDao marketplaceListingDao = mock(MarketplaceListingDao.class);
+        ItemInventoryDao dao = new ItemInventoryDao(mapper, marketplaceListingDao);
+        ItemInventory existing = new ItemInventory();
+        existing.setItemInventoryId(1);
+        existing.setSaleIntentCode("SELL");
+        existing.setSaleIntentNote("old");
+        ItemInventory updated = new ItemInventory();
+        updated.setItemInventoryId(1);
+        updated.setSaleIntentCode("SELL");
+        updated.setSaleIntentNote("new");
+
+        when(mapper.findByItemInventoryId(1))
+                .thenReturn(Optional.of(existing))
+                .thenReturn(Optional.of(updated));
+
+        assertThat(dao.updateSaleIntent(1, "SELL", null, "new")).isSameAs(updated);
+    }
+
+    @Test
+    void marketplaceOrderItemDaoCoversUpsertReturnValue() {
+        MarketplaceOrderItemMapper mapper = mock(MarketplaceOrderItemMapper.class);
+        MarketplaceOrderItemDao dao = new MarketplaceOrderItemDao(mapper);
+        MarketplaceOrderItem item = MarketplaceOrderItem.builder()
+                .marketplaceOrderItemId(1)
+                .build();
+        when(mapper.delete(1)).thenReturn(1);
+
+        assertThat(dao.delete(1)).isOne();
+        assertThat(dao.upsert(item)).isSameAs(item);
+        verify(mapper).upsert(item);
+    }
+
+    @Test
+    void itemInventoryPhotoDaoCoversWrapperMethodsAndTransitionFailures() {
+        ItemInventoryPhotoMapper mapper = mock(ItemInventoryPhotoMapper.class);
+        ItemInventoryPhotoDao dao = new ItemInventoryPhotoDao(mapper);
+        ItemInventoryPhoto photo = ItemInventoryPhoto.builder()
+                .itemInventoryPhotoId(1)
+                .itemInventoryId(2)
+                .md5("md5")
+                .fileName("photo.jpg")
+                .status(PhotoStatus.UPLOADED)
+                .build();
+
+        when(mapper.findAll()).thenReturn(Set.of(photo));
+        when(mapper.findByItemInventoryPhotoId(1)).thenReturn(Optional.of(photo));
+        when(mapper.findByMD5("md5")).thenReturn(Optional.of(photo));
+        when(mapper.updateStatus("md5", PhotoStatus.UPLOADED, PhotoStatus.PROCESSED))
+                .thenReturn(0)
+                .thenReturn(1);
+        when(mapper.markUploaded("md5", "bucket", "key", 100L)).thenReturn(1);
+        when(mapper.replaceStoredObject(1, "photo.jpg", "md5", null, "bucket", "key", 100L, true, "caption", PhotoStatus.PROCESSED))
+                .thenReturn(1);
+        when(mapper.updateMetadata(1, "photo.jpg", null, true, "caption", PhotoStatus.PROCESSED)).thenReturn(1);
+        when(mapper.clearPrimaryForItem(2)).thenReturn(1);
+        when(mapper.setPrimary(2, "md5")).thenReturn(1);
+        when(mapper.findByItemInventoryId(2)).thenReturn(Set.of(photo));
+        when(mapper.findPrimaryByItemInventoryId(2)).thenReturn(Optional.of(photo));
+        when(mapper.findByStatus(PhotoStatus.FAILED)).thenReturn(Set.of(photo));
+        when(mapper.deleteByMd5("md5")).thenReturn(1);
+        when(mapper.deleteByMd5AndStorage("md5", "bucket", "key")).thenReturn(1);
+        when(mapper.findWithoutS3Key()).thenReturn(Set.of(photo));
+
+        assertThat(dao.findAll()).containsExactly(photo);
+        assertThat(dao.findByItemInventoryPhotoId(1)).contains(photo);
+        assertThat(dao.findByUuid("md5")).contains(photo);
+        assertThatThrownBy(() -> dao.transitionStatus("md5", PhotoStatus.PROCESSED, PhotoStatus.UPLOADED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid transition: PROCESSED ? UPLOADED");
+        assertThatThrownBy(() -> dao.transitionStatus("md5", PhotoStatus.UPLOADED, PhotoStatus.PROCESSED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Stale state or race condition for md5=md5");
+        assertThat(dao.transitionStatus("md5", PhotoStatus.UPLOADED, PhotoStatus.PROCESSED)).isOne();
+        assertThat(dao.markUploaded("md5", "bucket", "key", 100L)).isOne();
+        assertThat(dao.replaceStoredObject(1, "photo.jpg", "md5", "bucket", "key", 100L, true, "caption", PhotoStatus.PROCESSED)).isOne();
+        assertThat(dao.updateMetadata(1, "photo.jpg", true, "caption", PhotoStatus.PROCESSED)).isOne();
+        dao.clearPrimaryForItem(2);
+        dao.setPrimary(2, "md5");
+        dao.setPrimaryForItem(2, "md5");
+        dao.setPrimaryPhoto(2, "md5");
+        assertThat(dao.findByItemInventoryId(2)).containsExactly(photo);
+        assertThat(dao.findPrimaryByItemInventoryId(2)).contains(photo);
+        assertThat(dao.findByStatus(PhotoStatus.FAILED)).containsExactly(photo);
+        assertThat(dao.countByStatus(PhotoStatus.FAILED)).isOne();
+        assertThat(dao.findFailed()).containsExactly(photo);
+        assertThat(dao.resetToUploaded("md5")).isZero();
+        assertThat(dao.deleteByMd5("md5")).isOne();
+        assertThat(dao.deleteByMd5AndStorage("md5", "bucket", "key")).isOne();
+        assertThat(dao.findWithoutS3Key()).containsExactly(photo);
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
@@ -1,0 +1,135 @@
+package io.legohunter.data.validation;
+
+import io.legohunter.data.dao.ConditionDao;
+import io.legohunter.data.dao.CostTypeDao;
+import io.legohunter.data.dao.ExternalCatalogItemDao;
+import io.legohunter.data.dao.ExternalServiceDao;
+import io.legohunter.data.dao.TransactionPlatformDao;
+import io.legohunter.data.dao.TransactionTypeDao;
+import io.legohunter.data.dto.Condition;
+import io.legohunter.data.dto.CostType;
+import io.legohunter.data.dto.ExternalCatalogItem;
+import io.legohunter.data.dto.ExternalService;
+import io.legohunter.data.dto.TransactionPlatform;
+import io.legohunter.data.dto.TransactionType;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ValidatorCoverageTest {
+
+    @Test
+    void itemNumberValidatorAcceptsNullExistingItemsAndRejectsMissingItems() {
+        ExternalCatalogItemDao catalogItemDao = mock(ExternalCatalogItemDao.class);
+        ExternalServiceDao externalServiceDao = mock(ExternalServiceDao.class);
+        ConstraintValidatorContext context = mockContext();
+        ItemNumberExists annotation = mock(ItemNumberExists.class);
+        ExternalService bricklink = new ExternalService();
+        bricklink.setExternalServiceId(1);
+        bricklink.setServiceCode("BRICKLINK");
+        ExternalCatalogItem catalogItem = ExternalCatalogItem.builder()
+                .externalCatalogItemId(10)
+                .externalItemKey("6390-1")
+                .build();
+        ItemNumberValidator validator = new ItemNumberValidator(catalogItemDao, externalServiceDao);
+
+        when(annotation.externalService()).thenReturn("BRICKLINK");
+        validator.initialize(annotation);
+        assertThat(validator.isValid(null, context)).isTrue();
+
+        when(externalServiceDao.findByServiceCode("BRICKLINK")).thenReturn(Optional.of(bricklink));
+        when(catalogItemDao.findByExternalServiceIdAndExternalItemKey(1, "6390-1")).thenReturn(Optional.of(catalogItem));
+        assertThat(validator.isValid("6390-1", context)).isTrue();
+
+        when(catalogItemDao.findByExternalServiceIdAndExternalItemKey(1, "missing")).thenReturn(Optional.empty());
+        assertThat(validator.isValid("missing", context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate("Item Number was not found in external service BRICKLINK");
+    }
+
+    @Test
+    void conditionCodeValidatorAcceptsNullExistingCodesAndRejectsMissingCodes() {
+        ConditionDao dao = mock(ConditionDao.class);
+        ConstraintValidatorContext context = mockContext();
+        Condition good = Condition.builder().conditionCode("G").build();
+        ConditionCodeValidator validator = new ConditionCodeValidator(dao);
+
+        when(dao.findAll()).thenReturn(List.of(good));
+        validator.initialize(mock(ConditionCodeExists.class));
+        assertThat(validator.isValid(null, context)).isTrue();
+
+        when(dao.findByConditionCode("G")).thenReturn(Optional.of(good));
+        assertThat(validator.isValid("G", context)).isTrue();
+
+        when(dao.findByConditionCode("BAD")).thenReturn(Optional.empty());
+        assertThat(validator.isValid("BAD", context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate("Must be one of [G]");
+    }
+
+    @Test
+    void costTypeValidatorAcceptsExistingCodesAndRejectsMissingCodes() {
+        CostTypeDao dao = mock(CostTypeDao.class);
+        ConstraintValidatorContext context = mockContext();
+        CostType shipping = CostType.builder().costTypeCode("SHIP").build();
+        CostTypeValidator validator = new CostTypeValidator(dao);
+
+        when(dao.findAll()).thenReturn(List.of(shipping));
+        validator.initialize(mock(CostTypeExists.class));
+
+        when(dao.findCostTypeByCode("SHIP")).thenReturn(Optional.of(shipping));
+        assertThat(validator.isValid("SHIP", context)).isTrue();
+
+        when(dao.findCostTypeByCode("BAD")).thenReturn(Optional.empty());
+        assertThat(validator.isValid("BAD", context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate("Cost Type Code [BAD] is invalid. Must be one of [SHIP]");
+    }
+
+    @Test
+    void transactionPlatformValidatorAcceptsNullExistingNamesAndRejectsMissingNames() {
+        TransactionPlatformDao dao = mock(TransactionPlatformDao.class);
+        ConstraintValidatorContext context = mockContext();
+        TransactionPlatform bricklink = TransactionPlatform.builder().transactionPlatformName("BrickLink").build();
+        TransactionPlatformValidator validator = new TransactionPlatformValidator(dao);
+
+        when(dao.findAll()).thenReturn(List.of(bricklink));
+        validator.initialize(mock(TransactionPlatformExists.class));
+        assertThat(validator.isValid(null, context)).isTrue();
+
+        when(dao.findTransactionPlatformByName("BrickLink")).thenReturn(Optional.of(bricklink));
+        assertThat(validator.isValid("BrickLink", context)).isTrue();
+
+        when(dao.findTransactionPlatformByName("Bad")).thenReturn(Optional.empty());
+        assertThat(validator.isValid("Bad", context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate("Transaction Platform [Bad] is invalid. Must be one of [BrickLink]");
+    }
+
+    @Test
+    void transactionTypeValidatorAcceptsNullExistingCodesAndRejectsMissingCodes() {
+        TransactionTypeDao dao = mock(TransactionTypeDao.class);
+        ConstraintValidatorContext context = mockContext();
+        TransactionType sale = TransactionType.builder().transactionTypeCode("SALE").build();
+        TransactionTypeValidator validator = new TransactionTypeValidator(dao);
+
+        when(dao.findAll()).thenReturn(List.of(sale));
+        validator.initialize(mock(TransactionTypeExists.class));
+        assertThat(validator.isValid(null, context)).isTrue();
+
+        when(dao.findTransactionTypeByCode("SALE")).thenReturn(Optional.of(sale));
+        assertThat(validator.isValid("SALE", context)).isTrue();
+
+        when(dao.findTransactionTypeByCode("BAD")).thenReturn(Optional.empty());
+        assertThat(validator.isValid("BAD", context)).isFalse();
+        verify(context).buildConstraintViolationWithTemplate("Transaction Type [BAD] is invalid. Must be one of [SALE]");
+    }
+
+    private ConstraintValidatorContext mockContext() {
+        return mock(ConstraintValidatorContext.class, RETURNS_DEEP_STUBS);
+    }
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecisionReview.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecisionReview.java
@@ -1,0 +1,45 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingDecisionReview {
+    private Integer marketplaceListingId;
+    private String externalListingId;
+    private String listingStatusCode;
+    private BigDecimal currentUnitPrice;
+    private String currencyCode;
+    private Boolean fixedPrice;
+    private Integer itemInventoryId;
+    private String itemInventoryUuid;
+    private String newOrUsed;
+    private String completeness;
+    private Integer externalCatalogItemId;
+    private String externalItemKey;
+    private String externalUniqueKey;
+    private Long pricingDecisionId;
+    private Long pricingSnapshotId;
+    private String algorithmVersion;
+    private String decisionStatusCode;
+    private String reasonCode;
+    private String strategyCode;
+    private BigDecimal computedPrice;
+    private BigDecimal finalPrice;
+    private BigDecimal previousPrice;
+    private Integer comparableCount;
+    private BigDecimal confidence;
+    private String notes;
+    private ZonedDateTime decisionCreatedAt;
+    private ZonedDateTime appliedAt;
+    private ZonedDateTime snapshotCapturedAt;
+    private Integer snapshotComparableCount;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -201,6 +201,86 @@ public interface MarketplaceListingMapper {
     @Select("""
             SELECT ${columns}
             ${fromClause}
+            JOIN item_inventory ii
+                ON ii.item_inventory_id = ml.item_inventory_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND ml.external_catalog_item_id IS NOT NULL
+              AND (
+                  COALESCE(ml.fixed_price, FALSE) = TRUE
+                  OR (
+                      ii.new_or_used IS NOT NULL
+                      AND TRIM(ii.new_or_used) <> ''
+                      AND ii.completeness IS NOT NULL
+                      AND TRIM(ii.completeness) <> ''
+                      AND EXISTS (
+                          SELECT 1
+                          FROM pricing_snapshot ps
+                          WHERE ps.marketplace_listing_id = ml.marketplace_listing_id
+                            AND ps.item_condition_code = CASE UPPER(TRIM(ii.new_or_used))
+                                WHEN 'NEW' THEN 'N'
+                                WHEN 'N' THEN 'N'
+                                WHEN 'USED' THEN 'U'
+                                WHEN 'U' THEN 'U'
+                                ELSE NULL
+                            END
+                            AND (
+                                ps.completeness_code = CASE UPPER(TRIM(ii.completeness))
+                                    WHEN 'SEALED' THEN 'S'
+                                    WHEN 'S' THEN 'S'
+                                    WHEN 'COMPLETE' THEN 'C'
+                                    WHEN 'C' THEN 'C'
+                                    WHEN 'INCOMPLETE' THEN 'X'
+                                    WHEN 'I' THEN 'X'
+                                    WHEN 'X' THEN 'X'
+                                    ELSE UPPER(TRIM(ii.completeness))
+                                END
+                                OR (
+                                    ps.completeness_code IS NULL
+                                    AND CASE UPPER(TRIM(ii.completeness))
+                                        WHEN 'SEALED' THEN 'S'
+                                        WHEN 'S' THEN 'S'
+                                        WHEN 'COMPLETE' THEN 'C'
+                                        WHEN 'C' THEN 'C'
+                                        WHEN 'INCOMPLETE' THEN 'X'
+                                        WHEN 'I' THEN 'X'
+                                        WHEN 'X' THEN 'X'
+                                        ELSE UPPER(TRIM(ii.completeness))
+                                    END IS NULL
+                                )
+                            )
+                      )
+                  )
+              )
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceListingResultMap")
+    Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            ${fromClause}
             WHERE ml.listing_external_service_id = #{listingExternalServiceId}
               AND ml.external_listing_id = #{externalListingId}
             """)

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -1,6 +1,7 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingDecisionReview;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
@@ -31,6 +32,38 @@ public interface PricingDecisionMapper {
             notes,
             applied_at,
             created_at
+            """;
+
+    String REVIEW_COLUMNS = """
+            ml.marketplace_listing_id,
+            ml.external_listing_id,
+            ml.listing_status_code,
+            ml.unit_price AS current_unit_price,
+            ml.currency_code,
+            ml.fixed_price,
+            ii.item_inventory_id,
+            ii.uuid AS item_inventory_uuid,
+            ii.new_or_used,
+            ii.completeness,
+            eci.external_catalog_item_id,
+            eci.external_item_key,
+            eci.external_unique_key,
+            pd.pricing_decision_id,
+            pd.pricing_snapshot_id,
+            pd.algorithm_version,
+            pd.decision_status_code,
+            pd.reason_code,
+            pd.strategy_code,
+            pd.computed_price,
+            pd.final_price,
+            pd.previous_price,
+            pd.comparable_count,
+            pd.confidence,
+            pd.notes,
+            pd.created_at AS decision_created_at,
+            pd.applied_at,
+            ps.captured_at AS snapshot_captured_at,
+            ps.comparable_count AS snapshot_comparable_count
             """;
 
     @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision")
@@ -68,6 +101,53 @@ public interface PricingDecisionMapper {
 
     default Optional<PricingDecision> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
         return findLatestByMarketplaceListingId(marketplaceListingId, ALL_COLUMNS);
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM marketplace_listing ml
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            LEFT JOIN (
+                SELECT pd.*
+                FROM pricing_decision pd
+                JOIN (
+                    SELECT marketplace_listing_id,
+                           MAX(pricing_decision_id) AS pricing_decision_id
+                    FROM pricing_decision
+                    GROUP BY marketplace_listing_id
+                ) latest
+                  ON latest.pricing_decision_id = pd.pricing_decision_id
+            ) pd
+              ON pd.marketplace_listing_id = ml.marketplace_listing_id
+            LEFT JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = pd.pricing_snapshot_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingDecisionReviewResultMap")
+    Set<PricingDecisionReview> findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default Set<PricingDecisionReview> findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                limit,
+                REVIEW_COLUMNS
+        );
     }
 
     @Insert("""

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
@@ -19,4 +19,36 @@
     <result column="applied_at"             property="appliedAt"/>
     <result column="created_at"             property="createdAt"/>
   </resultMap>
+
+  <resultMap type="io.legohunter.data.dto.PricingDecisionReview" id="pricingDecisionReviewResultMap">
+    <id     column="marketplace_listing_id"  property="marketplaceListingId"/>
+    <result column="external_listing_id"     property="externalListingId"/>
+    <result column="listing_status_code"     property="listingStatusCode"/>
+    <result column="current_unit_price"      property="currentUnitPrice"/>
+    <result column="currency_code"           property="currencyCode"/>
+    <result column="fixed_price"             property="fixedPrice"/>
+    <result column="item_inventory_id"       property="itemInventoryId"/>
+    <result column="item_inventory_uuid"     property="itemInventoryUuid"/>
+    <result column="new_or_used"             property="newOrUsed"/>
+    <result column="completeness"            property="completeness"/>
+    <result column="external_catalog_item_id" property="externalCatalogItemId"/>
+    <result column="external_item_key"       property="externalItemKey"/>
+    <result column="external_unique_key"     property="externalUniqueKey"/>
+    <result column="pricing_decision_id"     property="pricingDecisionId"/>
+    <result column="pricing_snapshot_id"     property="pricingSnapshotId"/>
+    <result column="algorithm_version"       property="algorithmVersion"/>
+    <result column="decision_status_code"    property="decisionStatusCode"/>
+    <result column="reason_code"             property="reasonCode"/>
+    <result column="strategy_code"           property="strategyCode"/>
+    <result column="computed_price"          property="computedPrice"/>
+    <result column="final_price"             property="finalPrice"/>
+    <result column="previous_price"          property="previousPrice"/>
+    <result column="comparable_count"        property="comparableCount"/>
+    <result column="confidence"              property="confidence"/>
+    <result column="notes"                   property="notes"/>
+    <result column="decision_created_at"     property="decisionCreatedAt"/>
+    <result column="applied_at"              property="appliedAt"/>
+    <result column="snapshot_captured_at"    property="snapshotCapturedAt"/>
+    <result column="snapshot_comparable_count" property="snapshotComparableCount"/>
+  </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -8,6 +8,7 @@ import io.legohunter.data.dto.ExternalCategory;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingSnapshot;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -90,6 +91,44 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 1))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactly("BL-PRICEABLE");
+    }
+
+    @Test
+    void pricingDecisionCandidatesCanRequireMatchingCurrentSnapshot() {
+        ListingFixture noSnapshotFixture = listingFixture("listing-no-snapshot");
+        MarketplaceListing noSnapshotListing = marketplaceListing(noSnapshotFixture.inventory().getItemInventoryId(), noSnapshotFixture.item().getExternalCatalogItemId(), 2, "BL-NO-SNAPSHOT");
+        noSnapshotListing.setFixedPrice(false);
+        marketplaceListingMapper.insert(noSnapshotListing);
+
+        ListingFixture snapshotFixture = listingFixture("listing-with-snapshot");
+        MarketplaceListing snapshotListing = marketplaceListing(snapshotFixture.inventory().getItemInventoryId(), snapshotFixture.item().getExternalCatalogItemId(), 2, "BL-WITH-SNAPSHOT");
+        snapshotListing.setFixedPrice(false);
+        marketplaceListingMapper.insert(snapshotListing);
+        PricingSnapshot snapshot = pricingSnapshot(
+                null,
+                snapshotListing.getMarketplaceListingId(),
+                snapshotFixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT
+        );
+        snapshot.setItemConditionCode("U");
+        snapshot.setCompletenessCode("C");
+        pricingSnapshotMapper.insert(snapshot);
+
+        ListingFixture fixedPriceFixture = listingFixture("listing-fixed-without-snapshot");
+        fixedPriceFixture.inventory().setNewOrUsed(null);
+        fixedPriceFixture.inventory().setCompleteness(null);
+        itemInventoryMapper.update(fixedPriceFixture.inventory());
+        MarketplaceListing fixedPriceListing = marketplaceListing(fixedPriceFixture.inventory().getItemInventoryId(), fixedPriceFixture.item().getExternalCatalogItemId(), 2, "BL-FIXED-NO-SNAPSHOT");
+        fixedPriceListing.setFixedPrice(true);
+        marketplaceListingMapper.insert(fixedPriceListing);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-NO-SNAPSHOT", "BL-WITH-SNAPSHOT", "BL-FIXED-NO-SNAPSHOT");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-WITH-SNAPSHOT", "BL-FIXED-NO-SNAPSHOT");
     }
 
     @Test

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -5,12 +5,14 @@ import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingDecision;
+import io.legohunter.data.dto.PricingDecisionReview;
 import io.legohunter.data.dto.PricingSnapshot;
 import io.legohunter.data.dto.PricingSnapshotListing;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -285,6 +287,54 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         assertThat(pricingDecisionMapper.findByPricingDecisionId(decision.getPricingDecisionId())).isEmpty();
     }
 
+    @Test
+    void pricingDecisionReviewReturnsLatestDecisionWithListingContext() {
+        PricingFixture decidedFixture = pricingFixture("pricing-review-decided");
+        PricingSnapshot snapshot = insertedSnapshot(decidedFixture);
+        PricingDecision olderDecision = pricingDecision(decidedFixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        olderDecision.setReasonCode("NO_CURRENT_SNAPSHOT");
+        olderDecision.setDecisionStatusCode("FAILED");
+        olderDecision.setFinalPrice(null);
+        pricingDecisionMapper.insert(olderDecision);
+
+        PricingDecision latestDecision = pricingDecision(decidedFixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        latestDecision.setReasonCode("MATCHED_LOWEST_COMPETITOR");
+        latestDecision.setDecisionStatusCode("PROPOSED");
+        latestDecision.setFinalPrice(new BigDecimal("199.99"));
+        pricingDecisionMapper.insert(latestDecision);
+
+        PricingFixture undecidedFixture = pricingFixture("pricing-review-undecided");
+
+        Set<PricingDecisionReview> reviews = pricingDecisionMapper.findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
+                2,
+                "ACTIVE",
+                10
+        );
+
+        assertThat(reviews).hasSize(2);
+        assertThat(reviews)
+                .filteredOn(review -> review.getMarketplaceListingId().equals(decidedFixture.listing().getMarketplaceListingId()))
+                .singleElement()
+                .satisfies(review -> {
+                    assertThat(review.getPricingDecisionId()).isEqualTo(latestDecision.getPricingDecisionId());
+                    assertThat(review.getReasonCode()).isEqualTo("MATCHED_LOWEST_COMPETITOR");
+                    assertThat(review.getDecisionStatusCode()).isEqualTo("PROPOSED");
+                    assertThat(review.getFinalPrice()).isEqualByComparingTo("199.99");
+                    assertThat(review.getCurrentUnitPrice()).isEqualByComparingTo(decidedFixture.listing().getUnitPrice());
+                    assertThat(review.getExternalItemKey()).isEqualTo("pricing-review-decided");
+                    assertThat(review.getSnapshotComparableCount()).isEqualTo(snapshot.getComparableCount());
+                    assertThat(review.getSnapshotCapturedAt()).isEqualTo(snapshot.getCapturedAt());
+                });
+        assertThat(reviews)
+                .filteredOn(review -> review.getMarketplaceListingId().equals(undecidedFixture.listing().getMarketplaceListingId()))
+                .singleElement()
+                .satisfies(review -> {
+                    assertThat(review.getPricingDecisionId()).isNull();
+                    assertThat(review.getDecisionStatusCode()).isNull();
+                    assertThat(review.getExternalItemKey()).isEqualTo("pricing-review-undecided");
+                });
+    }
+
     private PricingSnapshot insertedSnapshot(PricingFixture fixture) {
         PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);
         PricingSnapshot snapshot = pricingSnapshot(
@@ -311,8 +361,8 @@ class PricingPlaneMapperTest extends MapperTestSupport {
 
     private PricingFixture pricingFixture(String key) {
         seedExternalCatalog();
-        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "MARKETPLACE_LISTING"));
-        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "PRICE_GUIDE"));
+        externalServiceCapabilityMapper.upsert(externalServiceCapability(2, "MARKETPLACE_LISTING"));
+        externalServiceCapabilityMapper.upsert(externalServiceCapability(2, "PRICE_GUIDE"));
         ExternalCatalogItem catalogItem = insertExternalCatalogItem(key);
         ItemInventory inventory = insertItemInventory("inventory-" + key);
         MarketplaceListing listing = marketplaceListing(


### PR DESCRIPTION
## Summary
- Add `PricingDecisionReview` DTO for one-row-per-listing review views.
- Add latest pricing decision review mapper/DAO support with listing, inventory, catalog, decision, and snapshot context.
- Add snapshot-gated pricing decision candidate selection for non-fixed listings.
- Add mapper integration coverage for latest review rows and snapshot-required candidate selection.

## Verification
- `mvn -pl lego-data-mybatis -am -Dtest=PricingPlaneMapperTest,MarketplaceListingMapperTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn clean install`

## Review Notes
Review and merge this before the lego-data-ingress Phase 5 PR because ingress consumes the new DAO method.