### PR TITLE
Fix Pricing Plane phase 8 crawl diagnostics

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -2,6 +2,7 @@ package io.legohunter.data.dao;
 
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemFailure;
 import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
 import lombok.RequiredArgsConstructor;
@@ -67,8 +68,16 @@ public class PricingCrawlWorkItemDao {
         );
     }
 
-    public Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(String pendingStatusCode, int limit) {
-        return pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems(pendingStatusCode, Math.max(1, limit));
+    public Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(
+            String pendingStatusCode,
+            String claimedStatusCode,
+            int limit
+    ) {
+        return pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems(pendingStatusCode, claimedStatusCode, Math.max(1, limit));
+    }
+
+    public Set<PricingCrawlWorkItemFailure> findRecentFailures(int limit) {
+        return pricingCrawlWorkItemMapper.findRecentFailures(Math.max(1, limit));
     }
 
     public Set<PricingCrawlWorkItem> findDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt, int limit) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -332,13 +332,15 @@ class DaoDelegationCoverageTest {
         dao.countRetryableByWorkStatusCode("PENDING");
         dao.countStaleClaimed("CLAIMED", now.minusHours(2));
         dao.summarizeMaintenance("PENDING", "CLAIMED", "SUCCEEDED", now, now.minusHours(2));
-        dao.findDuplicateMarketplaceListingWorkItems("PENDING", 0);
+        dao.findDuplicateMarketplaceListingWorkItems("PENDING", "CLAIMED", 0);
+        dao.findRecentFailures(0);
 
         verify(mapper).countByWorkStatusCode("PENDING");
         verify(mapper).countDueByWorkStatusCode("PENDING", now);
         verify(mapper).countRetryableByWorkStatusCode("PENDING");
         verify(mapper).countStaleClaimed("CLAIMED", now.minusHours(2));
         verify(mapper).summarizeMaintenance("PENDING", "CLAIMED", "SUCCEEDED", now, now.minusHours(2));
-        verify(mapper).findDuplicateMarketplaceListingWorkItems("PENDING", 1);
+        verify(mapper).findDuplicateMarketplaceListingWorkItems("PENDING", "CLAIMED", 1);
+        verify(mapper).findRecentFailures(1);
     }
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemFailure.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingCrawlWorkItemFailure.java
@@ -1,0 +1,33 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingCrawlWorkItemFailure {
+    private Long pricingCrawlWorkItemId;
+    private Integer marketplaceListingId;
+    private String externalListingId;
+    private Integer externalCatalogItemId;
+    private String externalItemKey;
+    private String externalUniqueKey;
+    private Integer itemInventoryId;
+    private String itemInventoryUuid;
+    private String newOrUsed;
+    private String completeness;
+    private String workStatusCode;
+    private Integer attemptCount;
+    private Integer maxAttempts;
+    private ZonedDateTime nextAttemptAt;
+    private String sourceRequestUrl;
+    private String sourceRequestParameters;
+    private String lastErrorMessage;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -2,6 +2,7 @@ package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemFailure;
 import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
@@ -126,6 +127,7 @@ public interface PricingCrawlWorkItemMapper {
                    GROUP_CONCAT(work_status_code ORDER BY pricing_crawl_work_item_id SEPARATOR ',') AS work_status_codes,
                    GROUP_CONCAT(pricing_crawl_work_item_id ORDER BY pricing_crawl_work_item_id SEPARATOR ',') AS pricing_crawl_work_item_ids
             FROM pricing_crawl_work_item
+            WHERE work_status_code IN (#{pendingStatusCode}, #{claimedStatusCode})
             GROUP BY marketplace_listing_id
             HAVING COUNT(*) > 1
             ORDER BY work_item_count DESC,
@@ -135,8 +137,44 @@ public interface PricingCrawlWorkItemMapper {
     @ResultMap("pricingCrawlWorkItemDuplicateResultMap")
     Set<PricingCrawlWorkItemDuplicate> findDuplicateMarketplaceListingWorkItems(
             @Param("pendingStatusCode") String pendingStatusCode,
+            @Param("claimedStatusCode") String claimedStatusCode,
             @Param("limit") int limit
     );
+
+    @Select("""
+            SELECT pcwi.pricing_crawl_work_item_id,
+                   pcwi.marketplace_listing_id,
+                   ml.external_listing_id,
+                   pcwi.external_catalog_item_id,
+                   eci.external_item_key,
+                   eci.external_unique_key,
+                   ii.item_inventory_id,
+                   ii.uuid AS item_inventory_uuid,
+                   ii.new_or_used,
+                   ii.completeness,
+                   pcwi.work_status_code,
+                   pcwi.attempt_count,
+                   pcwi.max_attempts,
+                   pcwi.next_attempt_at,
+                   pcwi.source_request_url,
+                   pcwi.source_request_parameters,
+                   pcwi.last_error_message,
+                   pcwi.updated_at
+            FROM pricing_crawl_work_item pcwi
+            LEFT JOIN marketplace_listing ml
+              ON ml.marketplace_listing_id = pcwi.marketplace_listing_id
+            LEFT JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = pcwi.external_catalog_item_id
+            LEFT JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            WHERE pcwi.last_error_message IS NOT NULL
+               OR pcwi.work_status_code LIKE 'FAILED%'
+            ORDER BY pcwi.updated_at DESC,
+                     pcwi.pricing_crawl_work_item_id DESC
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingCrawlWorkItemFailureResultMap")
+    Set<PricingCrawlWorkItemFailure> findRecentFailures(int limit);
 
     @Select("""
             SELECT ${columns}

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.xml
@@ -41,4 +41,25 @@
     <result column="work_status_codes"             property="workStatusCodes"/>
     <result column="pricing_crawl_work_item_ids"   property="pricingCrawlWorkItemIds"/>
   </resultMap>
+
+  <resultMap type="io.legohunter.data.dto.PricingCrawlWorkItemFailure" id="pricingCrawlWorkItemFailureResultMap">
+    <id     column="pricing_crawl_work_item_id" property="pricingCrawlWorkItemId"/>
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="external_listing_id"        property="externalListingId"/>
+    <result column="external_catalog_item_id"   property="externalCatalogItemId"/>
+    <result column="external_item_key"          property="externalItemKey"/>
+    <result column="external_unique_key"        property="externalUniqueKey"/>
+    <result column="item_inventory_id"          property="itemInventoryId"/>
+    <result column="item_inventory_uuid"        property="itemInventoryUuid"/>
+    <result column="new_or_used"                property="newOrUsed"/>
+    <result column="completeness"               property="completeness"/>
+    <result column="work_status_code"           property="workStatusCode"/>
+    <result column="attempt_count"              property="attemptCount"/>
+    <result column="max_attempts"               property="maxAttempts"/>
+    <result column="next_attempt_at"            property="nextAttemptAt"/>
+    <result column="source_request_url"         property="sourceRequestUrl"/>
+    <result column="source_request_parameters"  property="sourceRequestParameters"/>
+    <result column="last_error_message"         property="lastErrorMessage"/>
+    <result column="updated_at"                 property="updatedAt"/>
+  </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -5,6 +5,7 @@ import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
+import io.legohunter.data.dto.PricingCrawlWorkItemFailure;
 import io.legohunter.data.dto.PricingCrawlWorkItemMaintenanceSummary;
 import io.legohunter.data.dto.PricingDecision;
 import io.legohunter.data.dto.PricingDecisionReview;
@@ -201,7 +202,16 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         assertThat(summary.getSkippedWorkItemCount()).isOne();
         assertThat(summary.getFailedWorkItemCount()).isOne();
 
-        Set<PricingCrawlWorkItemDuplicate> duplicates = pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems("PENDING", 10);
+        PricingCrawlWorkItem historicalTerminal = pricingCrawlWorkItem(
+                terminalFixture.listing().getMarketplaceListingId(),
+                terminalFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusDays(8)
+        );
+        historicalTerminal.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.insert(historicalTerminal);
+
+        Set<PricingCrawlWorkItemDuplicate> duplicates = pricingCrawlWorkItemMapper.findDuplicateMarketplaceListingWorkItems("PENDING", "CLAIMED", 10);
 
         assertThat(duplicates)
                 .filteredOn(duplicate -> duplicate.getMarketplaceListingId().equals(duplicateFixture.listing().getMarketplaceListingId()))
@@ -211,6 +221,42 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                     assertThat(duplicate.getPendingCount()).isEqualTo(2);
                     assertThat(duplicate.getWorkStatusCodes()).contains("PENDING", "CLAIMED");
                     assertThat(duplicate.getPricingCrawlWorkItemIds()).contains(String.valueOf(pendingDue.getPricingCrawlWorkItemId()));
+                });
+        assertThat(duplicates)
+                .extracting(PricingCrawlWorkItemDuplicate::getMarketplaceListingId)
+                .doesNotContain(terminalFixture.listing().getMarketplaceListingId());
+    }
+
+    @Test
+    void pricingCrawlWorkItemMapperReportsRecentFailuresWithListingContext() {
+        PricingFixture fixture = pricingFixture("pricing-work-failure-context");
+        PricingCrawlWorkItem failed = insertedWorkItem(fixture, CRAWL_AT);
+        failed.setWorkStatusCode("FAILED_PRICING_HTTP_ERROR");
+        failed.setAttemptCount(3);
+        failed.setMaxAttempts(3);
+        failed.setSourceRequestUrl("/ajax/clone/catalogifs.ajax");
+        failed.setSourceRequestParameters("{\"itemid\":4997,\"cond\":\"U\"}");
+        failed.setLastErrorMessage("GET https://www.bricklink.com/ajax/clone/catalogifs.ajax returned []");
+        pricingCrawlWorkItemMapper.update(failed);
+
+        Set<PricingCrawlWorkItemFailure> failures = pricingCrawlWorkItemMapper.findRecentFailures(10);
+
+        assertThat(failures)
+                .filteredOn(failure -> failure.getPricingCrawlWorkItemId().equals(failed.getPricingCrawlWorkItemId()))
+                .singleElement()
+                .satisfies(failure -> {
+                    assertThat(failure.getMarketplaceListingId()).isEqualTo(fixture.listing().getMarketplaceListingId());
+                    assertThat(failure.getExternalListingId()).isEqualTo(fixture.listing().getExternalListingId());
+                    assertThat(failure.getExternalItemKey()).isEqualTo("pricing-work-failure-context");
+                    assertThat(failure.getExternalUniqueKey()).isEqualTo("unique-pricing-work-failure-context");
+                    assertThat(failure.getItemInventoryUuid()).isEqualTo(fixture.inventory().getUuid());
+                    assertThat(failure.getNewOrUsed()).isEqualTo("USED");
+                    assertThat(failure.getCompleteness()).isEqualTo("COMPLETE");
+                    assertThat(failure.getWorkStatusCode()).isEqualTo("FAILED_PRICING_HTTP_ERROR");
+                    assertThat(failure.getAttemptCount()).isEqualTo(3);
+                    assertThat(failure.getLastErrorMessage()).contains("returned []");
+                    assertThat(failure.getSourceRequestUrl()).isEqualTo("/ajax/clone/catalogifs.ajax");
+                    assertThat(failure.getSourceRequestParameters()).contains("\"itemid\":4997");
                 });
     }
 


### PR DESCRIPTION
## Summary
- Add `PricingCrawlWorkItemFailure` DTO and MyBatis result map support for enriched pricing crawl failure diagnostics.
- Add DAO/mapper support for recent pricing crawl failures with listing, inventory, and catalog context.
- Tighten duplicate work item reporting so it only reports active `PENDING` and `CLAIMED` duplicates, not historical terminal rows.
- Add mapper and DAO unit coverage for the new diagnostics and duplicate-filtering behavior.

## Tests
- `mvn -pl lego-data-mybatis,lego-data-dao -am test '-Dtest=PricingPlaneMapperTest,DaoDelegationCoverageTest' '-Dsurefire.failIfNoSpecifiedTests=false'`
- `mvn clean install`

## Review Notes
Review this PR before the `lego-data-ingress` PR because ingress consumes the new DAO method and DTO.