### PR TITLE
Pricing Plane Phase 10: crawl current count support

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingCrawlWorkItemDao.java
@@ -40,16 +40,36 @@ public class PricingCrawlWorkItemDao {
         return pricingCrawlWorkItemMapper.countByWorkStatusCode(workStatusCode);
     }
 
+    public long countLatestByWorkStatusCode(String workStatusCode) {
+        return pricingCrawlWorkItemMapper.countLatestByWorkStatusCode(workStatusCode);
+    }
+
     public long countDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt) {
         return pricingCrawlWorkItemMapper.countDueByWorkStatusCode(workStatusCode, dueAt);
+    }
+
+    public long countLatestDueByWorkStatusCode(String workStatusCode, ZonedDateTime dueAt) {
+        return pricingCrawlWorkItemMapper.countLatestDueByWorkStatusCode(workStatusCode, dueAt);
     }
 
     public long countRetryableByWorkStatusCode(String workStatusCode) {
         return pricingCrawlWorkItemMapper.countRetryableByWorkStatusCode(workStatusCode);
     }
 
+    public long countLatestRetryableByWorkStatusCode(String workStatusCode) {
+        return pricingCrawlWorkItemMapper.countLatestRetryableByWorkStatusCode(workStatusCode);
+    }
+
     public long countStaleClaimed(String claimedStatusCode, ZonedDateTime claimedBefore) {
         return pricingCrawlWorkItemMapper.countStaleClaimed(claimedStatusCode, claimedBefore);
+    }
+
+    public long countLatestStaleClaimed(String claimedStatusCode, ZonedDateTime claimedBefore) {
+        return pricingCrawlWorkItemMapper.countLatestStaleClaimed(claimedStatusCode, claimedBefore);
+    }
+
+    public long countLatestByWorkStatusPattern(String workStatusPattern) {
+        return pricingCrawlWorkItemMapper.countLatestByWorkStatusPattern(workStatusPattern);
     }
 
     public PricingCrawlWorkItemMaintenanceSummary summarizeMaintenance(

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -248,6 +248,45 @@ class PricingPlaneDaoTest {
     }
 
     @Test
+    void pricingCrawlDaoLatestCountsIgnoreSupersededHistoricalRows() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem historicalFailed = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        historicalFailed.setWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH");
+        pricingCrawlWorkItemDao.update(historicalFailed);
+
+        PricingCrawlWorkItem latestPending = pricingCrawlWorkItem(fixture);
+        latestPending.setNextAttemptAt(CRAWL_AT.minusMinutes(5));
+        latestPending.setAttemptCount(1);
+        latestPending.setMaxAttempts(3);
+        pricingCrawlWorkItemDao.insert(latestPending);
+
+        assertThat(pricingCrawlWorkItemDao.countByWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH")).isOne();
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH")).isZero();
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusPattern("FAILED%")).isZero();
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusCode("PENDING")).isOne();
+        assertThat(pricingCrawlWorkItemDao.countLatestDueByWorkStatusCode("PENDING", CRAWL_AT)).isOne();
+        assertThat(pricingCrawlWorkItemDao.countLatestRetryableByWorkStatusCode("PENDING")).isOne();
+
+        PricingCrawlWorkItem latestClaimed = pricingCrawlWorkItem(fixture);
+        latestClaimed.setWorkStatusCode("CLAIMED");
+        latestClaimed.setAttemptCount(1);
+        latestClaimed.setMaxAttempts(3);
+        latestClaimed.setClaimedAt(CRAWL_AT.minusHours(3));
+        pricingCrawlWorkItemDao.insert(latestClaimed);
+
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusCode("PENDING")).isZero();
+        assertThat(pricingCrawlWorkItemDao.countLatestStaleClaimed("CLAIMED", CRAWL_AT.minusHours(1))).isOne();
+
+        PricingCrawlWorkItem latestSucceeded = pricingCrawlWorkItem(fixture);
+        latestSucceeded.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemDao.insert(latestSucceeded);
+
+        assertThat(pricingCrawlWorkItemDao.countLatestStaleClaimed("CLAIMED", CRAWL_AT.minusHours(1))).isZero();
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusCode("SUCCEEDED")).isOne();
+        assertThat(pricingCrawlWorkItemDao.countLatestByWorkStatusPattern("SKIPPED%")).isZero();
+    }
+
+    @Test
     void pricingDaosExposeExactConditionAndCompletenessComparables() {
         PricingFixture fixture = pricingFixture();
         PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingCrawlWorkItemMapper.java
@@ -56,11 +56,43 @@ public interface PricingCrawlWorkItemMapper {
 
     @Select("""
             SELECT COUNT(*)
+            FROM pricing_crawl_work_item pcwi
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_crawl_work_item_id) AS pricing_crawl_work_item_id
+                FROM pricing_crawl_work_item
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_crawl_work_item_id = pcwi.pricing_crawl_work_item_id
+            WHERE pcwi.work_status_code = #{workStatusCode}
+            """)
+    long countLatestByWorkStatusCode(String workStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
             FROM pricing_crawl_work_item
             WHERE work_status_code = #{workStatusCode}
               AND next_attempt_at <= #{dueAt}
             """)
     long countDueByWorkStatusCode(
+            @Param("workStatusCode") String workStatusCode,
+            @Param("dueAt") ZonedDateTime dueAt
+    );
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item pcwi
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_crawl_work_item_id) AS pricing_crawl_work_item_id
+                FROM pricing_crawl_work_item
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_crawl_work_item_id = pcwi.pricing_crawl_work_item_id
+            WHERE pcwi.work_status_code = #{workStatusCode}
+              AND pcwi.next_attempt_at <= #{dueAt}
+            """)
+    long countLatestDueByWorkStatusCode(
             @Param("workStatusCode") String workStatusCode,
             @Param("dueAt") ZonedDateTime dueAt
     );
@@ -76,6 +108,22 @@ public interface PricingCrawlWorkItemMapper {
 
     @Select("""
             SELECT COUNT(*)
+            FROM pricing_crawl_work_item pcwi
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_crawl_work_item_id) AS pricing_crawl_work_item_id
+                FROM pricing_crawl_work_item
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_crawl_work_item_id = pcwi.pricing_crawl_work_item_id
+            WHERE pcwi.work_status_code = #{workStatusCode}
+              AND COALESCE(pcwi.attempt_count, 0) > 0
+              AND COALESCE(pcwi.attempt_count, 0) < COALESCE(pcwi.max_attempts, 3)
+            """)
+    long countLatestRetryableByWorkStatusCode(String workStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
             FROM pricing_crawl_work_item
             WHERE work_status_code = #{claimedStatusCode}
               AND claimed_at <= #{claimedBefore}
@@ -85,6 +133,39 @@ public interface PricingCrawlWorkItemMapper {
             @Param("claimedStatusCode") String claimedStatusCode,
             @Param("claimedBefore") ZonedDateTime claimedBefore
     );
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item pcwi
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_crawl_work_item_id) AS pricing_crawl_work_item_id
+                FROM pricing_crawl_work_item
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_crawl_work_item_id = pcwi.pricing_crawl_work_item_id
+            WHERE pcwi.work_status_code = #{claimedStatusCode}
+              AND pcwi.claimed_at <= #{claimedBefore}
+              AND COALESCE(pcwi.attempt_count, 0) < COALESCE(pcwi.max_attempts, 3)
+            """)
+    long countLatestStaleClaimed(
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("claimedBefore") ZonedDateTime claimedBefore
+    );
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM pricing_crawl_work_item pcwi
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_crawl_work_item_id) AS pricing_crawl_work_item_id
+                FROM pricing_crawl_work_item
+                GROUP BY marketplace_listing_id
+            ) latest
+              ON latest.pricing_crawl_work_item_id = pcwi.pricing_crawl_work_item_id
+            WHERE pcwi.work_status_code LIKE #{workStatusPattern}
+            """)
+    long countLatestByWorkStatusPattern(String workStatusPattern);
 
     @Select("""
             SELECT COUNT(*) AS work_item_count,

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -132,6 +132,59 @@ class PricingPlaneMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void pricingCrawlWorkItemLatestCountsIgnoreSupersededHistoricalRows() {
+        PricingFixture recoveredFixture = pricingFixture("pricing-work-latest-recovered");
+        PricingCrawlWorkItem historicalFailed = insertedWorkItem(recoveredFixture, CRAWL_AT.minusDays(1));
+        historicalFailed.setWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH");
+        pricingCrawlWorkItemMapper.update(historicalFailed);
+        PricingCrawlWorkItem latestSucceeded = pricingCrawlWorkItem(
+                recoveredFixture.listing().getMarketplaceListingId(),
+                recoveredFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.plusDays(1)
+        );
+        latestSucceeded.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.insert(latestSucceeded);
+
+        PricingFixture pendingFixture = pricingFixture("pricing-work-latest-pending");
+        PricingCrawlWorkItem historicalSucceeded = insertedWorkItem(pendingFixture, CRAWL_AT.minusDays(1));
+        historicalSucceeded.setWorkStatusCode("SUCCEEDED");
+        pricingCrawlWorkItemMapper.update(historicalSucceeded);
+        PricingCrawlWorkItem latestPending = pricingCrawlWorkItem(
+                pendingFixture.listing().getMarketplaceListingId(),
+                pendingFixture.catalogItem().getExternalCatalogItemId(),
+                2,
+                CRAWL_AT.minusMinutes(5)
+        );
+        latestPending.setAttemptCount(1);
+        latestPending.setMaxAttempts(3);
+        pricingCrawlWorkItemMapper.insert(latestPending);
+
+        PricingFixture claimedFixture = pricingFixture("pricing-work-latest-claimed");
+        PricingCrawlWorkItem latestClaimed = insertedWorkItem(claimedFixture, CRAWL_AT.minusHours(4));
+        latestClaimed.setWorkStatusCode("CLAIMED");
+        latestClaimed.setAttemptCount(1);
+        latestClaimed.setMaxAttempts(3);
+        latestClaimed.setClaimedAt(CRAWL_AT.minusHours(3));
+        pricingCrawlWorkItemMapper.update(latestClaimed);
+
+        PricingFixture skippedFixture = pricingFixture("pricing-work-latest-skipped");
+        PricingCrawlWorkItem latestSkipped = insertedWorkItem(skippedFixture, CRAWL_AT);
+        latestSkipped.setWorkStatusCode("SKIPPED_MISSING_CONDITION");
+        pricingCrawlWorkItemMapper.update(latestSkipped);
+
+        assertThat(pricingCrawlWorkItemMapper.countByWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH")).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestByWorkStatusCode("FAILED_ITEM_ID_LOOKUP_NO_MATCH")).isZero();
+        assertThat(pricingCrawlWorkItemMapper.countLatestByWorkStatusPattern("FAILED%")).isZero();
+        assertThat(pricingCrawlWorkItemMapper.countLatestByWorkStatusCode("SUCCEEDED")).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestByWorkStatusCode("PENDING")).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestDueByWorkStatusCode("PENDING", CRAWL_AT)).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestRetryableByWorkStatusCode("PENDING")).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestStaleClaimed("CLAIMED", CRAWL_AT.minusHours(1))).isOne();
+        assertThat(pricingCrawlWorkItemMapper.countLatestByWorkStatusPattern("SKIPPED%")).isOne();
+    }
+
+    @Test
     void pricingCrawlWorkItemMaintenanceSummaryAndDuplicateReportExposeQueueHygiene() {
         PricingFixture duplicateFixture = pricingFixture("pricing-work-maintenance-duplicate");
         PricingCrawlWorkItem pendingDue = insertedWorkItem(duplicateFixture, CRAWL_AT.minusMinutes(1));


### PR DESCRIPTION
## Summary

Pricing Plane Phase 10 data-layer support for current crawl work metrics.

This PR adds latest-per-marketplace-listing count APIs for `pricing_crawl_work_item` so callers can report current crawl health without counting historical failed/skipped rows that were superseded by newer successful work for the same listing.

## Changes

- Added latest-count mapper methods for crawl work item states:
  - `countLatestByWorkStatusCode`
  - `countLatestDueByWorkStatusCode`
  - `countLatestRetryableByWorkStatusCode`
  - `countLatestStaleClaimed`
  - `countLatestByWorkStatusPattern`
- Exposed the new methods through `PricingCrawlWorkItemDao`.
- Added MyBatis regression coverage proving historical failed rows no longer count as current failures after newer `SUCCEEDED` work exists.
- Added DAO coverage for a listing moving through failed, pending, claimed, and succeeded historical work states.

## Validation

- `mvn clean install`
- `lego-data-mybatis`: 57 tests, 0 failures
- `lego-data-dao`: 69 tests, 0 failures