### PR TITLE
Exclude fixed-price listings from snapshot decision branch

### DIFF
--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
@@ -203,6 +203,8 @@
           <include refid="fixedPriceNotAlreadyDecided"/>
         )
         OR (
+          COALESCE(ml.fixed_price, FALSE) &lt;&gt; TRUE
+          AND
           <include refid="priceableInventoryConditionPresent"/>
           AND (
             NOT <include refid="latestPricingDecisionExists"/>
@@ -233,6 +235,8 @@
           <include refid="fixedPriceNotAlreadyDecided"/>
         )
         OR (
+          COALESCE(ml.fixed_price, FALSE) &lt;&gt; TRUE
+          AND
           <include refid="priceableInventoryConditionPresent"/>
           AND <include refid="matchingPricingSnapshotExists"/>
           AND <include refid="notAlreadyDecidedForLatestMatchingSnapshot"/>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -189,6 +189,16 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         listing.setFixedPrice(true);
         listing.setUnitPrice(new BigDecimal("25.00"));
         marketplaceListingMapper.insert(listing);
+        PricingSnapshot snapshot = pricingSnapshot(
+                null,
+                listing.getMarketplaceListingId(),
+                fixture.item().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT
+        );
+        snapshot.setItemConditionCode("U");
+        snapshot.setCompletenessCode("C");
+        pricingSnapshotMapper.insert(snapshot);
 
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
                 .extracting(MarketplaceListing::getExternalListingId)


### PR DESCRIPTION
## Summary
- Prevent fixed-price marketplace listings from entering the pricing decision candidate set through the snapshot/comparable branch.
- Preserve the intended fixed-price behavior: a fixed listing is eligible once when its current fixed price has not yet been recorded, then suppressed until the current listing price changes.
- Add mapper coverage for a fixed-price listing that also has a matching pricing snapshot.

## Root cause
The previous candidate de-dupe suppressed fixed-price listings in the fixed-price branch, but the non-fixed snapshot branch did not explicitly require ixed_price != true. Fixed listings with matching snapshots could therefore still be selected every decision cycle and written as repeated SKIPPED/FIXED_PRICE_OVERRIDE decisions.

## Verification
- mvn -pl lego-data-mybatis -Dtest=MarketplaceListingMapperTest test
- mvn clean install