### PR TITLE
Pricing Plane Phase 6: apply-readiness review support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -50,6 +50,20 @@ public class PricingDecisionDao {
         );
     }
 
+    public Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            String decisionStatusCode,
+            int limit
+    ) {
+        return pricingDecisionMapper.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                decisionStatusCode,
+                limit
+        );
+    }
+
     public PricingDecision insert(PricingDecision pricingDecision) {
         pricingDecisionMapper.insert(pricingDecision);
         return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -297,7 +297,19 @@ class DaoDelegationCoverageTest {
         PricingDecisionDao dao = new PricingDecisionDao(mapper);
 
         dao.findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
+        dao.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+                1,
+                "ACTIVE",
+                "PROPOSED",
+                25
+        );
 
         verify(mapper).findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
+        verify(mapper).findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+                1,
+                "ACTIVE",
+                "PROPOSED",
+                25
+        );
     }
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecisionReview.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingDecisionReview.java
@@ -17,7 +17,9 @@ public class PricingDecisionReview {
     private String externalListingId;
     private String listingStatusCode;
     private BigDecimal currentUnitPrice;
+    private String currentCurrencyCode;
     private String currencyCode;
+    private String decisionCurrencyCode;
     private Boolean fixedPrice;
     private Integer itemInventoryId;
     private String itemInventoryUuid;

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -39,7 +39,7 @@ public interface PricingDecisionMapper {
             ml.external_listing_id,
             ml.listing_status_code,
             ml.unit_price AS current_unit_price,
-            ml.currency_code,
+            ml.currency_code AS current_currency_code,
             ml.fixed_price,
             ii.item_inventory_id,
             ii.uuid AS item_inventory_uuid,
@@ -57,6 +57,8 @@ public interface PricingDecisionMapper {
             pd.computed_price,
             pd.final_price,
             pd.previous_price,
+            pd.currency_code,
+            pd.currency_code AS decision_currency_code,
             pd.comparable_count,
             pd.confidence,
             pd.notes,
@@ -145,6 +147,59 @@ public interface PricingDecisionMapper {
         return findLatestReviewsByListingExternalServiceIdAndListingStatusCode(
                 listingExternalServiceId,
                 listingStatusCode,
+                limit,
+                REVIEW_COLUMNS
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM marketplace_listing ml
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            JOIN (
+                SELECT pd.*
+                FROM pricing_decision pd
+                JOIN (
+                    SELECT marketplace_listing_id,
+                           MAX(pricing_decision_id) AS pricing_decision_id
+                    FROM pricing_decision
+                    GROUP BY marketplace_listing_id
+                ) latest
+                  ON latest.pricing_decision_id = pd.pricing_decision_id
+            ) pd
+              ON pd.marketplace_listing_id = ml.marketplace_listing_id
+            LEFT JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = pd.pricing_snapshot_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND pd.decision_status_code = #{decisionStatusCode}
+              AND pd.applied_at IS NULL
+            ORDER BY pd.created_at DESC,
+                     pd.pricing_decision_id DESC
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingDecisionReviewResultMap")
+    Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("decisionStatusCode") String decisionStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            String decisionStatusCode,
+            int limit
+    ) {
+        return findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                decisionStatusCode,
                 limit,
                 REVIEW_COLUMNS
         );

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
@@ -25,7 +25,9 @@
     <result column="external_listing_id"     property="externalListingId"/>
     <result column="listing_status_code"     property="listingStatusCode"/>
     <result column="current_unit_price"      property="currentUnitPrice"/>
+    <result column="current_currency_code"   property="currentCurrencyCode"/>
     <result column="currency_code"           property="currencyCode"/>
+    <result column="decision_currency_code"  property="decisionCurrencyCode"/>
     <result column="fixed_price"             property="fixedPrice"/>
     <result column="item_inventory_id"       property="itemInventoryId"/>
     <result column="item_inventory_uuid"     property="itemInventoryUuid"/>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -321,6 +321,9 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                     assertThat(review.getDecisionStatusCode()).isEqualTo("PROPOSED");
                     assertThat(review.getFinalPrice()).isEqualByComparingTo("199.99");
                     assertThat(review.getCurrentUnitPrice()).isEqualByComparingTo(decidedFixture.listing().getUnitPrice());
+                    assertThat(review.getCurrentCurrencyCode()).isEqualTo("USD");
+                    assertThat(review.getDecisionCurrencyCode()).isEqualTo("USD");
+                    assertThat(review.getCurrencyCode()).isEqualTo("USD");
                     assertThat(review.getExternalItemKey()).isEqualTo("pricing-review-decided");
                     assertThat(review.getSnapshotComparableCount()).isEqualTo(snapshot.getComparableCount());
                     assertThat(review.getSnapshotCapturedAt()).isEqualTo(snapshot.getCapturedAt());
@@ -332,6 +335,63 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                     assertThat(review.getPricingDecisionId()).isNull();
                     assertThat(review.getDecisionStatusCode()).isNull();
                     assertThat(review.getExternalItemKey()).isEqualTo("pricing-review-undecided");
+                });
+    }
+
+    @Test
+    void pricingDecisionApplyReadinessReviewReturnsLatestUnappliedProposedDecisionsOnly() {
+        PricingFixture readyFixture = pricingFixture("pricing-apply-ready");
+        PricingSnapshot readySnapshot = insertedSnapshot(readyFixture);
+        PricingDecision failedDecision = pricingDecision(readyFixture.listing().getMarketplaceListingId(), readySnapshot.getPricingSnapshotId());
+        failedDecision.setDecisionStatusCode("FAILED");
+        failedDecision.setReasonCode("NO_EXACT_COMPARABLES");
+        failedDecision.setFinalPrice(null);
+        pricingDecisionMapper.insert(failedDecision);
+        PricingDecision readyDecision = pricingDecision(readyFixture.listing().getMarketplaceListingId(), readySnapshot.getPricingSnapshotId());
+        readyDecision.setDecisionStatusCode("PROPOSED");
+        readyDecision.setReasonCode("MEAN_PLUS_STDDEV");
+        readyDecision.setFinalPrice(new BigDecimal("212.25"));
+        pricingDecisionMapper.insert(readyDecision);
+
+        PricingFixture appliedFixture = pricingFixture("pricing-apply-applied");
+        PricingSnapshot appliedSnapshot = insertedSnapshot(appliedFixture);
+        PricingDecision appliedDecision = pricingDecision(appliedFixture.listing().getMarketplaceListingId(), appliedSnapshot.getPricingSnapshotId());
+        appliedDecision.setDecisionStatusCode("PROPOSED");
+        appliedDecision.setReasonCode("MATCHED_LOWEST_COMPETITOR");
+        appliedDecision.setFinalPrice(new BigDecimal("190.00"));
+        appliedDecision.setAppliedAt(SNAPSHOT_AT.plusMinutes(10));
+        pricingDecisionMapper.insert(appliedDecision);
+
+        PricingFixture failedFixture = pricingFixture("pricing-apply-failed");
+        PricingSnapshot failedSnapshot = insertedSnapshot(failedFixture);
+        PricingDecision latestFailedDecision = pricingDecision(failedFixture.listing().getMarketplaceListingId(), failedSnapshot.getPricingSnapshotId());
+        latestFailedDecision.setDecisionStatusCode("FAILED");
+        latestFailedDecision.setReasonCode("NO_CURRENT_SNAPSHOT");
+        latestFailedDecision.setFinalPrice(null);
+        pricingDecisionMapper.insert(latestFailedDecision);
+
+        Set<PricingDecisionReview> reviews = pricingDecisionMapper
+                .findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
+                        2,
+                        "ACTIVE",
+                        "PROPOSED",
+                        10
+                );
+
+        assertThat(reviews)
+                .extracting(PricingDecisionReview::getMarketplaceListingId)
+                .containsExactly(readyFixture.listing().getMarketplaceListingId());
+        assertThat(reviews)
+                .singleElement()
+                .satisfies(review -> {
+                    assertThat(review.getPricingDecisionId()).isEqualTo(readyDecision.getPricingDecisionId());
+                    assertThat(review.getDecisionStatusCode()).isEqualTo("PROPOSED");
+                    assertThat(review.getReasonCode()).isEqualTo("MEAN_PLUS_STDDEV");
+                    assertThat(review.getFinalPrice()).isEqualByComparingTo("212.25");
+                    assertThat(review.getAppliedAt()).isNull();
+                    assertThat(review.getCurrentUnitPrice()).isEqualByComparingTo(readyFixture.listing().getUnitPrice());
+                    assertThat(review.getCurrentCurrencyCode()).isEqualTo("USD");
+                    assertThat(review.getDecisionCurrencyCode()).isEqualTo("USD");
                 });
     }
 


### PR DESCRIPTION
## Summary

Adds read-only data-layer support for Pricing Plane Phase 6 apply-readiness dry-run review.

## Changes

- Adds explicit `currentCurrencyCode` and `decisionCurrencyCode` fields to `PricingDecisionReview` while preserving the existing `currencyCode` mapping for the decision currency.
- Adds a mapper/DAO method that returns latest, unapplied pricing decision reviews for active marketplace listings by decision status.
- Keeps the lookup read-only and latest-only so stale superseded pricing decisions are excluded from dry-run apply review.
- Adds mapper integration coverage for latest proposed/unapplied selection and DAO delegation coverage for the new method.

## Verification

- `mvn clean install`

## Dependency Notes

Review and merge before the matching `lego-data-ingress` Phase 6 PR because ingress depends on this DAO method and the explicit currency fields.