### PR TITLE
Pricing Plane Phase 9 apply readiness data access

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingApplyReadinessDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingApplyReadinessDao.java
@@ -1,0 +1,90 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PricingApplyReadiness;
+import io.legohunter.data.dto.PricingApplyReadinessReview;
+import io.legohunter.data.mybatis.mapper.PricingApplyReadinessMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class PricingApplyReadinessDao {
+    private final PricingApplyReadinessMapper pricingApplyReadinessMapper;
+
+    public Set<PricingApplyReadiness> findAll() {
+        return pricingApplyReadinessMapper.findAll();
+    }
+
+    public Optional<PricingApplyReadiness> findByPricingApplyReadinessId(Long pricingApplyReadinessId) {
+        return pricingApplyReadinessMapper.findByPricingApplyReadinessId(pricingApplyReadinessId);
+    }
+
+    public Optional<PricingApplyReadiness> findByPricingDecisionId(Long pricingDecisionId) {
+        return pricingApplyReadinessMapper.findByPricingDecisionId(pricingDecisionId);
+    }
+
+    public Set<PricingApplyReadiness> findByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingApplyReadinessMapper.findByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingApplyReadiness> findByReadinessStatusCode(String readinessStatusCode) {
+        return pricingApplyReadinessMapper.findByReadinessStatusCode(readinessStatusCode);
+    }
+
+    public Set<PricingApplyReadiness> findByBlockReasonCode(String blockReasonCode) {
+        return pricingApplyReadinessMapper.findByBlockReasonCode(blockReasonCode);
+    }
+
+    public Optional<PricingApplyReadiness> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return pricingApplyReadinessMapper.findLatestByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<PricingApplyReadinessReview> findLatestReviews(String readinessStatusCode, String blockReasonCode, int limit) {
+        return pricingApplyReadinessMapper.findLatestReviews(readinessStatusCode, blockReasonCode, Math.max(1, limit));
+    }
+
+    public Set<PricingApplyReadinessReview> findLatestReadyToApplyReviews(int limit) {
+        return pricingApplyReadinessMapper.findLatestReadyToApplyReviews(Math.max(1, limit));
+    }
+
+    public long countByReadinessStatusCode(String readinessStatusCode) {
+        return pricingApplyReadinessMapper.countByReadinessStatusCode(readinessStatusCode);
+    }
+
+    public long countByBlockReasonCode(String blockReasonCode) {
+        return pricingApplyReadinessMapper.countByBlockReasonCode(blockReasonCode);
+    }
+
+    public long countLatestByReadinessStatusCode(String readinessStatusCode) {
+        return pricingApplyReadinessMapper.countLatestByReadinessStatusCode(readinessStatusCode);
+    }
+
+    public long countLatestByBlockReasonCode(String blockReasonCode) {
+        return pricingApplyReadinessMapper.countLatestByBlockReasonCode(blockReasonCode);
+    }
+
+    public PricingApplyReadiness insert(PricingApplyReadiness pricingApplyReadiness) {
+        pricingApplyReadinessMapper.insert(pricingApplyReadiness);
+        return findByPricingApplyReadinessId(pricingApplyReadiness.getPricingApplyReadinessId()).orElseThrow();
+    }
+
+    public PricingApplyReadiness update(PricingApplyReadiness pricingApplyReadiness) {
+        pricingApplyReadinessMapper.update(pricingApplyReadiness);
+        return findByPricingApplyReadinessId(pricingApplyReadiness.getPricingApplyReadinessId()).orElseThrow();
+    }
+
+    public PricingApplyReadiness upsert(PricingApplyReadiness pricingApplyReadiness) {
+        pricingApplyReadinessMapper.upsert(pricingApplyReadiness);
+        if (pricingApplyReadiness.getPricingApplyReadinessId() != null) {
+            return findByPricingApplyReadinessId(pricingApplyReadiness.getPricingApplyReadinessId()).orElseThrow();
+        }
+        return findByPricingDecisionId(pricingApplyReadiness.getPricingDecisionId()).orElseThrow();
+    }
+
+    public void delete(Long pricingApplyReadinessId) {
+        pricingApplyReadinessMapper.delete(pricingApplyReadinessId);
+    }
+}

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -6,6 +6,7 @@ import io.legohunter.data.dto.CostType;
 import io.legohunter.data.dto.InventoryIndex;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.PaymentPlatform;
+import io.legohunter.data.dto.PricingApplyReadiness;
 import io.legohunter.data.dto.PricingDecision;
 import io.legohunter.data.dto.TransactionCost;
 import io.legohunter.data.dto.TransactionItem;
@@ -22,6 +23,7 @@ import io.legohunter.data.mybatis.mapper.InventoryIndexMapper;
 import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
 import io.legohunter.data.mybatis.mapper.PartyMapper;
 import io.legohunter.data.mybatis.mapper.PaymentPlatformMapper;
+import io.legohunter.data.mybatis.mapper.PricingApplyReadinessMapper;
 import io.legohunter.data.mybatis.mapper.PricingCrawlWorkItemMapper;
 import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
 import io.legohunter.data.mybatis.mapper.TransactionCostMapper;
@@ -319,6 +321,61 @@ class DaoDelegationCoverageTest {
                 "PROPOSED",
                 25
         );
+    }
+
+    @Test
+    void pricingApplyReadinessDaoDelegatesAllOperations() {
+        PricingApplyReadinessMapper mapper = mock(PricingApplyReadinessMapper.class);
+        PricingApplyReadinessDao dao = new PricingApplyReadinessDao(mapper);
+        PricingApplyReadiness readiness = PricingApplyReadiness.builder()
+                .pricingApplyReadinessId(100L)
+                .pricingDecisionId(200L)
+                .marketplaceListingId(300)
+                .readinessStatusCode("READY_TO_APPLY")
+                .build();
+
+        when(mapper.findAll()).thenReturn(Set.of(readiness));
+        when(mapper.findByPricingApplyReadinessId(100L)).thenReturn(Optional.of(readiness));
+        when(mapper.findByPricingDecisionId(200L)).thenReturn(Optional.of(readiness));
+        when(mapper.findByMarketplaceListingId(300)).thenReturn(Set.of(readiness));
+        when(mapper.findByReadinessStatusCode("READY_TO_APPLY")).thenReturn(Set.of(readiness));
+        when(mapper.findByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).thenReturn(Set.of(readiness));
+        when(mapper.findLatestByMarketplaceListingId(300)).thenReturn(Optional.of(readiness));
+        when(mapper.countByReadinessStatusCode("READY_TO_APPLY")).thenReturn(1L);
+        when(mapper.countByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).thenReturn(1L);
+        when(mapper.countLatestByReadinessStatusCode("READY_TO_APPLY")).thenReturn(1L);
+        when(mapper.countLatestByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).thenReturn(1L);
+
+        assertThat(dao.findAll()).containsExactly(readiness);
+        assertThat(dao.findByPricingApplyReadinessId(100L)).contains(readiness);
+        assertThat(dao.findByPricingDecisionId(200L)).contains(readiness);
+        assertThat(dao.findByMarketplaceListingId(300)).containsExactly(readiness);
+        assertThat(dao.findByReadinessStatusCode("READY_TO_APPLY")).containsExactly(readiness);
+        assertThat(dao.findByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).containsExactly(readiness);
+        assertThat(dao.findLatestByMarketplaceListingId(300)).contains(readiness);
+        assertThat(dao.findLatestReviews(null, null, 0)).isEmpty();
+        assertThat(dao.findLatestReadyToApplyReviews(0)).isEmpty();
+        assertThat(dao.countByReadinessStatusCode("READY_TO_APPLY")).isOne();
+        assertThat(dao.countByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(dao.countLatestByReadinessStatusCode("READY_TO_APPLY")).isOne();
+        assertThat(dao.countLatestByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+
+        dao.update(readiness);
+        dao.upsert(readiness);
+        dao.delete(100L);
+
+        verify(mapper).update(readiness);
+        verify(mapper).upsert(readiness);
+        verify(mapper).delete(100L);
+        verify(mapper).findLatestReviews(null, null, 1);
+        verify(mapper).findLatestReadyToApplyReviews(1);
+
+        PricingApplyReadiness generatedByDecision = PricingApplyReadiness.builder()
+                .pricingDecisionId(201L)
+                .build();
+        when(mapper.findByPricingDecisionId(201L)).thenReturn(Optional.of(generatedByDecision));
+        assertThat(dao.upsert(generatedByDecision)).isSameAs(generatedByDecision);
+        verify(mapper).upsert(generatedByDecision);
     }
 
     @Test

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -7,6 +7,8 @@ import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ExternalService;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingApplyReadiness;
+import io.legohunter.data.dto.PricingApplyReadinessReview;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingDecision;
 import io.legohunter.data.dto.PricingSnapshot;
@@ -45,6 +47,7 @@ class PricingPlaneDaoTest {
     @Autowired PricingSnapshotDao pricingSnapshotDao;
     @Autowired PricingSnapshotListingDao pricingSnapshotListingDao;
     @Autowired PricingDecisionDao pricingDecisionDao;
+    @Autowired PricingApplyReadinessDao pricingApplyReadinessDao;
 
     @Test
     void pricingDaosSupportPhaseOneCrudAndLookups() {
@@ -112,14 +115,78 @@ class PricingPlaneDaoTest {
         decision.setReasonCode("FIXED_PRICE_OVERRIDE");
         assertThat(pricingDecisionDao.upsert(decision).getReasonCode()).isEqualTo("FIXED_PRICE_OVERRIDE");
 
+        PricingApplyReadiness applyReadiness = pricingApplyReadiness(decision, snapshot, fixture);
+        applyReadiness = pricingApplyReadinessDao.insert(applyReadiness);
+        applyReadiness.setReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT");
+        applyReadiness.setBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT");
+        applyReadiness.setMinimumRequiredDelta(new BigDecimal("4.50"));
+        applyReadiness = pricingApplyReadinessDao.update(applyReadiness);
+        assertThat(applyReadiness.getBlockReasonCode()).isEqualTo("BELOW_MINIMUM_DELTA_PERCENT");
+        assertThat(pricingApplyReadinessDao.findByPricingApplyReadinessId(applyReadiness.getPricingApplyReadinessId())).isPresent();
+        assertThat(pricingApplyReadinessDao.findByPricingDecisionId(decision.getPricingDecisionId()))
+                .map(PricingApplyReadiness::getReadinessStatusCode)
+                .contains("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT");
+        assertThat(pricingApplyReadinessDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(pricingApplyReadinessDao.findByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).hasSize(1);
+        assertThat(pricingApplyReadinessDao.findByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).hasSize(1);
+        assertThat(pricingApplyReadinessDao.countByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(pricingApplyReadinessDao.countByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(pricingApplyReadinessDao.countLatestByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(pricingApplyReadinessDao.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
+                .map(PricingApplyReadiness::getPricingApplyReadinessId)
+                .contains(applyReadiness.getPricingApplyReadinessId());
+        assertThat(pricingApplyReadinessDao.findAll()).hasSize(1);
+        applyReadiness.setReadinessStatusCode("READY_TO_APPLY");
+        applyReadiness.setBlockReasonCode(null);
+        assertThat(pricingApplyReadinessDao.upsert(applyReadiness).getReadinessStatusCode()).isEqualTo("READY_TO_APPLY");
+        assertThat(pricingApplyReadinessDao.findLatestReviews("READY_TO_APPLY", null, 10))
+                .extracting(PricingApplyReadinessReview::getPricingApplyReadinessId)
+                .containsExactly(applyReadiness.getPricingApplyReadinessId());
+        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10))
+                .extracting(PricingApplyReadinessReview::getExternalListingId)
+                .containsExactly("BL-PRICING-1");
+
+        pricingApplyReadinessDao.delete(applyReadiness.getPricingApplyReadinessId());
         pricingDecisionDao.delete(decision.getPricingDecisionId());
         pricingSnapshotListingDao.delete(snapshotListing.getPricingSnapshotListingId());
         pricingSnapshotDao.delete(snapshot.getPricingSnapshotId());
         pricingCrawlWorkItemDao.delete(workItem.getPricingCrawlWorkItemId());
         assertThat(pricingDecisionDao.findAll()).isEmpty();
+        assertThat(pricingApplyReadinessDao.findAll()).isEmpty();
         assertThat(pricingSnapshotListingDao.findAll()).isEmpty();
         assertThat(pricingSnapshotDao.findAll()).isEmpty();
         assertThat(pricingCrawlWorkItemDao.findAll()).isEmpty();
+    }
+
+    @Test
+    void pricingApplyReadinessDaoReportsOnlyLatestReadinessPerListing() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        PricingSnapshot snapshot = pricingSnapshotDao.insert(pricingSnapshot(workItem, fixture));
+        PricingDecision oldDecision = pricingDecisionDao.insert(pricingDecision(snapshot, fixture));
+        PricingApplyReadiness oldReadiness = pricingApplyReadiness(oldDecision, snapshot, fixture);
+        oldReadiness.setReadinessStatusCode("BLOCKED_STALE_DECISION");
+        oldReadiness.setBlockReasonCode("STALE_DECISION");
+        oldReadiness.setEvaluatedAt(SNAPSHOT_AT.plusMinutes(1));
+        pricingApplyReadinessDao.insert(oldReadiness);
+
+        PricingDecision latestDecision = pricingDecision(snapshot, fixture);
+        latestDecision.setFinalPrice(new BigDecimal("218.00"));
+        latestDecision = pricingDecisionDao.insert(latestDecision);
+        PricingApplyReadiness latestReadiness = pricingApplyReadiness(latestDecision, snapshot, fixture);
+        latestReadiness.setEvaluatedAt(SNAPSHOT_AT.plusMinutes(2));
+        latestReadiness = pricingApplyReadinessDao.insert(latestReadiness);
+
+        assertThat(pricingApplyReadinessDao.findLatestReviews(null, null, 10))
+                .extracting(PricingApplyReadinessReview::getPricingApplyReadinessId)
+                .containsExactly(latestReadiness.getPricingApplyReadinessId());
+        assertThat(pricingApplyReadinessDao.findLatestReviews("BLOCKED_STALE_DECISION", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10))
+                .extracting(PricingApplyReadinessReview::getPricingApplyReadinessId)
+                .containsExactly(latestReadiness.getPricingApplyReadinessId());
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("READY_TO_APPLY")).isOne();
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("BLOCKED_STALE_DECISION")).isZero();
     }
 
     @Test
@@ -305,6 +372,24 @@ class PricingPlaneDaoTest {
                 .confidence(new BigDecimal("0.7500"))
                 .sourceSummaryJson("{\"snapshot\":true}")
                 .notes("Initial recommendation")
+                .build();
+    }
+
+    private PricingApplyReadiness pricingApplyReadiness(PricingDecision decision, PricingSnapshot snapshot, PricingFixture fixture) {
+        return PricingApplyReadiness.builder()
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .pricingDecisionId(decision.getPricingDecisionId())
+                .pricingSnapshotId(snapshot.getPricingSnapshotId())
+                .readinessStatusCode("READY_TO_APPLY")
+                .currentPrice(new BigDecimal("225.00"))
+                .proposedPrice(new BigDecimal("219.00"))
+                .deltaAmount(new BigDecimal("6.00"))
+                .deltaPercent(new BigDecimal("0.026667"))
+                .minimumRequiredDelta(new BigDecimal("0.01"))
+                .currencyCode("USD")
+                .confidence(new BigDecimal("0.7500"))
+                .comparableCount(2)
+                .evaluatedAt(SNAPSHOT_AT.plusMinutes(1))
                 .build();
     }
 

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS pricing_apply_readiness;
 DROP TABLE IF EXISTS pricing_decision;
 DROP TABLE IF EXISTS pricing_snapshot_listing;
 DROP TABLE IF EXISTS pricing_snapshot;
@@ -269,6 +270,27 @@ CREATE TABLE pricing_decision (
     notes CLOB,
     applied_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_apply_readiness (
+    pricing_apply_readiness_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    pricing_decision_id BIGINT NOT NULL,
+    pricing_snapshot_id BIGINT,
+    readiness_status_code VARCHAR(64) NOT NULL,
+    block_reason_code VARCHAR(64),
+    current_price DECIMAL(12,2),
+    proposed_price DECIMAL(12,2),
+    delta_amount DECIMAL(12,2),
+    delta_percent DECIMAL(9,6),
+    minimum_required_delta DECIMAL(12,2),
+    currency_code VARCHAR(8),
+    confidence DECIMAL(5,4),
+    comparable_count INT,
+    evaluated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (pricing_decision_id)
 );
 
 CREATE TABLE bricklink_marketplace_listing (
@@ -559,6 +581,12 @@ CREATE INDEX idx_pricing_decision_status
     ON pricing_decision (decision_status_code);
 CREATE INDEX idx_pricing_decision_reason
     ON pricing_decision (reason_code);
+CREATE INDEX idx_pricing_apply_readiness_listing
+    ON pricing_apply_readiness (marketplace_listing_id, evaluated_at);
+CREATE INDEX idx_pricing_apply_readiness_status
+    ON pricing_apply_readiness (readiness_status_code);
+CREATE INDEX idx_pricing_apply_readiness_block_reason
+    ON pricing_apply_readiness (block_reason_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -736,6 +764,21 @@ ALTER TABLE pricing_decision
 
 ALTER TABLE pricing_decision
     ADD CONSTRAINT fk_pricing_decision_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_decision1
+    FOREIGN KEY (pricing_decision_id) REFERENCES pricing_decision (pricing_decision_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_snapshot1
     FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingApplyReadiness.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingApplyReadiness.java
@@ -1,0 +1,33 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PricingApplyReadiness {
+    private Long pricingApplyReadinessId;
+    private Integer marketplaceListingId;
+    private Long pricingDecisionId;
+    private Long pricingSnapshotId;
+    private String readinessStatusCode;
+    private String blockReasonCode;
+    private BigDecimal currentPrice;
+    private BigDecimal proposedPrice;
+    private BigDecimal deltaAmount;
+    private BigDecimal deltaPercent;
+    private BigDecimal minimumRequiredDelta;
+    private String currencyCode;
+    private BigDecimal confidence;
+    private Integer comparableCount;
+    private ZonedDateTime evaluatedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PricingApplyReadinessReview.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PricingApplyReadinessReview.java
@@ -12,19 +12,14 @@ import java.time.ZonedDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PricingDecisionReview {
+public class PricingApplyReadinessReview {
+    private Long pricingApplyReadinessId;
     private Integer marketplaceListingId;
     private String externalListingId;
     private String listingStatusCode;
-    private BigDecimal currentUnitPrice;
-    private String currentCurrencyCode;
-    private String currencyCode;
-    private String decisionCurrencyCode;
     private Boolean fixedPrice;
     private Integer itemInventoryId;
     private String itemInventoryUuid;
-    private String newOrUsed;
-    private String completeness;
     private Integer externalCatalogItemId;
     private String externalItemKey;
     private String externalUniqueKey;
@@ -32,17 +27,19 @@ public class PricingDecisionReview {
     private Long pricingSnapshotId;
     private String algorithmVersion;
     private String decisionStatusCode;
-    private String reasonCode;
+    private String decisionReasonCode;
     private String strategyCode;
-    private BigDecimal computedPrice;
-    private BigDecimal finalPrice;
-    private BigDecimal previousPrice;
-    private Integer comparableCount;
+    private String readinessStatusCode;
+    private String blockReasonCode;
+    private BigDecimal currentPrice;
+    private BigDecimal proposedPrice;
+    private BigDecimal deltaAmount;
+    private BigDecimal deltaPercent;
+    private BigDecimal minimumRequiredDelta;
+    private String currencyCode;
     private BigDecimal confidence;
-    private String notes;
+    private Integer comparableCount;
     private ZonedDateTime decisionCreatedAt;
-    private ZonedDateTime appliedAt;
     private ZonedDateTime snapshotCapturedAt;
-    private Integer snapshotComparableCount;
-    private Boolean newerSnapshotAvailable;
+    private ZonedDateTime evaluatedAt;
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
@@ -1,0 +1,308 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PricingApplyReadiness;
+import io.legohunter.data.dto.PricingApplyReadinessReview;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface PricingApplyReadinessMapper {
+    String ALL_COLUMNS = """
+            pricing_apply_readiness_id,
+            marketplace_listing_id,
+            pricing_decision_id,
+            pricing_snapshot_id,
+            readiness_status_code,
+            block_reason_code,
+            current_price,
+            proposed_price,
+            delta_amount,
+            delta_percent,
+            minimum_required_delta,
+            currency_code,
+            confidence,
+            comparable_count,
+            evaluated_at,
+            created_at,
+            updated_at
+            """;
+
+    String REVIEW_COLUMNS = """
+            par.pricing_apply_readiness_id,
+            par.marketplace_listing_id,
+            ml.external_listing_id,
+            ml.listing_status_code,
+            ml.fixed_price,
+            ii.item_inventory_id,
+            ii.uuid AS item_inventory_uuid,
+            eci.external_catalog_item_id,
+            eci.external_item_key,
+            eci.external_unique_key,
+            par.pricing_decision_id,
+            par.pricing_snapshot_id,
+            pd.algorithm_version,
+            pd.decision_status_code,
+            pd.reason_code AS decision_reason_code,
+            pd.strategy_code,
+            par.readiness_status_code,
+            par.block_reason_code,
+            par.current_price,
+            par.proposed_price,
+            par.delta_amount,
+            par.delta_percent,
+            par.minimum_required_delta,
+            par.currency_code,
+            par.confidence,
+            par.comparable_count,
+            pd.created_at AS decision_created_at,
+            ps.captured_at AS snapshot_captured_at,
+            par.evaluated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Set<PricingApplyReadiness> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness WHERE pricing_apply_readiness_id = #{pricingApplyReadinessId}")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Optional<PricingApplyReadiness> findByPricingApplyReadinessId(Long pricingApplyReadinessId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness WHERE pricing_decision_id = #{pricingDecisionId}")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Optional<PricingApplyReadiness> findByPricingDecisionId(Long pricingDecisionId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Set<PricingApplyReadiness> findByMarketplaceListingId(Integer marketplaceListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness WHERE readiness_status_code = #{readinessStatusCode}")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Set<PricingApplyReadiness> findByReadinessStatusCode(String readinessStatusCode);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM pricing_apply_readiness WHERE block_reason_code = #{blockReasonCode}")
+    @ResultMap("pricingApplyReadinessResultMap")
+    Set<PricingApplyReadiness> findByBlockReasonCode(String blockReasonCode);
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_apply_readiness
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+            ORDER BY evaluated_at DESC, pricing_apply_readiness_id DESC
+            LIMIT 1
+            """)
+    @ResultMap("pricingApplyReadinessResultMap")
+    Optional<PricingApplyReadiness> findLatestByMarketplaceListingId(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("columns") String columns
+    );
+
+    default Optional<PricingApplyReadiness> findLatestByMarketplaceListingId(Integer marketplaceListingId) {
+        return findLatestByMarketplaceListingId(marketplaceListingId, ALL_COLUMNS);
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_apply_readiness par
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
+                FROM pricing_apply_readiness
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            JOIN marketplace_listing ml
+              ON ml.marketplace_listing_id = par.marketplace_listing_id
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            LEFT JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            JOIN pricing_decision pd
+              ON pd.pricing_decision_id = par.pricing_decision_id
+            LEFT JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = par.pricing_snapshot_id
+            WHERE (#{readinessStatusCode} IS NULL OR par.readiness_status_code = #{readinessStatusCode})
+              AND (#{blockReasonCode} IS NULL OR par.block_reason_code = #{blockReasonCode})
+            ORDER BY par.evaluated_at DESC,
+                     par.pricing_apply_readiness_id DESC
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingApplyReadinessReviewResultMap")
+    Set<PricingApplyReadinessReview> findLatestReviews(
+            @Param("readinessStatusCode") String readinessStatusCode,
+            @Param("blockReasonCode") String blockReasonCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default Set<PricingApplyReadinessReview> findLatestReviews(String readinessStatusCode, String blockReasonCode, int limit) {
+        return findLatestReviews(readinessStatusCode, blockReasonCode, limit, REVIEW_COLUMNS);
+    }
+
+    default Set<PricingApplyReadinessReview> findLatestReadyToApplyReviews(int limit) {
+        return findLatestReviews("READY_TO_APPLY", null, limit);
+    }
+
+    @Select("SELECT COUNT(*) FROM pricing_apply_readiness WHERE readiness_status_code = #{readinessStatusCode}")
+    long countByReadinessStatusCode(String readinessStatusCode);
+
+    @Select("SELECT COUNT(*) FROM pricing_apply_readiness WHERE block_reason_code = #{blockReasonCode}")
+    long countByBlockReasonCode(String blockReasonCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_apply_readiness par
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
+                FROM pricing_apply_readiness
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            WHERE par.readiness_status_code = #{readinessStatusCode}
+            """)
+    long countLatestByReadinessStatusCode(String readinessStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_apply_readiness par
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
+                FROM pricing_apply_readiness
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            WHERE par.block_reason_code = #{blockReasonCode}
+            """)
+    long countLatestByBlockReasonCode(String blockReasonCode);
+
+    @Insert("""
+            INSERT INTO pricing_apply_readiness (
+                marketplace_listing_id,
+                pricing_decision_id,
+                pricing_snapshot_id,
+                readiness_status_code,
+                block_reason_code,
+                current_price,
+                proposed_price,
+                delta_amount,
+                delta_percent,
+                minimum_required_delta,
+                currency_code,
+                confidence,
+                comparable_count,
+                evaluated_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceListingId},
+                #{pricingDecisionId},
+                #{pricingSnapshotId},
+                #{readinessStatusCode},
+                #{blockReasonCode},
+                #{currentPrice},
+                #{proposedPrice},
+                #{deltaAmount},
+                #{deltaPercent},
+                #{minimumRequiredDelta},
+                #{currencyCode},
+                #{confidence},
+                #{comparableCount},
+                COALESCE(#{evaluatedAt}, CURRENT_TIMESTAMP),
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_apply_readiness_id", keyProperty = "pricingApplyReadinessId")
+    void insert(PricingApplyReadiness pricingApplyReadiness);
+
+    @Update("""
+            UPDATE pricing_apply_readiness
+            SET marketplace_listing_id = #{marketplaceListingId},
+                pricing_decision_id = #{pricingDecisionId},
+                pricing_snapshot_id = #{pricingSnapshotId},
+                readiness_status_code = #{readinessStatusCode},
+                block_reason_code = #{blockReasonCode},
+                current_price = #{currentPrice},
+                proposed_price = #{proposedPrice},
+                delta_amount = #{deltaAmount},
+                delta_percent = #{deltaPercent},
+                minimum_required_delta = #{minimumRequiredDelta},
+                currency_code = #{currencyCode},
+                confidence = #{confidence},
+                comparable_count = #{comparableCount},
+                evaluated_at = #{evaluatedAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE pricing_apply_readiness_id = #{pricingApplyReadinessId}
+            """)
+    int update(PricingApplyReadiness pricingApplyReadiness);
+
+    @Insert("""
+            INSERT INTO pricing_apply_readiness (
+                pricing_apply_readiness_id,
+                marketplace_listing_id,
+                pricing_decision_id,
+                pricing_snapshot_id,
+                readiness_status_code,
+                block_reason_code,
+                current_price,
+                proposed_price,
+                delta_amount,
+                delta_percent,
+                minimum_required_delta,
+                currency_code,
+                confidence,
+                comparable_count,
+                evaluated_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{pricingApplyReadinessId},
+                #{marketplaceListingId},
+                #{pricingDecisionId},
+                #{pricingSnapshotId},
+                #{readinessStatusCode},
+                #{blockReasonCode},
+                #{currentPrice},
+                #{proposedPrice},
+                #{deltaAmount},
+                #{deltaPercent},
+                #{minimumRequiredDelta},
+                #{currencyCode},
+                #{confidence},
+                #{comparableCount},
+                COALESCE(#{evaluatedAt}, CURRENT_TIMESTAMP),
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                marketplace_listing_id = VALUES(marketplace_listing_id),
+                pricing_snapshot_id = VALUES(pricing_snapshot_id),
+                readiness_status_code = VALUES(readiness_status_code),
+                block_reason_code = VALUES(block_reason_code),
+                current_price = VALUES(current_price),
+                proposed_price = VALUES(proposed_price),
+                delta_amount = VALUES(delta_amount),
+                delta_percent = VALUES(delta_percent),
+                minimum_required_delta = VALUES(minimum_required_delta),
+                currency_code = VALUES(currency_code),
+                confidence = VALUES(confidence),
+                comparable_count = VALUES(comparable_count),
+                evaluated_at = VALUES(evaluated_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "pricing_apply_readiness_id", keyProperty = "pricingApplyReadinessId")
+    void upsert(PricingApplyReadiness pricingApplyReadiness);
+
+    @Delete("DELETE FROM pricing_apply_readiness WHERE pricing_apply_readiness_id = #{pricingApplyReadinessId}")
+    int delete(Long pricingApplyReadinessId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -65,7 +65,26 @@ public interface PricingDecisionMapper {
             pd.created_at AS decision_created_at,
             pd.applied_at,
             ps.captured_at AS snapshot_captured_at,
-            ps.comparable_count AS snapshot_comparable_count
+            ps.comparable_count AS snapshot_comparable_count,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM pricing_snapshot newer_ps
+                    WHERE newer_ps.marketplace_listing_id = ml.marketplace_listing_id
+                      AND (
+                            newer_ps.captured_at > ps.captured_at
+                            OR (
+                                ps.captured_at IS NULL
+                                AND (
+                                    pd.pricing_snapshot_id IS NULL
+                                    OR newer_ps.pricing_snapshot_id <> pd.pricing_snapshot_id
+                                )
+                            )
+                          )
+                )
+                THEN TRUE
+                ELSE FALSE
+            END AS newer_snapshot_available
             """;
 
     @Select("SELECT " + ALL_COLUMNS + " FROM pricing_decision")

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.xml
@@ -1,0 +1,54 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PricingApplyReadinessMapper">
+  <resultMap type="io.legohunter.data.dto.PricingApplyReadiness" id="pricingApplyReadinessResultMap">
+    <id     column="pricing_apply_readiness_id" property="pricingApplyReadinessId"/>
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="pricing_decision_id"        property="pricingDecisionId"/>
+    <result column="pricing_snapshot_id"        property="pricingSnapshotId"/>
+    <result column="readiness_status_code"      property="readinessStatusCode"/>
+    <result column="block_reason_code"          property="blockReasonCode"/>
+    <result column="current_price"              property="currentPrice"/>
+    <result column="proposed_price"             property="proposedPrice"/>
+    <result column="delta_amount"               property="deltaAmount"/>
+    <result column="delta_percent"              property="deltaPercent"/>
+    <result column="minimum_required_delta"     property="minimumRequiredDelta"/>
+    <result column="currency_code"              property="currencyCode"/>
+    <result column="confidence"                 property="confidence"/>
+    <result column="comparable_count"           property="comparableCount"/>
+    <result column="evaluated_at"               property="evaluatedAt"/>
+    <result column="created_at"                 property="createdAt"/>
+    <result column="updated_at"                 property="updatedAt"/>
+  </resultMap>
+
+  <resultMap type="io.legohunter.data.dto.PricingApplyReadinessReview" id="pricingApplyReadinessReviewResultMap">
+    <id     column="pricing_apply_readiness_id" property="pricingApplyReadinessId"/>
+    <result column="marketplace_listing_id"     property="marketplaceListingId"/>
+    <result column="external_listing_id"        property="externalListingId"/>
+    <result column="listing_status_code"        property="listingStatusCode"/>
+    <result column="fixed_price"                property="fixedPrice"/>
+    <result column="item_inventory_id"          property="itemInventoryId"/>
+    <result column="item_inventory_uuid"        property="itemInventoryUuid"/>
+    <result column="external_catalog_item_id"   property="externalCatalogItemId"/>
+    <result column="external_item_key"          property="externalItemKey"/>
+    <result column="external_unique_key"        property="externalUniqueKey"/>
+    <result column="pricing_decision_id"        property="pricingDecisionId"/>
+    <result column="pricing_snapshot_id"        property="pricingSnapshotId"/>
+    <result column="algorithm_version"          property="algorithmVersion"/>
+    <result column="decision_status_code"       property="decisionStatusCode"/>
+    <result column="decision_reason_code"       property="decisionReasonCode"/>
+    <result column="strategy_code"              property="strategyCode"/>
+    <result column="readiness_status_code"      property="readinessStatusCode"/>
+    <result column="block_reason_code"          property="blockReasonCode"/>
+    <result column="current_price"              property="currentPrice"/>
+    <result column="proposed_price"             property="proposedPrice"/>
+    <result column="delta_amount"               property="deltaAmount"/>
+    <result column="delta_percent"              property="deltaPercent"/>
+    <result column="minimum_required_delta"     property="minimumRequiredDelta"/>
+    <result column="currency_code"              property="currencyCode"/>
+    <result column="confidence"                 property="confidence"/>
+    <result column="comparable_count"           property="comparableCount"/>
+    <result column="decision_created_at"        property="decisionCreatedAt"/>
+    <result column="snapshot_captured_at"       property="snapshotCapturedAt"/>
+    <result column="evaluated_at"               property="evaluatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.xml
@@ -52,5 +52,6 @@
     <result column="applied_at"              property="appliedAt"/>
     <result column="snapshot_captured_at"    property="snapshotCapturedAt"/>
     <result column="snapshot_comparable_count" property="snapshotComparableCount"/>
+    <result column="newer_snapshot_available" property="newerSnapshotAvailable"/>
   </resultMap>
 </mapper>


### PR DESCRIPTION
- Add PricingApplyReadiness and PricingApplyReadinessReview DTOs.
- Add PricingApplyReadinessDao and MyBatis mapper/XML support for the Phase 9 apply-preview table.
- Add latest-readiness-per-listing report queries, ready-to-apply dry-run selection, and current latest count methods for metrics/reporting.
- Add stale snapshot detection to PricingDecisionReview so ingress can block stale proposed decisions.
- Keep the H2 test schema aligned with pricing_apply_readiness and cover DAO CRUD, upsert, latest selection, filtering, and delegation.

Verification:
- mvn clean install