### PR TITLE
Deduplicate pricing decision candidates

### DIFF
--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -155,128 +155,17 @@ public interface MarketplaceListingMapper {
         );
     }
 
-    @Select("""
-            SELECT ${columns}
-            ${fromClause}
-            JOIN item_inventory ii
-                ON ii.item_inventory_id = ml.item_inventory_id
-            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
-              AND ml.listing_status_code = #{listingStatusCode}
-              AND ml.external_catalog_item_id IS NOT NULL
-              AND (
-                  COALESCE(ml.fixed_price, FALSE) = TRUE
-                  OR (
-                      ii.new_or_used IS NOT NULL
-                      AND TRIM(ii.new_or_used) <> ''
-                      AND ii.completeness IS NOT NULL
-                      AND TRIM(ii.completeness) <> ''
-                  )
-              )
-            ORDER BY ml.marketplace_listing_id
-            LIMIT #{limit}
-            """)
-    @ResultMap("marketplaceListingResultMap")
     Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
             @Param("listingStatusCode") String listingStatusCode,
-            @Param("limit") int limit,
-            @Param("columns") String columns,
-            @Param("fromClause") String fromClause
+            @Param("limit") int limit
     );
 
-    default Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
-            Integer listingExternalServiceId,
-            String listingStatusCode,
-            int limit
-    ) {
-        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
-                listingExternalServiceId,
-                listingStatusCode,
-                limit,
-                ALL_COLUMNS,
-                FROM_CLAUSE
-        );
-    }
-
-    @Select("""
-            SELECT ${columns}
-            ${fromClause}
-            JOIN item_inventory ii
-                ON ii.item_inventory_id = ml.item_inventory_id
-            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
-              AND ml.listing_status_code = #{listingStatusCode}
-              AND ml.external_catalog_item_id IS NOT NULL
-              AND (
-                  COALESCE(ml.fixed_price, FALSE) = TRUE
-                  OR (
-                      ii.new_or_used IS NOT NULL
-                      AND TRIM(ii.new_or_used) <> ''
-                      AND ii.completeness IS NOT NULL
-                      AND TRIM(ii.completeness) <> ''
-                      AND EXISTS (
-                          SELECT 1
-                          FROM pricing_snapshot ps
-                          WHERE ps.marketplace_listing_id = ml.marketplace_listing_id
-                            AND ps.item_condition_code = CASE UPPER(TRIM(ii.new_or_used))
-                                WHEN 'NEW' THEN 'N'
-                                WHEN 'N' THEN 'N'
-                                WHEN 'USED' THEN 'U'
-                                WHEN 'U' THEN 'U'
-                                ELSE NULL
-                            END
-                            AND (
-                                ps.completeness_code = CASE UPPER(TRIM(ii.completeness))
-                                    WHEN 'SEALED' THEN 'S'
-                                    WHEN 'S' THEN 'S'
-                                    WHEN 'COMPLETE' THEN 'C'
-                                    WHEN 'C' THEN 'C'
-                                    WHEN 'INCOMPLETE' THEN 'X'
-                                    WHEN 'I' THEN 'X'
-                                    WHEN 'X' THEN 'X'
-                                    ELSE UPPER(TRIM(ii.completeness))
-                                END
-                                OR (
-                                    ps.completeness_code IS NULL
-                                    AND CASE UPPER(TRIM(ii.completeness))
-                                        WHEN 'SEALED' THEN 'S'
-                                        WHEN 'S' THEN 'S'
-                                        WHEN 'COMPLETE' THEN 'C'
-                                        WHEN 'C' THEN 'C'
-                                        WHEN 'INCOMPLETE' THEN 'X'
-                                        WHEN 'I' THEN 'X'
-                                        WHEN 'X' THEN 'X'
-                                        ELSE UPPER(TRIM(ii.completeness))
-                                    END IS NULL
-                                )
-                            )
-                      )
-                  )
-              )
-            ORDER BY ml.marketplace_listing_id
-            LIMIT #{limit}
-            """)
-    @ResultMap("marketplaceListingResultMap")
     Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
             @Param("listingStatusCode") String listingStatusCode,
-            @Param("limit") int limit,
-            @Param("columns") String columns,
-            @Param("fromClause") String fromClause
+            @Param("limit") int limit
     );
-
-    default Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
-            Integer listingExternalServiceId,
-            String listingStatusCode,
-            int limit
-    ) {
-        return findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
-                listingExternalServiceId,
-                listingStatusCode,
-                limit,
-                ALL_COLUMNS,
-                FROM_CLAUSE
-        );
-    }
 
     @Select("""
             SELECT ${columns}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
@@ -25,4 +25,220 @@
                  notNullColumn="external_catalog_item_id"
                  javaType="io.legohunter.data.dto.ExternalCatalogItem"/>
   </resultMap>
+
+  <sql id="marketplaceListingColumns">
+    ml.marketplace_listing_id,
+    ml.item_inventory_id,
+    ml.listing_external_service_id,
+    ml.external_catalog_item_id,
+    ml.external_listing_id,
+    ml.external_listing_url,
+    ml.listing_status_code,
+    ml.title,
+    ml.description,
+    ml.private_notes,
+    ml.unit_price,
+    ml.currency_code,
+    ml.fixed_price,
+    ml.created_at,
+    ml.updated_at,
+    ml.published_at,
+    ml.ended_at,
+    ml.last_synchronized_at,
+    eci.external_catalog_item_id AS eci_external_catalog_item_id,
+    eci.external_service_id AS eci_external_service_id,
+    eci.external_item_key AS eci_external_item_key,
+    eci.external_unique_key AS eci_external_unique_key,
+    eci.item_name AS eci_item_name,
+    eci.item_type_code AS eci_item_type_code,
+    eci.item_url AS eci_item_url,
+    eci.year_released AS eci_year_released,
+    es.external_service_id AS eci_es_external_service_id,
+    es.service_code AS eci_es_service_code,
+    es.display_name AS eci_es_display_name,
+    es.service_url AS eci_es_service_url,
+    es.external_service_type_id AS eci_es_external_service_type_id,
+    est.external_service_type_id AS eci_es_est_external_service_type_id,
+    est.external_service_type_name AS eci_es_est_external_service_type_name,
+    est.external_service_type_description AS eci_es_est_external_service_type_description
+  </sql>
+
+  <sql id="marketplaceListingFromClause">
+    FROM marketplace_listing ml
+    LEFT JOIN external_catalog_item eci
+      ON eci.external_catalog_item_id = ml.external_catalog_item_id
+    LEFT JOIN external_service es
+      ON es.external_service_id = eci.external_service_id
+    LEFT JOIN external_service_type est
+      ON est.external_service_type_id = es.external_service_type_id
+  </sql>
+
+  <sql id="priceableInventoryConditionPresent">
+    ii.new_or_used IS NOT NULL
+    AND TRIM(ii.new_or_used) &lt;&gt; ''
+    AND ii.completeness IS NOT NULL
+    AND TRIM(ii.completeness) &lt;&gt; ''
+  </sql>
+
+  <sql id="normalizedItemConditionCode">
+    CASE UPPER(TRIM(${value}))
+      WHEN 'NEW' THEN 'N'
+      WHEN 'N' THEN 'N'
+      WHEN 'USED' THEN 'U'
+      WHEN 'U' THEN 'U'
+      ELSE NULL
+    END
+  </sql>
+
+  <sql id="normalizedCompletenessCode">
+    CASE UPPER(TRIM(${value}))
+      WHEN 'SEALED' THEN 'S'
+      WHEN 'S' THEN 'S'
+      WHEN 'COMPLETE' THEN 'C'
+      WHEN 'C' THEN 'C'
+      WHEN 'INCOMPLETE' THEN 'X'
+      WHEN 'I' THEN 'X'
+      WHEN 'X' THEN 'X'
+      ELSE UPPER(TRIM(${value}))
+    END
+  </sql>
+
+  <sql id="pricingSnapshotMatchesInventoryCondition">
+    ps.item_condition_code = <include refid="normalizedItemConditionCode">
+      <property name="value" value="ii.new_or_used"/>
+    </include>
+    AND (
+      ps.completeness_code = <include refid="normalizedCompletenessCode">
+        <property name="value" value="ii.completeness"/>
+      </include>
+      OR (
+        ps.completeness_code IS NULL
+        AND <include refid="normalizedCompletenessCode">
+          <property name="value" value="ii.completeness"/>
+        </include> IS NULL
+      )
+    )
+  </sql>
+
+  <sql id="latestMatchingPricingSnapshotId">
+    SELECT ps.pricing_snapshot_id
+    FROM pricing_snapshot ps
+    WHERE ps.marketplace_listing_id = ml.marketplace_listing_id
+      AND <include refid="pricingSnapshotMatchesInventoryCondition"/>
+    ORDER BY ps.captured_at DESC,
+             ps.pricing_snapshot_id DESC
+    LIMIT 1
+  </sql>
+
+  <sql id="matchingPricingSnapshotExists">
+    EXISTS (
+      SELECT 1
+      FROM pricing_snapshot ps
+      WHERE ps.marketplace_listing_id = ml.marketplace_listing_id
+        AND <include refid="pricingSnapshotMatchesInventoryCondition"/>
+    )
+  </sql>
+
+  <sql id="latestPricingDecisionJoin">
+    JOIN (
+      SELECT marketplace_listing_id,
+             MAX(pricing_decision_id) AS pricing_decision_id
+      FROM pricing_decision
+      GROUP BY marketplace_listing_id
+    ) latest
+      ON latest.pricing_decision_id = latest_pd.pricing_decision_id
+  </sql>
+
+  <sql id="latestPricingDecisionExists">
+    EXISTS (
+      SELECT 1
+      FROM pricing_decision latest_pd
+      <include refid="latestPricingDecisionJoin"/>
+      WHERE latest_pd.marketplace_listing_id = ml.marketplace_listing_id
+    )
+  </sql>
+
+  <sql id="fixedPriceNotAlreadyDecided">
+    COALESCE(ml.fixed_price, FALSE) = TRUE
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pricing_decision latest_pd
+      <include refid="latestPricingDecisionJoin"/>
+      WHERE latest_pd.marketplace_listing_id = ml.marketplace_listing_id
+        AND latest_pd.decision_status_code = 'SKIPPED'
+        AND latest_pd.reason_code = 'FIXED_PRICE_OVERRIDE'
+        AND (
+          latest_pd.final_price = ml.unit_price
+          OR (
+            latest_pd.final_price IS NULL
+            AND ml.unit_price IS NULL
+          )
+        )
+    )
+  </sql>
+
+  <sql id="notAlreadyDecidedForLatestMatchingSnapshot">
+    NOT EXISTS (
+      SELECT 1
+      FROM pricing_decision latest_pd
+      <include refid="latestPricingDecisionJoin"/>
+      WHERE latest_pd.marketplace_listing_id = ml.marketplace_listing_id
+        AND latest_pd.pricing_snapshot_id = (
+          <include refid="latestMatchingPricingSnapshotId"/>
+        )
+    )
+  </sql>
+
+  <select id="findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode"
+          resultMap="marketplaceListingResultMap">
+    SELECT <include refid="marketplaceListingColumns"/>
+    <include refid="marketplaceListingFromClause"/>
+    JOIN item_inventory ii
+      ON ii.item_inventory_id = ml.item_inventory_id
+    WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+      AND ml.listing_status_code = #{listingStatusCode}
+      AND ml.external_catalog_item_id IS NOT NULL
+      AND (
+        (
+          <include refid="fixedPriceNotAlreadyDecided"/>
+        )
+        OR (
+          <include refid="priceableInventoryConditionPresent"/>
+          AND (
+            NOT <include refid="latestPricingDecisionExists"/>
+            OR (
+              (
+                <include refid="latestMatchingPricingSnapshotId"/>
+              ) IS NOT NULL
+              AND <include refid="notAlreadyDecidedForLatestMatchingSnapshot"/>
+            )
+          )
+        )
+      )
+    ORDER BY ml.marketplace_listing_id
+    LIMIT #{limit}
+  </select>
+
+  <select id="findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode"
+          resultMap="marketplaceListingResultMap">
+    SELECT <include refid="marketplaceListingColumns"/>
+    <include refid="marketplaceListingFromClause"/>
+    JOIN item_inventory ii
+      ON ii.item_inventory_id = ml.item_inventory_id
+    WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+      AND ml.listing_status_code = #{listingStatusCode}
+      AND ml.external_catalog_item_id IS NOT NULL
+      AND (
+        (
+          <include refid="fixedPriceNotAlreadyDecided"/>
+        )
+        OR (
+          <include refid="priceableInventoryConditionPresent"/>
+          AND <include refid="matchingPricingSnapshotExists"/>
+          AND <include refid="notAlreadyDecidedForLatestMatchingSnapshot"/>
+        )
+      )
+    ORDER BY ml.marketplace_listing_id
+    LIMIT #{limit}
+  </select>
 </mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -8,6 +8,7 @@ import io.legohunter.data.dto.ExternalCategory;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingDecision;
 import io.legohunter.data.dto.PricingSnapshot;
 import org.junit.jupiter.api.Test;
 
@@ -129,6 +130,92 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactlyInAnyOrder("BL-WITH-SNAPSHOT", "BL-FIXED-NO-SNAPSHOT");
+    }
+
+    @Test
+    void pricingDecisionCandidatesSkipAlreadyDecidedListingsUntilNewMatchingSnapshotExists() {
+        ListingFixture fixture = listingFixture("listing-decision-dedupe");
+        MarketplaceListing listing = marketplaceListing(fixture.inventory().getItemInventoryId(), fixture.item().getExternalCatalogItemId(), 2, "BL-DEDUPE");
+        listing.setFixedPrice(false);
+        marketplaceListingMapper.insert(listing);
+        PricingSnapshot firstSnapshot = pricingSnapshot(
+                null,
+                listing.getMarketplaceListingId(),
+                fixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT
+        );
+        firstSnapshot.setItemConditionCode("U");
+        firstSnapshot.setCompletenessCode("C");
+        pricingSnapshotMapper.insert(firstSnapshot);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-DEDUPE");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-DEDUPE");
+
+        pricingDecisionMapper.insert(pricingDecision(listing.getMarketplaceListingId(), firstSnapshot.getPricingSnapshotId()));
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .isEmpty();
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .isEmpty();
+
+        PricingSnapshot newerSnapshot = pricingSnapshot(
+                null,
+                listing.getMarketplaceListingId(),
+                fixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusHours(1)
+        );
+        newerSnapshot.setItemConditionCode("U");
+        newerSnapshot.setCompletenessCode("C");
+        pricingSnapshotMapper.insert(newerSnapshot);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-DEDUPE");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-DEDUPE");
+    }
+
+    @Test
+    void pricingDecisionCandidatesSkipFixedPriceListingsUntilCurrentPriceChanges() {
+        ListingFixture fixture = listingFixture("listing-fixed-dedupe");
+        MarketplaceListing listing = marketplaceListing(fixture.inventory().getItemInventoryId(), fixture.item().getExternalCatalogItemId(), 2, "BL-FIXED-DEDUPE");
+        listing.setFixedPrice(true);
+        listing.setUnitPrice(new BigDecimal("25.00"));
+        marketplaceListingMapper.insert(listing);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-FIXED-DEDUPE");
+
+        PricingDecision fixedPriceDecision = pricingDecision(listing.getMarketplaceListingId(), null);
+        fixedPriceDecision.setDecisionStatusCode("SKIPPED");
+        fixedPriceDecision.setReasonCode("FIXED_PRICE_OVERRIDE");
+        fixedPriceDecision.setComputedPrice(null);
+        fixedPriceDecision.setFinalPrice(new BigDecimal("25.00"));
+        fixedPriceDecision.setComparableCount(0);
+        pricingDecisionMapper.insert(fixedPriceDecision);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .isEmpty();
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .isEmpty();
+
+        listing.setUnitPrice(new BigDecimal("30.00"));
+        marketplaceListingMapper.update(listing);
+
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-FIXED-DEDUPE");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactly("BL-FIXED-DEDUPE");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Prevent the pricing decision job from repeatedly selecting listings already decided for the same pricing input.
- Suppress fixed-price candidates after a latest FIXED_PRICE_OVERRIDE decision preserves the current listing price.
- Suppress non-fixed candidates after the latest decision has already used the latest matching pricing snapshot.
- Let listings become candidates again when a newer matching snapshot is crawled or a fixed listing price changes.
- Move the pricing decision candidate SQL from large Java annotations into XML mapper statements with reusable MyBatis SQL fragments.

## SQL fragment cleanup
- Adds fragments for Marketplace Listing columns/from-clause, inventory condition presence, BrickLink condition/completeness normalization, latest matching snapshot lookup, latest decision joins, fixed-price suppression, and snapshot-decision suppression.
- Keeps the Java mapper method signatures small and lets XML own the complex SQL composition.

## Verification
- mvn -pl lego-data-mybatis -Dtest=MarketplaceListingMapperTest test
- mvn clean install

## Operational note
After this merges, rebuild/redeploy lego-data-ingress so the running sandbox image consumes the updated lego-data dependency.