### PR TITLE
Pricing Plane Phase 8: data quality diagnostics

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -1,6 +1,7 @@
 package io.legohunter.data.dao;
 
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingHydrationGap;
 import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -90,6 +91,18 @@ public class MarketplaceListingDao {
 
     public Optional<MarketplaceListing> findByListingExternalServiceIdAndExternalListingId(Integer listingExternalServiceId, String externalListingId) {
         return marketplaceListingMapper.findByListingExternalServiceIdAndExternalListingId(listingExternalServiceId, externalListingId);
+    }
+
+    public Set<PricingHydrationGap> findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(
+            Integer listingExternalServiceId,
+            String listingStatusCode,
+            int limit
+    ) {
+        return marketplaceListingMapper.findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(
+                listingExternalServiceId,
+                listingStatusCode,
+                Math.max(1, limit)
+        );
     }
 
     public MarketplaceListing insert(MarketplaceListing marketplaceListing) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -1,6 +1,8 @@
 package io.legohunter.data.dao;
 
 import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -47,6 +49,26 @@ public class PricingCrawlWorkItemDao {
 
     public long countStaleClaimed(String claimedStatusCode, ZonedDateTime claimedBefore) {
         return pricingCrawlWorkItemMapper.countStaleClaimed(claimedStatusCode, claimedBefore);
+    }
+
+    public PricingCrawlWorkItemMaintenanceSummary summarizeMaintenance(
+            String pendingStatusCode,
+            String claimedStatusCode,
+            String succeededStatusCode,
+            ZonedDateTime dueAt,
+            ZonedDateTime claimedBefore
+    ) {
+        return pricingCrawlWorkItemMapper.summarizeMaintenance(
+                pendingStatusCode,
+                claimedStatusCode,
+                succeededStatusCode,
+                dueAt,
+                claimedBefore
+        );
+    }
+
+    public Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(String pendingStatusCode, int limit) {
+        return pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems(pendingStatusCode, Math.max(1, limit));
     }
 
     public Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -276,6 +276,9 @@ class DaoDelegationCoverageTest {
                 1, "ACTIVE", "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
         )).containsExactly(listing);
 
+        dao.findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 0);
+        verify(mapper).findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 1);
+
         MarketplaceListing missingIdListing = MarketplaceListing.builder()
                 .listingExternalServiceId(1)
                 .externalListingId("remote-2")
@@ -328,10 +331,14 @@ class DaoDelegationCoverageTest {
         dao.countDueByWorkStatusCode("PENDING", now);
         dao.countRetryableByWorkStatusCode("PENDING");
         dao.countStaleClaimed("CLAIMED", now.minusHours(2));
+        dao.summarizeMaintenance("PENDING", "CLAIMED", "SUCCEEDED", now, now.minusHours(2));
+        dao.findDuplicateMarketplaceListingWorkItems("PENDING", 0);
 
         verify(mapper).countByWorkStatusCode("PENDING");
         verify(mapper).countDueByWorkStatusCode("PENDING", now);
         verify(mapper).countRetryableByWorkStatusCode("PENDING");
         verify(mapper).countStaleClaimed("CLAIMED", now.minusHours(2));
+        verify(mapper).summarizeMaintenance("PENDING", "CLAIMED", "SUCCEEDED", now, now.minusHours(2));
+        verify(mapper).findDuplicateMarketplaceListingWorkItems("PENDING", 1);
     }
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemDuplicate.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemDuplicate.java
@@ -1,0 +1,18 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingCrawlWorkItemDuplicate {
+    private Integer marketplaceListingId;
+    private Integer workItemCount;
+    private Integer pendingCount;
+    private String workStatusCodes;
+    private String pricingCrawlWorkItemIds;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemMaintenanceSummary.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemMaintenanceSummary.java
@@ -1,0 +1,26 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingCrawlWorkItemMaintenanceSummary {
+    private Long workItemCount;
+    private Long distinctMarketplaceListingCount;
+    private Long duplicateWorkItemCount;
+    private Long pendingWorkItemCount;
+    private Long distinctPendingMarketplaceListingCount;
+    private Long duplicatePendingWorkItemCount;
+    private Long duePendingWorkItemCount;
+    private Long retryablePendingWorkItemCount;
+    private Long claimedWorkItemCount;
+    private Long staleClaimedWorkItemCount;
+    private Long succeededWorkItemCount;
+    private Long skippedWorkItemCount;
+    private Long failedWorkItemCount;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingHydrationGap.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingHydrationGap.java
@@ -1,0 +1,22 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingHydrationGap {
+    private Integer marketplaceListingId;
+    private String externalListingId;
+    private Integer externalCatalogItemId;
+    private String externalItemKey;
+    private String externalUniqueKey;
+    private Integer itemInventoryId;
+    private String itemInventoryUuid;
+    private String newOrUsed;
+    private String completeness;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -1,11 +1,14 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingHydrationGap;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
@@ -162,6 +165,44 @@ public interface MarketplaceListingMapper {
     );
 
     Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit
+    );
+
+    @Select("""
+            SELECT ml.marketplace_listing_id,
+                   ml.external_listing_id,
+                   eci.external_catalog_item_id,
+                   eci.external_item_key,
+                   eci.external_unique_key,
+                   ii.item_inventory_id,
+                   ii.uuid AS item_inventory_uuid,
+                   ii.new_or_used,
+                   ii.completeness
+            FROM marketplace_listing ml
+            JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code = #{listingStatusCode}
+              AND (eci.external_unique_key IS NULL OR eci.external_unique_key = '')
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @Results(id = "pricingHydrationGapResultMap", value = {
+            @Result(property = "marketplaceListingId", column = "marketplace_listing_id"),
+            @Result(property = "externalListingId", column = "external_listing_id"),
+            @Result(property = "externalCatalogItemId", column = "external_catalog_item_id"),
+            @Result(property = "externalItemKey", column = "external_item_key"),
+            @Result(property = "externalUniqueKey", column = "external_unique_key"),
+            @Result(property = "itemInventoryId", column = "item_inventory_id"),
+            @Result(property = "itemInventoryUuid", column = "item_inventory_uuid"),
+            @Result(property = "newOrUsed", column = "new_or_used"),
+            @Result(property = "completeness", column = "completeness")
+    })
+    Set<PricingHydrationGap> findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
             @Param("listingStatusCode") String listingStatusCode,
             @Param("limit") int limit

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -7,8 +7,6 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.Results;
-import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
@@ -191,17 +189,7 @@ public interface MarketplaceListingMapper {
             ORDER BY ml.marketplace_listing_id
             LIMIT #{limit}
             """)
-    @Results(id = "pricingHydrationGapResultMap", value = {
-            @Result(property = "marketplaceListingId", column = "marketplace_listing_id"),
-            @Result(property = "externalListingId", column = "external_listing_id"),
-            @Result(property = "externalCatalogItemId", column = "external_catalog_item_id"),
-            @Result(property = "externalItemKey", column = "external_item_key"),
-            @Result(property = "externalUniqueKey", column = "external_unique_key"),
-            @Result(property = "itemInventoryId", column = "item_inventory_id"),
-            @Result(property = "itemInventoryUuid", column = "item_inventory_uuid"),
-            @Result(property = "newOrUsed", column = "new_or_used"),
-            @Result(property = "completeness", column = "completeness")
-    })
+    @ResultMap("pricingHydrationGapResultMap")
     Set<PricingHydrationGap> findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
             @Param("listingStatusCode") String listingStatusCode,

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -1,11 +1,15 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
@@ -81,6 +85,79 @@ public interface PricingCrawlWorkItemMapper {
     long countStaleClaimed(
             @Param("claimedStatusCode") String claimedStatusCode,
             @Param("claimedBefore") ZonedDateTime claimedBefore
+    );
+
+    @Select("""
+            SELECT COUNT(*) AS work_item_count,
+                   COUNT(DISTINCT marketplace_listing_id) AS distinct_marketplace_listing_count,
+                   COUNT(*) - COUNT(DISTINCT marketplace_listing_id) AS duplicate_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code = #{pendingStatusCode} THEN 1 ELSE 0 END), 0) AS pending_work_item_count,
+                   COUNT(DISTINCT CASE WHEN work_status_code = #{pendingStatusCode} THEN marketplace_listing_id END) AS distinct_pending_marketplace_listing_count,
+                   COALESCE(SUM(CASE WHEN work_status_code = #{pendingStatusCode} THEN 1 ELSE 0 END), 0)
+                       - COUNT(DISTINCT CASE WHEN work_status_code = #{pendingStatusCode} THEN marketplace_listing_id END) AS duplicate_pending_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code = #{pendingStatusCode} AND next_attempt_at <= #{dueAt} THEN 1 ELSE 0 END), 0) AS due_pending_work_item_count,
+                   COALESCE(SUM(CASE
+                       WHEN work_status_code = #{pendingStatusCode}
+                        AND COALESCE(attempt_count, 0) > 0
+                        AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+                       THEN 1 ELSE 0 END), 0) AS retryable_pending_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code = #{claimedStatusCode} THEN 1 ELSE 0 END), 0) AS claimed_work_item_count,
+                   COALESCE(SUM(CASE
+                       WHEN work_status_code = #{claimedStatusCode}
+                        AND claimed_at <= #{claimedBefore}
+                        AND COALESCE(attempt_count, 0) < COALESCE(max_attempts, 3)
+                       THEN 1 ELSE 0 END), 0) AS stale_claimed_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code = #{succeededStatusCode} THEN 1 ELSE 0 END), 0) AS succeeded_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code LIKE 'SKIPPED%' THEN 1 ELSE 0 END), 0) AS skipped_work_item_count,
+                   COALESCE(SUM(CASE WHEN work_status_code LIKE 'FAILED%' THEN 1 ELSE 0 END), 0) AS failed_work_item_count
+            FROM pricing_crawl_work_item
+            """)
+    @Results(id = "pricingCrawlWorkItemMaintenanceSummaryResultMap", value = {
+            @Result(property = "workItemCount", column = "work_item_count"),
+            @Result(property = "distinctMarketplaceListingCount", column = "distinct_marketplace_listing_count"),
+            @Result(property = "duplicateWorkItemCount", column = "duplicate_work_item_count"),
+            @Result(property = "pendingWorkItemCount", column = "pending_work_item_count"),
+            @Result(property = "distinctPendingMarketplaceListingCount", column = "distinct_pending_marketplace_listing_count"),
+            @Result(property = "duplicatePendingWorkItemCount", column = "duplicate_pending_work_item_count"),
+            @Result(property = "duePendingWorkItemCount", column = "due_pending_work_item_count"),
+            @Result(property = "retryablePendingWorkItemCount", column = "retryable_pending_work_item_count"),
+            @Result(property = "claimedWorkItemCount", column = "claimed_work_item_count"),
+            @Result(property = "staleClaimedWorkItemCount", column = "stale_claimed_work_item_count"),
+            @Result(property = "succeededWorkItemCount", column = "succeeded_work_item_count"),
+            @Result(property = "skippedWorkItemCount", column = "skipped_work_item_count"),
+            @Result(property = "failedWorkItemCount", column = "failed_work_item_count")
+    })
+    PricingCrawlWorkItemMaintenanceSummary summarizeMaintenance(
+            @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("succeededStatusCode") String succeededStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt,
+            @Param("claimedBefore") ZonedDateTime claimedBefore
+    );
+
+    @Select("""
+            SELECT marketplace_listing_id,
+                   COUNT(*) AS work_item_count,
+                   SUM(CASE WHEN work_status_code = #{pendingStatusCode} THEN 1 ELSE 0 END) AS pending_count,
+                   GROUP_CONCAT(work_status_code ORDER BY pricing_crawl_work_item_id SEPARATOR ',') AS work_status_codes,
+                   GROUP_CONCAT(pricing_crawl_work_item_id ORDER BY pricing_crawl_work_item_id SEPARATOR ',') AS pricing_crawl_work_item_ids
+            FROM pricing_crawl_work_item
+            GROUP BY marketplace_listing_id
+            HAVING COUNT(*) > 1
+            ORDER BY work_item_count DESC,
+                     marketplace_listing_id
+            LIMIT #{limit}
+            """)
+    @Results(id = "pricingCrawlWorkItemDuplicateResultMap", value = {
+            @Result(property = "marketplaceListingId", column = "marketplace_listing_id"),
+            @Result(property = "workItemCount", column = "work_item_count"),
+            @Result(property = "pendingCount", column = "pending_count"),
+            @Result(property = "workStatusCodes", column = "work_status_codes"),
+            @Result(property = "pricingCrawlWorkItemIds", column = "pricing_crawl_work_item_ids")
+    })
+    Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(
+            @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("limit") int limit
     );
 
     @Select("""

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -7,9 +7,7 @@ import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
@@ -112,21 +110,7 @@ public interface PricingCrawlWorkItemMapper {
                    COALESCE(SUM(CASE WHEN work_status_code LIKE 'FAILED%' THEN 1 ELSE 0 END), 0) AS failed_work_item_count
             FROM pricing_crawl_work_item
             """)
-    @Results(id = "pricingCrawlWorkItemMaintenanceSummaryResultMap", value = {
-            @Result(property = "workItemCount", column = "work_item_count"),
-            @Result(property = "distinctMarketplaceListingCount", column = "distinct_marketplace_listing_count"),
-            @Result(property = "duplicateWorkItemCount", column = "duplicate_work_item_count"),
-            @Result(property = "pendingWorkItemCount", column = "pending_work_item_count"),
-            @Result(property = "distinctPendingMarketplaceListingCount", column = "distinct_pending_marketplace_listing_count"),
-            @Result(property = "duplicatePendingWorkItemCount", column = "duplicate_pending_work_item_count"),
-            @Result(property = "duePendingWorkItemCount", column = "due_pending_work_item_count"),
-            @Result(property = "retryablePendingWorkItemCount", column = "retryable_pending_work_item_count"),
-            @Result(property = "claimedWorkItemCount", column = "claimed_work_item_count"),
-            @Result(property = "staleClaimedWorkItemCount", column = "stale_claimed_work_item_count"),
-            @Result(property = "succeededWorkItemCount", column = "succeeded_work_item_count"),
-            @Result(property = "skippedWorkItemCount", column = "skipped_work_item_count"),
-            @Result(property = "failedWorkItemCount", column = "failed_work_item_count")
-    })
+    @ResultMap("pricingCrawlWorkItemMaintenanceSummaryResultMap")
     PricingCrawlWorkItemMaintenanceSummary summarizeMaintenance(
             @Param("pendingStatusCode") String pendingStatusCode,
             @Param("claimedStatusCode") String claimedStatusCode,
@@ -148,13 +132,7 @@ public interface PricingCrawlWorkItemMapper {
                      marketplace_listing_id
             LIMIT #{limit}
             """)
-    @Results(id = "pricingCrawlWorkItemDuplicateResultMap", value = {
-            @Result(property = "marketplaceListingId", column = "marketplace_listing_id"),
-            @Result(property = "workItemCount", column = "work_item_count"),
-            @Result(property = "pendingCount", column = "pending_count"),
-            @Result(property = "workStatusCodes", column = "work_status_codes"),
-            @Result(property = "pricingCrawlWorkItemIds", column = "pricing_crawl_work_item_ids")
-    })
+    @ResultMap("pricingCrawlWorkItemDuplicateResultMap")
     Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(
             @Param("pendingStatusCode") String pendingStatusCode,
             @Param("limit") int limit

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
@@ -26,6 +26,18 @@
                  javaType="io.legohunter.data.dto.ExternalCatalogItem"/>
   </resultMap>
 
+  <resultMap type="io.legohunter.data.dto.PricingHydrationGap" id="pricingHydrationGapResultMap">
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="external_listing_id"        property="externalListingId"/>
+    <result column="external_catalog_item_id"   property="externalCatalogItemId"/>
+    <result column="external_item_key"          property="externalItemKey"/>
+    <result column="external_unique_key"        property="externalUniqueKey"/>
+    <result column="item_inventory_id"          property="itemInventoryId"/>
+    <result column="item_inventory_uuid"        property="itemInventoryUuid"/>
+    <result column="new_or_used"                property="newOrUsed"/>
+    <result column="completeness"               property="completeness"/>
+  </resultMap>
+
   <sql id="marketplaceListingColumns">
     ml.marketplace_listing_id,
     ml.item_inventory_id,

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
@@ -17,4 +17,28 @@
     <result column="created_at"                 property="createdAt"/>
     <result column="updated_at"                 property="updatedAt"/>
   </resultMap>
+
+  <resultMap type="io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary" id="pricingCrawlWorkItemMaintenanceSummaryResultMap">
+    <result column="work_item_count"                              property="workItemCount"/>
+    <result column="distinct_marketplace_listing_count"           property="distinctMarketplaceListingCount"/>
+    <result column="duplicate_work_item_count"                    property="duplicateWorkItemCount"/>
+    <result column="pending_work_item_count"                      property="pendingWorkItemCount"/>
+    <result column="distinct_pending_marketplace_listing_count"   property="distinctPendingMarketplaceListingCount"/>
+    <result column="duplicate_pending_work_item_count"            property="duplicatePendingWorkItemCount"/>
+    <result column="due_pending_work_item_count"                  property="duePendingWorkItemCount"/>
+    <result column="retryable_pending_work_item_count"            property="retryablePendingWorkItemCount"/>
+    <result column="claimed_work_item_count"                      property="claimedWorkItemCount"/>
+    <result column="stale_claimed_work_item_count"                property="staleClaimedWorkItemCount"/>
+    <result column="succeeded_work_item_count"                    property="succeededWorkItemCount"/>
+    <result column="skipped_work_item_count"                      property="skippedWorkItemCount"/>
+    <result column="failed_work_item_count"                       property="failedWorkItemCount"/>
+  </resultMap>
+
+  <resultMap type="io.legohunter.data.dto.PricingCrawlWorkItemDuplicate" id="pricingCrawlWorkItemDuplicateResultMap">
+    <result column="marketplace_listing_id"        property="marketplaceListingId"/>
+    <result column="work_item_count"               property="workItemCount"/>
+    <result column="pending_count"                 property="pendingCount"/>
+    <result column="work_status_codes"             property="workStatusCodes"/>
+    <result column="pricing_crawl_work_item_ids"   property="pricingCrawlWorkItemIds"/>
+  </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -4,8 +4,11 @@ import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
+import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import io.legohunter.data.dto.PricingDecision;
 import io.legohunter.data.dto.PricingDecisionReview;
+import io.legohunter.data.dto.PricingHydrationGap;
 import io.legohunter.data.dto.PricingSnapshot;
 import io.legohunter.data.dto.PricingSnapshotListing;
 import org.junit.jupiter.api.Test;
@@ -123,6 +126,120 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                     assertThat(found.getClaimedAt()).isNull();
                     assertThat(found.getNextAttemptAt()).isEqualTo(CRAWL_AT.plusHours(1));
                     assertThat(found.getLastErrorMessage()).isEqualTo("Recovered stale claim");
+                });
+    }
+
+    @Test
+    void pricingCrawlWorkItemMaintenanceSummaryAndDuplicateReportExposeQueueHygiene() {
+        PricingFixture duplicateFixture = pricingFixture("pricing-work-maintenance-duplicate");
+        PricingCrawlWorkItem pendingDue = insertedWorkItem(duplicateFixture, CRAWL_AT.minusMinutes(1));
+
+        PricingCrawlWorkItem pendingRetryable = pricingCrawlWorkItem(
+                duplicateFixture.listing().getMarketplaceListingId(),
+                duplicateFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusMinutes(2)
+        );
+        pendingRetryable.setAttemptCount(1);
+        pendingRetryable.setMaxAttempts(3);
+        pricingCrawlWorkItemMapper.insert(pendingRetryable);
+
+        PricingCrawlWorkItem staleClaimed = pricingCrawlWorkItem(
+                duplicateFixture.listing().getMarketplaceListingId(),
+                duplicateFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusHours(2)
+        );
+        staleClaimed.setWorkStatusCode("CLAIMED");
+        staleClaimed.setAttemptCount(1);
+        staleClaimed.setMaxAttempts(3);
+        staleClaimed.setClaimedAt(CRAWL_AT.minusHours(3));
+        pricingCrawlWorkItemMapper.insert(staleClaimed);
+
+        PricingFixture terminalFixture = pricingFixture("pricing-work-maintenance-terminal");
+        PricingCrawlWorkItem succeeded = insertedWorkItem(terminalFixture, CRAWL_AT.plusDays(7));
+        succeeded.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.update(succeeded);
+
+        PricingCrawlWorkItem skipped = pricingCrawlWorkItem(
+                terminalFixture.listing().getMarketplaceListingId(),
+                terminalFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusDays(7)
+        );
+        skipped.setWorkStatusCode("SKIPPED_MISSING_CONDITION");
+        pricingCrawlWorkItemMapper.insert(skipped);
+
+        PricingCrawlWorkItem failed = pricingCrawlWorkItem(
+                terminalFixture.listing().getMarketplaceListingId(),
+                terminalFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusDays(7)
+        );
+        failed.setWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH");
+        pricingCrawlWorkItemMapper.insert(failed);
+
+        PricingCrawlWorkItemMaintenanceSummary summary = pricingCrawlWorkItemMapper.summarizeMaintenance(
+                "PENDING",
+                "CLAIMED",
+                "SUCCEEDED",
+                CRAWL_AT,
+                CRAWL_AT.minusHours(1)
+        );
+
+        assertThat(summary.getWorkItemCount()).isEqualTo(6);
+        assertThat(summary.getDistinctMarketplaceListingCount()).isEqualTo(2);
+        assertThat(summary.getDuplicateWorkItemCount()).isEqualTo(4);
+        assertThat(summary.getPendingWorkItemCount()).isEqualTo(2);
+        assertThat(summary.getDistinctPendingMarketplaceListingCount()).isOne();
+        assertThat(summary.getDuplicatePendingWorkItemCount()).isOne();
+        assertThat(summary.getDuePendingWorkItemCount()).isEqualTo(2);
+        assertThat(summary.getRetryablePendingWorkItemCount()).isOne();
+        assertThat(summary.getClaimedWorkItemCount()).isOne();
+        assertThat(summary.getStaleClaimedWorkItemCount()).isOne();
+        assertThat(summary.getSucceededWorkItemCount()).isOne();
+        assertThat(summary.getSkippedWorkItemCount()).isOne();
+        assertThat(summary.getFailedWorkItemCount()).isOne();
+
+        Set<PricingCrawlWorkItemDuplicate> duplicates = pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems("PENDING", 10);
+
+        assertThat(duplicates)
+                .filteredOn(duplicate -> duplicate.getMarketplaceListingId().equals(duplicateFixture.listing().getMarketplaceListingId()))
+                .singleElement()
+                .satisfies(duplicate -> {
+                    assertThat(duplicate.getWorkItemCount()).isEqualTo(3);
+                    assertThat(duplicate.getPendingCount()).isEqualTo(2);
+                    assertThat(duplicate.getWorkStatusCodes()).contains("PENDING", "CLAIMED");
+                    assertThat(duplicate.getPricingCrawlWorkItemIds()).contains(String.valueOf(pendingDue.getPricingCrawlWorkItemId()));
+                });
+    }
+
+    @Test
+    void marketplaceListingMapperReportsActivePricingHydrationGaps() {
+        PricingFixture missingHydration = pricingFixture("pricing-hydration-gap");
+        missingHydration.catalogItem().setExternalUniqueKey(null);
+        externalCatalogItemMapper.update(missingHydration.catalogItem());
+
+        PricingFixture hydrated = pricingFixture("pricing-hydration-complete");
+
+        Set<PricingHydrationGap> gaps = marketplaceListingMapper.findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(
+                2,
+                "ACTIVE",
+                10
+        );
+
+        assertThat(gaps)
+                .extracting(PricingHydrationGap::getMarketplaceListingId)
+                .contains(missingHydration.listing().getMarketplaceListingId())
+                .doesNotContain(hydrated.listing().getMarketplaceListingId());
+        assertThat(gaps)
+                .filteredOn(gap -> gap.getMarketplaceListingId().equals(missingHydration.listing().getMarketplaceListingId()))
+                .singleElement()
+                .satisfies(gap -> {
+                    assertThat(gap.getExternalItemKey()).isEqualTo("pricing-hydration-gap");
+                    assertThat(gap.getExternalUniqueKey()).isNull();
+                    assertThat(gap.getNewOrUsed()).isEqualTo("USED");
+                    assertThat(gap.getCompleteness()).isEqualTo("COMPLETE");
                 });
     }
 


### PR DESCRIPTION
## Summary

Adds data-layer diagnostics for Pricing Plane Phase 8.

- Adds DTOs for crawl queue maintenance summaries, duplicate crawl work item reports, and active BrickLink hydration gaps.
- Adds MyBatis mapper queries and DAO methods for dry-run maintenance/reporting use cases.
- Normalizes report limits and coalesces empty aggregate counts to zero.
- Adds mapper and DAO coverage for maintenance summary, duplicate work items, hydration gaps, and limit normalization.

## Verification

- `mvn -pl lego-data-mybatis,lego-data-dao -am test`
- `mvn clean install`