### PR TITLE
Pricing Plane Phase 9a: harden apply readiness current state

### DIFF
--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -190,6 +190,28 @@ class PricingPlaneDaoTest {
     }
 
     @Test
+    void pricingApplyReadinessDaoExcludesReadinessForSupersededDecisionFromCurrentReports() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        PricingSnapshot snapshot = pricingSnapshotDao.insert(pricingSnapshot(workItem, fixture));
+        PricingDecision readyDecision = pricingDecisionDao.insert(pricingDecision(snapshot, fixture));
+        PricingApplyReadiness readyReadiness = pricingApplyReadiness(readyDecision, snapshot, fixture);
+        readyReadiness = pricingApplyReadinessDao.insert(readyReadiness);
+
+        PricingDecision failedDecision = pricingDecision(snapshot, fixture);
+        failedDecision.setDecisionStatusCode("FAILED");
+        failedDecision.setReasonCode("NO_CURRENT_COMPARABLES");
+        failedDecision.setFinalPrice(null);
+        pricingDecisionDao.insert(failedDecision);
+
+        assertThat(pricingApplyReadinessDao.findByPricingApplyReadinessId(readyReadiness.getPricingApplyReadinessId())).isPresent();
+        assertThat(pricingApplyReadinessDao.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
+        assertThat(pricingApplyReadinessDao.countLatestByBlockReasonCode("STALE_DECISION")).isZero();
+    }
+
+    @Test
     void pricingCrawlDaoClaimsDueWorkAndRequeuesStaleClaims() {
         PricingFixture fixture = pricingFixture();
         PricingCrawlWorkItem workItem = pricingCrawlWorkItem(fixture);

--- a/lego-data-dao/src/test/resources/scripts/db/h2/item_inventory_photo_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/item_inventory_photo_schema.ddl
@@ -1,3 +1,42 @@
+create table if not exists item_inventory
+(
+    item_inventory_id             int auto_increment primary key,
+    uuid                          varchar(64) unique,
+    box_number                    int,
+    purchase_price                decimal(9,2),
+    description                   varchar(2048),
+    active                        boolean,
+    for_sale                      boolean,
+    new_or_used                   varchar(32),
+    completeness                  varchar(64),
+    item_condition_id             int,
+    box_condition_id              int,
+    instructions_condition_id     int,
+    sealed                        boolean,
+    built_once                    boolean,
+    inventory_state_code          varchar(30) default 'AVAILABLE' not null,
+    inventory_state_changed_at    timestamp default CURRENT_TIMESTAMP not null,
+    sale_intent_code              varchar(30) default 'UNDECIDED' not null,
+    sale_intent_updated_at        timestamp default CURRENT_TIMESTAMP not null,
+    sale_intent_note              varchar(500)
+);
+
+merge into item_inventory (
+    item_inventory_id,
+    uuid,
+    box_number,
+    purchase_price,
+    description,
+    active,
+    for_sale,
+    new_or_used,
+    completeness,
+    sealed,
+    built_once
+) key (item_inventory_id) values
+    (1, 'item-inventory-photo-test-1', 1, 0.00, 'Item inventory photo test row 1', true, false, 'USED', 'COMPLETE', false, false),
+    (2, 'item-inventory-photo-test-2', 1, 0.00, 'Item inventory photo test row 2', true, false, 'USED', 'COMPLETE', false, false);
+
 create table if not exists item_inventory_photo
 (
     item_inventory_photo_id int auto_increment primary key,

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
@@ -112,11 +112,12 @@ public interface PricingApplyReadinessMapper {
             FROM pricing_apply_readiness par
             JOIN (
                 SELECT marketplace_listing_id,
-                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
-                FROM pricing_apply_readiness
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
                 GROUP BY marketplace_listing_id
-            ) latest
-              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            ) latest_decision
+              ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
+             AND latest_decision.pricing_decision_id = par.pricing_decision_id
             JOIN marketplace_listing ml
               ON ml.marketplace_listing_id = par.marketplace_listing_id
             JOIN item_inventory ii
@@ -160,11 +161,12 @@ public interface PricingApplyReadinessMapper {
             FROM pricing_apply_readiness par
             JOIN (
                 SELECT marketplace_listing_id,
-                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
-                FROM pricing_apply_readiness
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
                 GROUP BY marketplace_listing_id
-            ) latest
-              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            ) latest_decision
+              ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
+             AND latest_decision.pricing_decision_id = par.pricing_decision_id
             WHERE par.readiness_status_code = #{readinessStatusCode}
             """)
     long countLatestByReadinessStatusCode(String readinessStatusCode);
@@ -174,11 +176,12 @@ public interface PricingApplyReadinessMapper {
             FROM pricing_apply_readiness par
             JOIN (
                 SELECT marketplace_listing_id,
-                       MAX(pricing_apply_readiness_id) AS pricing_apply_readiness_id
-                FROM pricing_apply_readiness
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
                 GROUP BY marketplace_listing_id
-            ) latest
-              ON latest.pricing_apply_readiness_id = par.pricing_apply_readiness_id
+            ) latest_decision
+              ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
+             AND latest_decision.pricing_decision_id = par.pricing_decision_id
             WHERE par.block_reason_code = #{blockReasonCode}
             """)
     long countLatestByBlockReasonCode(String blockReasonCode);

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -61,6 +61,7 @@ abstract class MapperTestSupport {
     @Autowired PricingSnapshotMapper pricingSnapshotMapper;
     @Autowired PricingSnapshotListingMapper pricingSnapshotListingMapper;
     @Autowired PricingDecisionMapper pricingDecisionMapper;
+    @Autowired PricingApplyReadinessMapper pricingApplyReadinessMapper;
     @Autowired PartyMapper partyMapper;
     @Autowired PaymentPlatformMapper paymentPlatformMapper;
     @Autowired TransactionCostMapper transactionCostMapper;

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -3,6 +3,7 @@ package io.legohunter.data.mybatis.mapper;
 import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.PricingApplyReadiness;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
 import io.legohunter.data.dto.PricingCrawlWorkItemFailure;
@@ -575,6 +576,29 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                 });
     }
 
+    @Test
+    void pricingApplyReadinessCurrentReviewsIgnoreReadinessForSupersededDecision() {
+        PricingFixture fixture = pricingFixture("pricing-readiness-superseded");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingDecision readyDecision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        readyDecision.setDecisionStatusCode("PROPOSED");
+        readyDecision.setReasonCode("MEAN_PLUS_STDDEV");
+        readyDecision.setFinalPrice(new BigDecimal("212.25"));
+        pricingDecisionMapper.insert(readyDecision);
+        PricingApplyReadiness readyReadiness = pricingApplyReadiness(readyDecision, snapshot, fixture);
+        pricingApplyReadinessMapper.insert(readyReadiness);
+
+        PricingDecision failedDecision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        failedDecision.setDecisionStatusCode("FAILED");
+        failedDecision.setReasonCode("NO_CURRENT_COMPARABLES");
+        failedDecision.setFinalPrice(null);
+        pricingDecisionMapper.insert(failedDecision);
+
+        assertThat(pricingApplyReadinessMapper.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessMapper.findLatestReadyToApplyReviews(10)).isEmpty();
+        assertThat(pricingApplyReadinessMapper.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
+    }
+
     private PricingSnapshot insertedSnapshot(PricingFixture fixture) {
         PricingCrawlWorkItem workItem = insertedWorkItem(fixture, CRAWL_AT);
         PricingSnapshot snapshot = pricingSnapshot(
@@ -597,6 +621,24 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         );
         pricingCrawlWorkItemMapper.insert(workItem);
         return workItem;
+    }
+
+    private PricingApplyReadiness pricingApplyReadiness(PricingDecision decision, PricingSnapshot snapshot, PricingFixture fixture) {
+        return PricingApplyReadiness.builder()
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .pricingDecisionId(decision.getPricingDecisionId())
+                .pricingSnapshotId(snapshot.getPricingSnapshotId())
+                .readinessStatusCode("READY_TO_APPLY")
+                .currentPrice(new BigDecimal("225.00"))
+                .proposedPrice(decision.getFinalPrice())
+                .deltaAmount(new BigDecimal("12.75"))
+                .deltaPercent(new BigDecimal("0.056667"))
+                .minimumRequiredDelta(new BigDecimal("0.01"))
+                .currencyCode("USD")
+                .confidence(new BigDecimal("0.9000"))
+                .comparableCount(5)
+                .evaluatedAt(SNAPSHOT_AT.plusMinutes(1))
+                .build();
     }
 
     private PricingFixture pricingFixture(String key) {

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS pricing_apply_readiness;
 DROP TABLE IF EXISTS pricing_decision;
 DROP TABLE IF EXISTS pricing_snapshot_listing;
 DROP TABLE IF EXISTS pricing_snapshot;
@@ -269,6 +270,27 @@ CREATE TABLE pricing_decision (
     notes CLOB,
     applied_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pricing_apply_readiness (
+    pricing_apply_readiness_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    pricing_decision_id BIGINT NOT NULL,
+    pricing_snapshot_id BIGINT,
+    readiness_status_code VARCHAR(64) NOT NULL,
+    block_reason_code VARCHAR(64),
+    current_price DECIMAL(12,2),
+    proposed_price DECIMAL(12,2),
+    delta_amount DECIMAL(12,2),
+    delta_percent DECIMAL(9,6),
+    minimum_required_delta DECIMAL(12,2),
+    currency_code VARCHAR(8),
+    confidence DECIMAL(5,4),
+    comparable_count INT,
+    evaluated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (pricing_decision_id)
 );
 
 CREATE TABLE bricklink_marketplace_listing (
@@ -559,6 +581,12 @@ CREATE INDEX idx_pricing_decision_status
     ON pricing_decision (decision_status_code);
 CREATE INDEX idx_pricing_decision_reason
     ON pricing_decision (reason_code);
+CREATE INDEX idx_pricing_apply_readiness_listing
+    ON pricing_apply_readiness (marketplace_listing_id, evaluated_at);
+CREATE INDEX idx_pricing_apply_readiness_status
+    ON pricing_apply_readiness (readiness_status_code);
+CREATE INDEX idx_pricing_apply_readiness_block_reason
+    ON pricing_apply_readiness (block_reason_code);
 
 CREATE TABLE party (
     party_id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -736,6 +764,21 @@ ALTER TABLE pricing_decision
 
 ALTER TABLE pricing_decision
     ADD CONSTRAINT fk_pricing_decision_snapshot1
+    FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_marketplace_listing1
+    FOREIGN KEY (marketplace_listing_id) REFERENCES marketplace_listing (marketplace_listing_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_decision1
+    FOREIGN KEY (pricing_decision_id) REFERENCES pricing_decision (pricing_decision_id)
+    ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE pricing_apply_readiness
+    ADD CONSTRAINT fk_pricing_apply_readiness_snapshot1
     FOREIGN KEY (pricing_snapshot_id) REFERENCES pricing_snapshot (pricing_snapshot_id)
     ON DELETE RESTRICT ON UPDATE RESTRICT;
 


### PR DESCRIPTION
## Summary
- Treat apply-readiness rows as current only when they belong to the latest pricing decision for the marketplace listing.
- Prevent stale READY_TO_APPLY rows from appearing in current readiness reports, current counts, and dry-run apply selection after a newer decision supersedes them.
- Add mapper and DAO regression tests for superseded-decision readiness behavior.
- Sync the mybatis H2 schema with pricing_apply_readiness so mapper tests can exercise this table directly.

## Validation
- mvn -pl lego-data-mybatis -Dtest=PricingPlaneMapperTest test
- mvn -pl lego-data-dao -am -Dtest=PricingPlaneDaoTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean install

## Review Order
Review and merge this PR before the lego-data-ingress Phase 9a PR so ingress observes the corrected DAO semantics.