### PR TITLE
Pricing Plane Phase 7 data observability counts

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -33,6 +33,22 @@ public class PricingCrawlWorkItemDao {
         return pricingCrawlWorkItemMapper.findByWorkStatusCode(workStatusCode);
     }
 
+    public long countByWorkStatusCode(String workStatusCode) {
+        return pricingCrawlWorkItemMapper.countByWorkStatusCode(workStatusCode);
+    }
+
+    public long countDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt) {
+        return pricingCrawlWorkItemMapper.countDueByWorkStatusCode(workStatusCode, dueAt);
+    }
+
+    public long countRetryableByWorkStatusCode(String workStatusCode) {
+        return pricingCrawlWorkItemMapper.countRetryableByWorkStatusCode(workStatusCode);
+    }
+
+    public long countStaleClaimed(String claimedStatusCode, ZonedDateTime claimedBefore) {
+        return pricingCrawlWorkItemMapper.countStaleClaimed(claimedStatusCode, claimedBefore);
+    }
+
     public Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {
         return pricingCrawlWorkItemMapper.findDueByWorkStatusCode(workStatusCode, dueAt, limit);
     }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -34,6 +34,14 @@ public class PricingDecisionDao {
         return pricingDecisionMapper.findByReasonCode(reasonCode);
     }
 
+    public long countLatestByDecisionStatusCode(String decisionStatusCode) {
+        return pricingDecisionMapper.countLatestByDecisionStatusCode(decisionStatusCode);
+    }
+
+    public long countLatestUnappliedByDecisionStatusCode(String decisionStatusCode) {
+        return pricingDecisionMapper.countLatestUnappliedByDecisionStatusCode(decisionStatusCode);
+    }
+
     public Optional<PricingDecision> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
         return pricingDecisionMapper.findLatestByMarketplaceListingId(marketplaceListingId);
     }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -22,6 +22,7 @@ import io.legohunter.data.mybatis.mapper.InventoryIndexMapper;
 import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
 import io.legohunter.data.mybatis.mapper.PartyMapper;
 import io.legohunter.data.mybatis.mapper.PaymentPlatformMapper;
+import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
 import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
 import io.legohunter.data.mybatis.mapper.TransactionCostMapper;
 import io.legohunter.data.mybatis.mapper.TransactionItemCostMapper;
@@ -296,6 +297,8 @@ class DaoDelegationCoverageTest {
         PricingDecisionMapper mapper = mock(PricingDecisionMapper.class);
         PricingDecisionDao dao = new PricingDecisionDao(mapper);
 
+        dao.countLatestByDecisionStatusCode("PROPOSED");
+        dao.countLatestUnappliedByDecisionStatusCode("PROPOSED");
         dao.findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
         dao.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
                 1,
@@ -304,6 +307,8 @@ class DaoDelegationCoverageTest {
                 25
         );
 
+        verify(mapper).countLatestByDecisionStatusCode("PROPOSED");
+        verify(mapper).countLatestUnappliedByDecisionStatusCode("PROPOSED");
         verify(mapper).findLatestReviewsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 25);
         verify(mapper).findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
                 1,
@@ -311,5 +316,22 @@ class DaoDelegationCoverageTest {
                 "PROPOSED",
                 25
         );
+    }
+
+    @Test
+    void pricingCrawlWorkItemDaoCoversObservabilityCounts() {
+        PricingCrawlWorkItemMapper mapper = mock(PricingCrawlWorkItemMapper.class);
+        PricingCrawlWorkItemDao dao = new PricingCrawlWorkItemDao(mapper);
+        ZonedDateTime now = ZonedDateTime.parse("2026-06-25T10:00:00Z");
+
+        dao.countByWorkStatusCode("PENDING");
+        dao.countDueByWorkStatusCode("PENDING", now);
+        dao.countRetryableByWorkStatusCode("PENDING");
+        dao.countStaleClaimed("CLAIMED", now.minusHours(2));
+
+        verify(mapper).countByWorkStatusCode("PENDING");
+        verify(mapper).countDueByWorkStatusCode("PENDING", now);
+        verify(mapper).countRetryableByWorkStatusCode("PENDING");
+        verify(mapper).countStaleClaimed("CLAIMED", now.minusHours(2));
     }
 }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -58,6 +58,9 @@ class PricingPlaneDaoTest {
         assertThat(pricingCrawlWorkItemDao.findByPricingCrawlWorkItemId(workItem.getPricingCrawlWorkItemId())).isPresent();
         assertThat(pricingCrawlWorkItemDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
         assertThat(pricingCrawlWorkItemDao.findByWorkStatusCode("CLAIMED")).hasSize(1);
+        assertThat(pricingCrawlWorkItemDao.countByWorkStatusCode("CLAIMED")).isOne();
+        assertThat(pricingCrawlWorkItemDao.countDueByWorkStatusCode("CLAIMED", CRAWL_AT.plusMinutes(1))).isOne();
+        assertThat(pricingCrawlWorkItemDao.countRetryableByWorkStatusCode("CLAIMED")).isZero();
         assertThat(pricingCrawlWorkItemDao.findDueByWorkStatusCode("CLAIMED", CRAWL_AT.plusMinutes(1), 5)).hasSize(1);
         assertThat(pricingCrawlWorkItemDao.findAll()).hasSize(1);
         workItem.setWorkStatusCode("SUCCEEDED");
@@ -100,6 +103,8 @@ class PricingPlaneDaoTest {
         assertThat(pricingDecisionDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
         assertThat(pricingDecisionDao.findByDecisionStatusCode("APPLIED")).hasSize(1);
         assertThat(pricingDecisionDao.findByReasonCode("MATCHED_LOWEST_COMPETITOR")).hasSize(1);
+        assertThat(pricingDecisionDao.countLatestByDecisionStatusCode("APPLIED")).isOne();
+        assertThat(pricingDecisionDao.countLatestUnappliedByDecisionStatusCode("APPLIED")).isZero();
         assertThat(pricingDecisionDao.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
                 .map(PricingDecision::getPricingDecisionId)
                 .contains(decision.getPricingDecisionId());
@@ -136,6 +141,7 @@ class PricingPlaneDaoTest {
                     assertThat(found.getAttemptCount()).isOne();
                     assertThat(found.getClaimedAt()).isEqualTo(CRAWL_AT);
                 });
+        assertThat(pricingCrawlWorkItemDao.countStaleClaimed("CLAIMED", CRAWL_AT.plusMinutes(10))).isOne();
 
         assertThat(pricingCrawlWorkItemDao.requeueStaleClaimed(
                 "CLAIMED",

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -48,6 +48,41 @@ public interface PricingCrawlWorkItemMapper {
     @ResultMap("pricingCrawlWorkItemResultMap")
     Set<PricingCrawlWorkItem> findByWorkStatusCode(String workStatusCode);
 
+    @Select("SELECT COUNT(*) FROM pricing_crawl_work_item WHERE work_status_code = #{workStatusCode}")
+    long countByWorkStatusCode(String workStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item
+            WHERE work_status_code = #{workStatusCode}
+              AND next_attempt_at <= #{dueAt}
+            """)
+    long countDueByWorkStatusCode(
+            @Param("workStatusCode") String workStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt
+    );
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item
+            WHERE work_status_code = #{workStatusCode}
+              AND COALESCE(attempt_count, 0) > 0
+              AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+            """)
+    long countRetryableByWorkStatusCode(String workStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item
+            WHERE work_status_code = #{claimedStatusCode}
+              AND claimed_at <= #{claimedBefore}
+              AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+            """)
+    long countStaleClaimed(
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("claimedBefore") ZonedDateTime claimedBefore
+    );
+
     @Select("""
             SELECT ${columns}
             FROM pricing_crawl_work_item

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -89,6 +89,35 @@ public interface PricingDecisionMapper {
     Set<PricingDecision> findByReasonCode(String reasonCode);
 
     @Select("""
+            SELECT COUNT(*)
+            FROM pricing_decision pd
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_decision_id = pd.pricing_decision_id
+            WHERE pd.decision_status_code = #{decisionStatusCode}
+            """)
+    long countLatestByDecisionStatusCode(String decisionStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_decision pd
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_decision_id = pd.pricing_decision_id
+            WHERE pd.decision_status_code = #{decisionStatusCode}
+              AND pd.applied_at IS NULL
+            """)
+    long countLatestUnappliedByDecisionStatusCode(String decisionStatusCode);
+
+    @Select("""
             SELECT ${columns}
             FROM pricing_decision
             WHERE marketplace_listing_id = #{marketplaceListingId}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -61,6 +61,15 @@ class PricingPlaneMapperTest extends MapperTestSupport {
     void pricingCrawlWorkItemSupportsClaimAndStaleRequeue() {
         PricingFixture fixture = pricingFixture("pricing-work-claim");
         PricingCrawlWorkItem dueWorkItem = insertedWorkItem(fixture, CRAWL_AT.minusMinutes(1));
+        PricingCrawlWorkItem retryableWorkItem = pricingCrawlWorkItem(
+                fixture.listing().getMarketplaceListingId(),
+                fixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusHours(6)
+        );
+        retryableWorkItem.setAttemptCount(1);
+        retryableWorkItem.setMaxAttempts(3);
+        pricingCrawlWorkItemMapper.insert(retryableWorkItem);
         PricingCrawlWorkItem maxedWorkItem = pricingCrawlWorkItem(
                 fixture.listing().getMarketplaceListingId(),
                 fixture.catalogItem().getExternalCatalogItemId(),
@@ -71,6 +80,9 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         maxedWorkItem.setMaxAttempts(3);
         pricingCrawlWorkItemMapper.insert(maxedWorkItem);
 
+        assertThat(pricingCrawlWorkItemMapper.countByWorkStatusCode("PENDING")).isEqualTo(3);
+        assertThat(pricingCrawlWorkItemMapper.countDueByWorkStatusCode("PENDING", CRAWL_AT)).isEqualTo(2);
+        assertThat(pricingCrawlWorkItemMapper.countRetryableByWorkStatusCode("PENDING")).isOne();
         assertThat(pricingCrawlWorkItemMapper.findClaimableByWorkStatusCode("PENDING", CRAWL_AT, 10))
                 .extracting(PricingCrawlWorkItem::getPricingCrawlWorkItemId)
                 .containsExactly(dueWorkItem.getPricingCrawlWorkItemId());
@@ -96,6 +108,7 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                     assertThat(found.getAttemptCount()).isOne();
                     assertThat(found.getClaimedAt()).isEqualTo(CRAWL_AT);
                 });
+        assertThat(pricingCrawlWorkItemMapper.countStaleClaimed("CLAIMED", CRAWL_AT.plusMinutes(5))).isOne();
 
         assertThat(pricingCrawlWorkItemMapper.requeueStaleClaimed(
                 "CLAIMED",
@@ -369,6 +382,10 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         latestFailedDecision.setReasonCode("NO_CURRENT_SNAPSHOT");
         latestFailedDecision.setFinalPrice(null);
         pricingDecisionMapper.insert(latestFailedDecision);
+
+        assertThat(pricingDecisionMapper.countLatestByDecisionStatusCode("PROPOSED")).isEqualTo(2);
+        assertThat(pricingDecisionMapper.countLatestUnappliedByDecisionStatusCode("PROPOSED")).isOne();
+        assertThat(pricingDecisionMapper.countLatestByDecisionStatusCode("FAILED")).isOne();
 
         Set<PricingDecisionReview> reviews = pricingDecisionMapper
                 .findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(


### PR DESCRIPTION
## Summary
- Add Pricing Plane count APIs for current crawl work item state: by status, due, retryable, and stale claimed.
- Add latest pricing decision count APIs by status and unapplied status for observability gauges.
- Cover the new mapper and DAO methods with H2 integration and delegation tests.

## Verification
- `mvn clean install`

## Review Notes
This PR should be reviewed and merged before the `lego-data-ingress` Phase 7 PR because ingress consumes these new DAO methods for Micrometer gauges.