### PR TITLE
Add marketplace listing sync request data layer

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -6,6 +6,7 @@ import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
@@ -113,6 +114,14 @@ public class MarketplaceListingDao {
     public MarketplaceListing update(MarketplaceListing marketplaceListing) {
         marketplaceListingMapper.update(marketplaceListing);
         return findByMarketplaceListingId(marketplaceListing.getMarketplaceListingId()).orElseThrow();
+    }
+
+    public Optional<MarketplaceListing> updateUnitPrice(Integer marketplaceListingId, BigDecimal unitPrice, ZonedDateTime updatedAt) {
+        int updated = marketplaceListingMapper.updateUnitPrice(marketplaceListingId, unitPrice, updatedAt);
+        if (updated == 0) {
+            return Optional.empty();
+        }
+        return findByMarketplaceListingId(marketplaceListingId);
     }
 
     public void delete(Integer marketplaceListingId) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingSyncRequestDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingSyncRequestDao.java
@@ -1,0 +1,78 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
+import io.legohunter.data.mybatis.mapper.MarketplaceListingSyncRequestMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceListingSyncRequestDao {
+    private final MarketplaceListingSyncRequestMapper marketplaceListingSyncRequestMapper;
+
+    public Set<MarketplaceListingSyncRequest> findAll() {
+        return marketplaceListingSyncRequestMapper.findAll();
+    }
+
+    public Optional<MarketplaceListingSyncRequest> findByMarketplaceListingSyncRequestId(Long marketplaceListingSyncRequestId) {
+        return marketplaceListingSyncRequestMapper.findByMarketplaceListingSyncRequestId(marketplaceListingSyncRequestId);
+    }
+
+    public Set<MarketplaceListingSyncRequest> findByMarketplaceListingId(Integer marketplaceListingId) {
+        return marketplaceListingSyncRequestMapper.findByMarketplaceListingId(marketplaceListingId);
+    }
+
+    public Set<MarketplaceListingSyncRequest> findBySyncRequestStatusCode(String syncRequestStatusCode) {
+        return marketplaceListingSyncRequestMapper.findBySyncRequestStatusCode(syncRequestStatusCode);
+    }
+
+    public Set<MarketplaceListingSyncRequest> findClaimableByStatusCode(String syncRequestStatusCode, ZonedDateTime asOf, int limit) {
+        return marketplaceListingSyncRequestMapper.findClaimableByStatusCode(syncRequestStatusCode, asOf, Math.max(1, limit));
+    }
+
+    public long countBySyncRequestStatusCode(String syncRequestStatusCode) {
+        return marketplaceListingSyncRequestMapper.countBySyncRequestStatusCode(syncRequestStatusCode);
+    }
+
+    public long countDueBySyncRequestStatusCode(String syncRequestStatusCode, ZonedDateTime asOf) {
+        return marketplaceListingSyncRequestMapper.countDueBySyncRequestStatusCode(syncRequestStatusCode, asOf);
+    }
+
+    public MarketplaceListingSyncRequest insert(MarketplaceListingSyncRequest syncRequest) {
+        marketplaceListingSyncRequestMapper.insert(syncRequest);
+        return findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId()).orElseThrow();
+    }
+
+    public MarketplaceListingSyncRequest update(MarketplaceListingSyncRequest syncRequest) {
+        marketplaceListingSyncRequestMapper.update(syncRequest);
+        return findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId()).orElseThrow();
+    }
+
+    public MarketplaceListingSyncRequest upsert(MarketplaceListingSyncRequest syncRequest) {
+        marketplaceListingSyncRequestMapper.upsert(syncRequest);
+        if (syncRequest.getMarketplaceListingSyncRequestId() != null) {
+            return findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId()).orElseThrow();
+        }
+        return marketplaceListingSyncRequestMapper.findByMarketplaceListingIdAndPricingDecisionIdAndSyncRequestTypeCode(
+                syncRequest.getMarketplaceListingId(),
+                syncRequest.getPricingDecisionId(),
+                syncRequest.getSyncRequestTypeCode()
+        ).orElseThrow();
+    }
+
+    public Optional<MarketplaceListingSyncRequest> claim(Long marketplaceListingSyncRequestId, String fromStatusCode, String claimedStatusCode, ZonedDateTime claimedAt) {
+        int updated = marketplaceListingSyncRequestMapper.claim(marketplaceListingSyncRequestId, fromStatusCode, claimedStatusCode, claimedAt);
+        if (updated == 0) {
+            return Optional.empty();
+        }
+        return findByMarketplaceListingSyncRequestId(marketplaceListingSyncRequestId);
+    }
+
+    public void delete(Long marketplaceListingSyncRequestId) {
+        marketplaceListingSyncRequestMapper.delete(marketplaceListingSyncRequestId);
+    }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -6,6 +6,7 @@ import io.legohunter.data.mybatis.mapper.PricingDecisionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
@@ -80,6 +81,14 @@ public class PricingDecisionDao {
     public PricingDecision update(PricingDecision pricingDecision) {
         pricingDecisionMapper.update(pricingDecision);
         return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();
+    }
+
+    public Optional<PricingDecision> markApplied(Long pricingDecisionId, ZonedDateTime appliedAt) {
+        int updated = pricingDecisionMapper.markApplied(pricingDecisionId, appliedAt);
+        if (updated == 0) {
+            return Optional.empty();
+        }
+        return findByPricingDecisionId(pricingDecisionId);
     }
 
     public void delete(Long pricingDecisionId) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -7,6 +7,7 @@ import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ExternalService;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
 import io.legohunter.data.dto.PricingApplyReadiness;
 import io.legohunter.data.dto.PricingApplyReadinessReview;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
@@ -48,6 +49,7 @@ class PricingPlaneDaoTest {
     @Autowired PricingSnapshotListingDao pricingSnapshotListingDao;
     @Autowired PricingDecisionDao pricingDecisionDao;
     @Autowired PricingApplyReadinessDao pricingApplyReadinessDao;
+    @Autowired MarketplaceListingSyncRequestDao marketplaceListingSyncRequestDao;
 
     @Test
     void pricingDaosSupportPhaseOneCrudAndLookups() {
@@ -157,6 +159,52 @@ class PricingPlaneDaoTest {
         assertThat(pricingSnapshotListingDao.findAll()).isEmpty();
         assertThat(pricingSnapshotDao.findAll()).isEmpty();
         assertThat(pricingCrawlWorkItemDao.findAll()).isEmpty();
+    }
+
+    @Test
+    void marketplaceListingSyncRequestDaoSupportsCrudClaimAndMetricsCounts() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        PricingSnapshot snapshot = pricingSnapshotDao.insert(pricingSnapshot(workItem, fixture));
+        PricingDecision decision = pricingDecisionDao.insert(pricingDecision(snapshot, fixture));
+        MarketplaceListingSyncRequest syncRequest = marketplaceListingSyncRequest(fixture, decision);
+
+        syncRequest = marketplaceListingSyncRequestDao.insert(syncRequest);
+        syncRequest.setLastErrorMessage("Waiting for remote worker");
+        syncRequest = marketplaceListingSyncRequestDao.update(syncRequest);
+
+        assertThat(syncRequest.getLastErrorMessage()).isEqualTo("Waiting for remote worker");
+        assertThat(marketplaceListingSyncRequestDao.findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId())).isPresent();
+        assertThat(marketplaceListingSyncRequestDao.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(marketplaceListingSyncRequestDao.findBySyncRequestStatusCode("PENDING")).hasSize(1);
+        assertThat(marketplaceListingSyncRequestDao.countBySyncRequestStatusCode("PENDING")).isOne();
+        assertThat(marketplaceListingSyncRequestDao.countDueBySyncRequestStatusCode("PENDING", SNAPSHOT_AT.plusHours(2))).isOne();
+        assertThat(marketplaceListingSyncRequestDao.findClaimableByStatusCode("PENDING", SNAPSHOT_AT.plusHours(2), 10)).hasSize(1);
+
+        assertThat(marketplaceListingSyncRequestDao.claim(
+                syncRequest.getMarketplaceListingSyncRequestId(),
+                "PENDING",
+                "CLAIMED",
+                SNAPSHOT_AT.plusHours(2)
+        )).hasValueSatisfying(claimed -> {
+            assertThat(claimed.getSyncRequestStatusCode()).isEqualTo("CLAIMED");
+            assertThat(claimed.getAttemptCount()).isOne();
+        });
+        assertThat(marketplaceListingSyncRequestDao.claim(
+                syncRequest.getMarketplaceListingSyncRequestId(),
+                "PENDING",
+                "CLAIMED",
+                SNAPSHOT_AT.plusHours(2)
+        )).isEmpty();
+
+        syncRequest.setSyncRequestStatusCode("PENDING");
+        syncRequest.setRequestedUnitPrice(new BigDecimal("218.00"));
+        syncRequest = marketplaceListingSyncRequestDao.upsert(syncRequest);
+        assertThat(syncRequest.getRequestedUnitPrice()).isEqualByComparingTo("218.00");
+        assertThat(marketplaceListingSyncRequestDao.findAll()).hasSize(1);
+
+        marketplaceListingSyncRequestDao.delete(syncRequest.getMarketplaceListingSyncRequestId());
+        assertThat(marketplaceListingSyncRequestDao.findAll()).isEmpty();
     }
 
     @Test
@@ -451,6 +499,30 @@ class PricingPlaneDaoTest {
                 .confidence(new BigDecimal("0.7500"))
                 .comparableCount(2)
                 .evaluatedAt(SNAPSHOT_AT.plusMinutes(1))
+                .build();
+    }
+
+    private MarketplaceListingSyncRequest marketplaceListingSyncRequest(PricingFixture fixture, PricingDecision decision) {
+        return MarketplaceListingSyncRequest.builder()
+                .marketplaceListingId(fixture.listing().getMarketplaceListingId())
+                .listingExternalServiceId(fixture.bricklink().getExternalServiceId())
+                .pricingDecisionId(decision.getPricingDecisionId())
+                .syncRequestTypeCode("PRICE_UPDATE")
+                .syncRequestStatusCode("PENDING")
+                .syncReasonCode("PRICING_DECISION_APPLIED")
+                .previousUnitPrice(new BigDecimal("225.00"))
+                .requestedUnitPrice(new BigDecimal("219.00"))
+                .currencyCode("USD")
+                .remoteInventoryId("123456")
+                .remoteVisibilityScopeCode("STOCKROOM")
+                .remoteVisibilityContainerId("A")
+                .remoteIsPubliclyAvailable(false)
+                .environmentCode("sandbox")
+                .createdByJobName("BricklinkPricingApplyJob")
+                .attemptCount(0)
+                .maxAttempts(3)
+                .nextAttemptAt(SNAPSHOT_AT.plusHours(1))
+                .appliedLocalAt(SNAPSHOT_AT.plusMinutes(30))
                 .build();
     }
 

--- a/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-dao/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS marketplace_listing_sync_request;
 DROP TABLE IF EXISTS pricing_apply_readiness;
 DROP TABLE IF EXISTS pricing_decision;
 DROP TABLE IF EXISTS pricing_snapshot_listing;
@@ -314,7 +315,42 @@ CREATE TABLE bricklink_marketplace_listing (
     tier_price3 DECIMAL(12,2),
     my_weight DECIMAL(10,4),
     remarks CLOB,
-    last_remote_quantity INT
+    last_remote_quantity INT,
+    environment_code VARCHAR(32),
+    system_remarks_hash VARCHAR(64),
+    last_remote_verified_at TIMESTAMP,
+    last_remote_safety_status_code VARCHAR(64),
+    last_remote_safety_message CLOB
+);
+
+CREATE TABLE marketplace_listing_sync_request (
+    marketplace_listing_sync_request_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    listing_external_service_id INT NOT NULL,
+    pricing_decision_id BIGINT,
+    pricing_apply_readiness_id BIGINT,
+    sync_request_type_code VARCHAR(64) NOT NULL,
+    sync_request_status_code VARCHAR(64) NOT NULL,
+    sync_reason_code VARCHAR(64) NOT NULL,
+    previous_unit_price DECIMAL(12,2),
+    requested_unit_price DECIMAL(12,2),
+    currency_code VARCHAR(8),
+    remote_inventory_id VARCHAR(100),
+    remote_visibility_scope_code VARCHAR(64),
+    remote_visibility_container_id VARCHAR(100),
+    remote_is_publicly_available BOOLEAN,
+    environment_code VARCHAR(32),
+    created_by_job_name VARCHAR(100),
+    last_error_message CLOB,
+    attempt_count INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    next_attempt_at TIMESTAMP NOT NULL,
+    claimed_at TIMESTAMP,
+    applied_local_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (marketplace_listing_id, pricing_decision_id, sync_request_type_code)
 );
 
 CREATE TABLE ebay_marketplace_listing (

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/BricklinkMarketplaceListing.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/BricklinkMarketplaceListing.java
@@ -34,6 +34,11 @@ public class BricklinkMarketplaceListing {
     private BigDecimal myWeight;
     private String remarks;
     private Integer lastRemoteQuantity;
+    private String environmentCode;
+    private String systemRemarksHash;
+    private ZonedDateTime lastRemoteVerifiedAt;
+    private String lastRemoteSafetyStatusCode;
+    private String lastRemoteSafetyMessage;
 }
 
 

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceListingSyncRequest.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/MarketplaceListingSyncRequest.java
@@ -1,0 +1,42 @@
+package io.legohunter.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarketplaceListingSyncRequest {
+    private Long marketplaceListingSyncRequestId;
+    private Integer marketplaceListingId;
+    private Integer listingExternalServiceId;
+    private Long pricingDecisionId;
+    private Long pricingApplyReadinessId;
+    private String syncRequestTypeCode;
+    private String syncRequestStatusCode;
+    private String syncReasonCode;
+    private BigDecimal previousUnitPrice;
+    private BigDecimal requestedUnitPrice;
+    private String currencyCode;
+    private String remoteInventoryId;
+    private String remoteVisibilityScopeCode;
+    private String remoteVisibilityContainerId;
+    private Boolean remoteIsPubliclyAvailable;
+    private String environmentCode;
+    private String createdByJobName;
+    private String lastErrorMessage;
+    private Integer attemptCount;
+    private Integer maxAttempts;
+    private ZonedDateTime nextAttemptAt;
+    private ZonedDateTime claimedAt;
+    private ZonedDateTime appliedLocalAt;
+    private ZonedDateTime completedAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/BricklinkMarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/BricklinkMarketplaceListingMapper.java
@@ -32,7 +32,12 @@ public interface BricklinkMarketplaceListingMapper {
             tier_price3,
             my_weight,
             remarks,
-            last_remote_quantity
+            last_remote_quantity,
+            environment_code,
+            system_remarks_hash,
+            last_remote_verified_at,
+            last_remote_safety_status_code,
+            last_remote_safety_message
             """;
 
     @Select("SELECT " + ALL_COLUMNS + " FROM bricklink_marketplace_listing")
@@ -69,7 +74,12 @@ public interface BricklinkMarketplaceListingMapper {
                 tier_price3,
                 my_weight,
                 remarks,
-                last_remote_quantity
+                last_remote_quantity,
+                environment_code,
+                system_remarks_hash,
+                last_remote_verified_at,
+                last_remote_safety_status_code,
+                last_remote_safety_message
             )
             VALUES (
                 #{marketplaceListingId},
@@ -92,7 +102,12 @@ public interface BricklinkMarketplaceListingMapper {
                 #{tierPrice3},
                 #{myWeight},
                 #{remarks},
-                #{lastRemoteQuantity}
+                #{lastRemoteQuantity},
+                #{environmentCode},
+                #{systemRemarksHash},
+                #{lastRemoteVerifiedAt},
+                #{lastRemoteSafetyStatusCode},
+                #{lastRemoteSafetyMessage}
             )
             """)
     int insert(BricklinkMarketplaceListing bricklinkMarketplaceListing);
@@ -118,7 +133,12 @@ public interface BricklinkMarketplaceListingMapper {
                 tier_price3 = #{tierPrice3},
                 my_weight = #{myWeight},
                 remarks = #{remarks},
-                last_remote_quantity = #{lastRemoteQuantity}
+                last_remote_quantity = #{lastRemoteQuantity},
+                environment_code = #{environmentCode},
+                system_remarks_hash = #{systemRemarksHash},
+                last_remote_verified_at = #{lastRemoteVerifiedAt},
+                last_remote_safety_status_code = #{lastRemoteSafetyStatusCode},
+                last_remote_safety_message = #{lastRemoteSafetyMessage}
             WHERE marketplace_listing_id = #{marketplaceListingId}
             """)
     int update(BricklinkMarketplaceListing bricklinkMarketplaceListing);
@@ -148,7 +168,12 @@ public interface BricklinkMarketplaceListingMapper {
                 tier_price3,
                 my_weight,
                 remarks,
-                last_remote_quantity
+                last_remote_quantity,
+                environment_code,
+                system_remarks_hash,
+                last_remote_verified_at,
+                last_remote_safety_status_code,
+                last_remote_safety_message
             )
             VALUES (
                 #{marketplaceListingId},
@@ -171,7 +196,12 @@ public interface BricklinkMarketplaceListingMapper {
                 #{tierPrice3},
                 #{myWeight},
                 #{remarks},
-                #{lastRemoteQuantity}
+                #{lastRemoteQuantity},
+                #{environmentCode},
+                #{systemRemarksHash},
+                #{lastRemoteVerifiedAt},
+                #{lastRemoteSafetyStatusCode},
+                #{lastRemoteSafetyMessage}
             )
             ON DUPLICATE KEY UPDATE
                 bricklink_inventory_id = VALUES(bricklink_inventory_id),
@@ -193,7 +223,12 @@ public interface BricklinkMarketplaceListingMapper {
                 tier_price3 = VALUES(tier_price3),
                 my_weight = VALUES(my_weight),
                 remarks = VALUES(remarks),
-                last_remote_quantity = VALUES(last_remote_quantity)
+                last_remote_quantity = VALUES(last_remote_quantity),
+                environment_code = VALUES(environment_code),
+                system_remarks_hash = VALUES(system_remarks_hash),
+                last_remote_verified_at = VALUES(last_remote_verified_at),
+                last_remote_safety_status_code = VALUES(last_remote_safety_status_code),
+                last_remote_safety_message = VALUES(last_remote_safety_message)
             """)
     int upsert(BricklinkMarketplaceListing bricklinkMarketplaceListing);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -10,6 +10,7 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
@@ -286,6 +287,18 @@ public interface MarketplaceListingMapper {
             WHERE marketplace_listing_id = #{marketplaceListingId}
             """)
     int update(MarketplaceListing marketplaceListing);
+
+    @Update("""
+            UPDATE marketplace_listing
+            SET unit_price = #{unitPrice},
+                updated_at = COALESCE(#{updatedAt}, CURRENT_TIMESTAMP)
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+            """)
+    int updateUnitPrice(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("unitPrice") BigDecimal unitPrice,
+            @Param("updatedAt") ZonedDateTime updatedAt
+    );
 
     @Delete("DELETE FROM marketplace_listing WHERE marketplace_listing_id = #{marketplaceListingId}")
     int delete(Integer marketplaceListingId);

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.java
@@ -1,0 +1,312 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+public interface MarketplaceListingSyncRequestMapper {
+    String ALL_COLUMNS = """
+            marketplace_listing_sync_request_id,
+            marketplace_listing_id,
+            listing_external_service_id,
+            pricing_decision_id,
+            pricing_apply_readiness_id,
+            sync_request_type_code,
+            sync_request_status_code,
+            sync_reason_code,
+            previous_unit_price,
+            requested_unit_price,
+            currency_code,
+            remote_inventory_id,
+            remote_visibility_scope_code,
+            remote_visibility_container_id,
+            remote_is_publicly_available,
+            environment_code,
+            created_by_job_name,
+            last_error_message,
+            attempt_count,
+            max_attempts,
+            next_attempt_at,
+            claimed_at,
+            applied_local_at,
+            completed_at,
+            created_at,
+            updated_at
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing_sync_request")
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findAll();
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing_sync_request WHERE marketplace_listing_sync_request_id = #{marketplaceListingSyncRequestId}")
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Optional<MarketplaceListingSyncRequest> findByMarketplaceListingSyncRequestId(Long marketplaceListingSyncRequestId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing_sync_request WHERE marketplace_listing_id = #{marketplaceListingId}")
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findByMarketplaceListingId(Integer marketplaceListingId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_listing_sync_request WHERE sync_request_status_code = #{syncRequestStatusCode}")
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findBySyncRequestStatusCode(String syncRequestStatusCode);
+
+    @Select("""
+            SELECT ${columns}
+            FROM marketplace_listing_sync_request
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+              AND pricing_decision_id = #{pricingDecisionId}
+              AND sync_request_type_code = #{syncRequestTypeCode}
+            """)
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Optional<MarketplaceListingSyncRequest> findByMarketplaceListingIdAndPricingDecisionIdAndSyncRequestTypeCode(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("pricingDecisionId") Long pricingDecisionId,
+            @Param("syncRequestTypeCode") String syncRequestTypeCode,
+            @Param("columns") String columns
+    );
+
+    default Optional<MarketplaceListingSyncRequest> findByMarketplaceListingIdAndPricingDecisionIdAndSyncRequestTypeCode(
+            Integer marketplaceListingId,
+            Long pricingDecisionId,
+            String syncRequestTypeCode
+    ) {
+        return findByMarketplaceListingIdAndPricingDecisionIdAndSyncRequestTypeCode(
+                marketplaceListingId,
+                pricingDecisionId,
+                syncRequestTypeCode,
+                ALL_COLUMNS
+        );
+    }
+
+    @Select("""
+            SELECT ${columns}
+            FROM marketplace_listing_sync_request
+            WHERE sync_request_status_code = #{syncRequestStatusCode}
+              AND next_attempt_at <= #{asOf}
+              AND attempt_count < max_attempts
+            ORDER BY next_attempt_at, marketplace_listing_sync_request_id
+            LIMIT #{limit}
+            """)
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findClaimableByStatusCode(
+            @Param("syncRequestStatusCode") String syncRequestStatusCode,
+            @Param("asOf") ZonedDateTime asOf,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    default Set<MarketplaceListingSyncRequest> findClaimableByStatusCode(String syncRequestStatusCode, ZonedDateTime asOf, int limit) {
+        return findClaimableByStatusCode(syncRequestStatusCode, asOf, limit, ALL_COLUMNS);
+    }
+
+    @Select("SELECT COUNT(*) FROM marketplace_listing_sync_request WHERE sync_request_status_code = #{syncRequestStatusCode}")
+    long countBySyncRequestStatusCode(String syncRequestStatusCode);
+
+    @Select("""
+            SELECT COUNT(*)
+            FROM marketplace_listing_sync_request
+            WHERE sync_request_status_code = #{syncRequestStatusCode}
+              AND next_attempt_at <= #{asOf}
+              AND attempt_count < max_attempts
+            """)
+    long countDueBySyncRequestStatusCode(@Param("syncRequestStatusCode") String syncRequestStatusCode, @Param("asOf") ZonedDateTime asOf);
+
+    @Insert("""
+            INSERT INTO marketplace_listing_sync_request (
+                marketplace_listing_id,
+                listing_external_service_id,
+                pricing_decision_id,
+                pricing_apply_readiness_id,
+                sync_request_type_code,
+                sync_request_status_code,
+                sync_reason_code,
+                previous_unit_price,
+                requested_unit_price,
+                currency_code,
+                remote_inventory_id,
+                remote_visibility_scope_code,
+                remote_visibility_container_id,
+                remote_is_publicly_available,
+                environment_code,
+                created_by_job_name,
+                last_error_message,
+                attempt_count,
+                max_attempts,
+                next_attempt_at,
+                claimed_at,
+                applied_local_at,
+                completed_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceListingId},
+                #{listingExternalServiceId},
+                #{pricingDecisionId},
+                #{pricingApplyReadinessId},
+                #{syncRequestTypeCode},
+                #{syncRequestStatusCode},
+                #{syncReasonCode},
+                #{previousUnitPrice},
+                #{requestedUnitPrice},
+                #{currencyCode},
+                #{remoteInventoryId},
+                #{remoteVisibilityScopeCode},
+                #{remoteVisibilityContainerId},
+                #{remoteIsPubliclyAvailable},
+                #{environmentCode},
+                #{createdByJobName},
+                #{lastErrorMessage},
+                COALESCE(#{attemptCount}, 0),
+                COALESCE(#{maxAttempts}, 3),
+                COALESCE(#{nextAttemptAt}, CURRENT_TIMESTAMP),
+                #{claimedAt},
+                #{appliedLocalAt},
+                #{completedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "marketplace_listing_sync_request_id", keyProperty = "marketplaceListingSyncRequestId")
+    void insert(MarketplaceListingSyncRequest syncRequest);
+
+    @Update("""
+            UPDATE marketplace_listing_sync_request
+            SET marketplace_listing_id = #{marketplaceListingId},
+                listing_external_service_id = #{listingExternalServiceId},
+                pricing_decision_id = #{pricingDecisionId},
+                pricing_apply_readiness_id = #{pricingApplyReadinessId},
+                sync_request_type_code = #{syncRequestTypeCode},
+                sync_request_status_code = #{syncRequestStatusCode},
+                sync_reason_code = #{syncReasonCode},
+                previous_unit_price = #{previousUnitPrice},
+                requested_unit_price = #{requestedUnitPrice},
+                currency_code = #{currencyCode},
+                remote_inventory_id = #{remoteInventoryId},
+                remote_visibility_scope_code = #{remoteVisibilityScopeCode},
+                remote_visibility_container_id = #{remoteVisibilityContainerId},
+                remote_is_publicly_available = #{remoteIsPubliclyAvailable},
+                environment_code = #{environmentCode},
+                created_by_job_name = #{createdByJobName},
+                last_error_message = #{lastErrorMessage},
+                attempt_count = #{attemptCount},
+                max_attempts = #{maxAttempts},
+                next_attempt_at = #{nextAttemptAt},
+                claimed_at = #{claimedAt},
+                applied_local_at = #{appliedLocalAt},
+                completed_at = #{completedAt},
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_listing_sync_request_id = #{marketplaceListingSyncRequestId}
+            """)
+    int update(MarketplaceListingSyncRequest syncRequest);
+
+    @Update("""
+            UPDATE marketplace_listing_sync_request
+            SET sync_request_status_code = #{claimedStatusCode},
+                claimed_at = #{claimedAt},
+                attempt_count = attempt_count + 1,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE marketplace_listing_sync_request_id = #{marketplaceListingSyncRequestId}
+              AND sync_request_status_code = #{fromStatusCode}
+              AND attempt_count < max_attempts
+            """)
+    int claim(
+            @Param("marketplaceListingSyncRequestId") Long marketplaceListingSyncRequestId,
+            @Param("fromStatusCode") String fromStatusCode,
+            @Param("claimedStatusCode") String claimedStatusCode,
+            @Param("claimedAt") ZonedDateTime claimedAt
+    );
+
+    @Insert("""
+            INSERT INTO marketplace_listing_sync_request (
+                marketplace_listing_sync_request_id,
+                marketplace_listing_id,
+                listing_external_service_id,
+                pricing_decision_id,
+                pricing_apply_readiness_id,
+                sync_request_type_code,
+                sync_request_status_code,
+                sync_reason_code,
+                previous_unit_price,
+                requested_unit_price,
+                currency_code,
+                remote_inventory_id,
+                remote_visibility_scope_code,
+                remote_visibility_container_id,
+                remote_is_publicly_available,
+                environment_code,
+                created_by_job_name,
+                last_error_message,
+                attempt_count,
+                max_attempts,
+                next_attempt_at,
+                claimed_at,
+                applied_local_at,
+                completed_at,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                #{marketplaceListingSyncRequestId},
+                #{marketplaceListingId},
+                #{listingExternalServiceId},
+                #{pricingDecisionId},
+                #{pricingApplyReadinessId},
+                #{syncRequestTypeCode},
+                #{syncRequestStatusCode},
+                #{syncReasonCode},
+                #{previousUnitPrice},
+                #{requestedUnitPrice},
+                #{currencyCode},
+                #{remoteInventoryId},
+                #{remoteVisibilityScopeCode},
+                #{remoteVisibilityContainerId},
+                #{remoteIsPubliclyAvailable},
+                #{environmentCode},
+                #{createdByJobName},
+                #{lastErrorMessage},
+                COALESCE(#{attemptCount}, 0),
+                COALESCE(#{maxAttempts}, 3),
+                COALESCE(#{nextAttemptAt}, CURRENT_TIMESTAMP),
+                #{claimedAt},
+                #{appliedLocalAt},
+                #{completedAt},
+                CURRENT_TIMESTAMP,
+                CURRENT_TIMESTAMP
+            )
+            ON DUPLICATE KEY UPDATE
+                pricing_apply_readiness_id = VALUES(pricing_apply_readiness_id),
+                sync_request_status_code = VALUES(sync_request_status_code),
+                sync_reason_code = VALUES(sync_reason_code),
+                previous_unit_price = VALUES(previous_unit_price),
+                requested_unit_price = VALUES(requested_unit_price),
+                currency_code = VALUES(currency_code),
+                remote_inventory_id = VALUES(remote_inventory_id),
+                remote_visibility_scope_code = VALUES(remote_visibility_scope_code),
+                remote_visibility_container_id = VALUES(remote_visibility_container_id),
+                remote_is_publicly_available = VALUES(remote_is_publicly_available),
+                environment_code = VALUES(environment_code),
+                created_by_job_name = VALUES(created_by_job_name),
+                last_error_message = VALUES(last_error_message),
+                max_attempts = VALUES(max_attempts),
+                next_attempt_at = VALUES(next_attempt_at),
+                claimed_at = VALUES(claimed_at),
+                applied_local_at = VALUES(applied_local_at),
+                completed_at = VALUES(completed_at),
+                updated_at = CURRENT_TIMESTAMP
+            """)
+    @Options(useGeneratedKeys = true, keyColumn = "marketplace_listing_sync_request_id", keyProperty = "marketplaceListingSyncRequestId")
+    void upsert(MarketplaceListingSyncRequest syncRequest);
+
+    @Delete("DELETE FROM marketplace_listing_sync_request WHERE marketplace_listing_sync_request_id = #{marketplaceListingSyncRequestId}")
+    int delete(Long marketplaceListingSyncRequestId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -10,6 +10,7 @@ import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Set;
 
@@ -314,6 +315,14 @@ public interface PricingDecisionMapper {
             WHERE pricing_decision_id = #{pricingDecisionId}
             """)
     int update(PricingDecision pricingDecision);
+
+    @Update("""
+            UPDATE pricing_decision
+            SET applied_at = COALESCE(#{appliedAt}, CURRENT_TIMESTAMP)
+            WHERE pricing_decision_id = #{pricingDecisionId}
+              AND applied_at IS NULL
+            """)
+    int markApplied(@Param("pricingDecisionId") Long pricingDecisionId, @Param("appliedAt") ZonedDateTime appliedAt);
 
     @Delete("DELETE FROM pricing_decision WHERE pricing_decision_id = #{pricingDecisionId}")
     int delete(Long pricingDecisionId);

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/BricklinkMarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/BricklinkMarketplaceListingMapper.xml
@@ -22,5 +22,10 @@
     <result column="my_weight"                        property="myWeight"/>
     <result column="remarks"                          property="remarks"/>
     <result column="last_remote_quantity"             property="lastRemoteQuantity"/>
+    <result column="environment_code"                  property="environmentCode"/>
+    <result column="system_remarks_hash"               property="systemRemarksHash"/>
+    <result column="last_remote_verified_at"           property="lastRemoteVerifiedAt"/>
+    <result column="last_remote_safety_status_code"    property="lastRemoteSafetyStatusCode"/>
+    <result column="last_remote_safety_message"        property="lastRemoteSafetyMessage"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.xml
@@ -1,0 +1,31 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.MarketplaceListingSyncRequestMapper">
+  <resultMap type="io.legohunter.data.dto.MarketplaceListingSyncRequest" id="marketplaceListingSyncRequestResultMap">
+    <id     column="marketplace_listing_sync_request_id" property="marketplaceListingSyncRequestId"/>
+    <result column="marketplace_listing_id"              property="marketplaceListingId"/>
+    <result column="listing_external_service_id"         property="listingExternalServiceId"/>
+    <result column="pricing_decision_id"                 property="pricingDecisionId"/>
+    <result column="pricing_apply_readiness_id"          property="pricingApplyReadinessId"/>
+    <result column="sync_request_type_code"              property="syncRequestTypeCode"/>
+    <result column="sync_request_status_code"            property="syncRequestStatusCode"/>
+    <result column="sync_reason_code"                    property="syncReasonCode"/>
+    <result column="previous_unit_price"                 property="previousUnitPrice"/>
+    <result column="requested_unit_price"                property="requestedUnitPrice"/>
+    <result column="currency_code"                       property="currencyCode"/>
+    <result column="remote_inventory_id"                 property="remoteInventoryId"/>
+    <result column="remote_visibility_scope_code"        property="remoteVisibilityScopeCode"/>
+    <result column="remote_visibility_container_id"      property="remoteVisibilityContainerId"/>
+    <result column="remote_is_publicly_available"        property="remoteIsPubliclyAvailable"/>
+    <result column="environment_code"                    property="environmentCode"/>
+    <result column="created_by_job_name"                 property="createdByJobName"/>
+    <result column="last_error_message"                  property="lastErrorMessage"/>
+    <result column="attempt_count"                       property="attemptCount"/>
+    <result column="max_attempts"                        property="maxAttempts"/>
+    <result column="next_attempt_at"                     property="nextAttemptAt"/>
+    <result column="claimed_at"                          property="claimedAt"/>
+    <result column="applied_local_at"                    property="appliedLocalAt"/>
+    <result column="completed_at"                        property="completedAt"/>
+    <result column="created_at"                          property="createdAt"/>
+    <result column="updated_at"                          property="updatedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MapperTestSupport.java
@@ -17,6 +17,7 @@ import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventoryPhoto;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
 import io.legohunter.data.dto.Party;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingDecision;
@@ -62,6 +63,7 @@ abstract class MapperTestSupport {
     @Autowired PricingSnapshotListingMapper pricingSnapshotListingMapper;
     @Autowired PricingDecisionMapper pricingDecisionMapper;
     @Autowired PricingApplyReadinessMapper pricingApplyReadinessMapper;
+    @Autowired MarketplaceListingSyncRequestMapper marketplaceListingSyncRequestMapper;
     @Autowired PartyMapper partyMapper;
     @Autowired PaymentPlatformMapper paymentPlatformMapper;
     @Autowired TransactionCostMapper transactionCostMapper;
@@ -271,6 +273,35 @@ abstract class MapperTestSupport {
                 .myWeight(new BigDecimal("1.2500"))
                 .remarks("Remarks")
                 .lastRemoteQuantity(1)
+                .environmentCode("sandbox")
+                .systemRemarksHash("hash-1")
+                .lastRemoteVerifiedAt(ZonedDateTime.parse("2026-01-02T00:00:00Z"))
+                .lastRemoteSafetyStatusCode("VERIFIED")
+                .lastRemoteSafetyMessage("Verified stockroom safety")
+                .build();
+    }
+
+    MarketplaceListingSyncRequest marketplaceListingSyncRequest(Integer marketplaceListingId, Integer listingExternalServiceId, Long pricingDecisionId) {
+        return MarketplaceListingSyncRequest.builder()
+                .marketplaceListingId(marketplaceListingId)
+                .listingExternalServiceId(listingExternalServiceId)
+                .pricingDecisionId(pricingDecisionId)
+                .syncRequestTypeCode("PRICE_UPDATE")
+                .syncRequestStatusCode("PENDING")
+                .syncReasonCode("PRICING_DECISION_APPLIED")
+                .previousUnitPrice(new BigDecimal("225.00"))
+                .requestedUnitPrice(new BigDecimal("219.00"))
+                .currencyCode("USD")
+                .remoteInventoryId("123456")
+                .remoteVisibilityScopeCode("STOCKROOM")
+                .remoteVisibilityContainerId("A")
+                .remoteIsPubliclyAvailable(false)
+                .environmentCode("sandbox")
+                .createdByJobName("BricklinkPricingApplyJob")
+                .attemptCount(0)
+                .maxAttempts(3)
+                .nextAttemptAt(ZonedDateTime.parse("2026-06-18T16:00:00Z"))
+                .appliedLocalAt(ZonedDateTime.parse("2026-06-18T15:30:00Z"))
                 .build();
     }
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -309,14 +309,25 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         bricklinkMarketplaceListingMapper.update(bricklink);
 
         assertThat(bricklinkMarketplaceListingMapper.findByMarketplaceListingId(listing.getMarketplaceListingId()))
-                .hasValueSatisfying(found -> assertThat(found.getColorName()).isEqualTo("Red"));
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getColorName()).isEqualTo("Red");
+                    assertThat(found.getEnvironmentCode()).isEqualTo("sandbox");
+                    assertThat(found.getSystemRemarksHash()).isEqualTo("hash-1");
+                    assertThat(found.getLastRemoteSafetyStatusCode()).isEqualTo("VERIFIED");
+                });
         assertThat(bricklinkMarketplaceListingMapper.findByBricklinkInventoryId(2001)).isPresent();
         assertThat(bricklinkMarketplaceListingMapper.findAll()).hasSize(1);
 
         bricklink.setLastRemoteQuantity(7);
+        bricklink.setLastRemoteSafetyStatusCode("BLOCKED");
+        bricklink.setLastRemoteSafetyMessage("Missing system block");
         bricklinkMarketplaceListingMapper.upsert(bricklink);
         assertThat(bricklinkMarketplaceListingMapper.findByMarketplaceListingId(listing.getMarketplaceListingId()))
-                .hasValueSatisfying(found -> assertThat(found.getLastRemoteQuantity()).isEqualTo(7));
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getLastRemoteQuantity()).isEqualTo(7);
+                    assertThat(found.getLastRemoteSafetyStatusCode()).isEqualTo("BLOCKED");
+                    assertThat(found.getLastRemoteSafetyMessage()).isEqualTo("Missing system block");
+                });
 
         assertThat(bricklinkMarketplaceListingMapper.delete(listing.getMarketplaceListingId())).isOne();
     }

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -3,6 +3,7 @@ package io.legohunter.data.mybatis.mapper;
 import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
 import io.legohunter.data.dto.PricingApplyReadiness;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
@@ -650,6 +651,79 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         assertThat(pricingApplyReadinessMapper.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
         assertThat(pricingApplyReadinessMapper.findLatestReadyToApplyReviews(10)).isEmpty();
         assertThat(pricingApplyReadinessMapper.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
+    }
+
+    @Test
+    void marketplaceListingSyncRequestSupportsCrudClaimAndIdempotentUpsert() {
+        PricingFixture fixture = pricingFixture("pricing-sync-request");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingDecision decision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        pricingDecisionMapper.insert(decision);
+        MarketplaceListingSyncRequest syncRequest = marketplaceListingSyncRequest(
+                fixture.listing().getMarketplaceListingId(),
+                2,
+                decision.getPricingDecisionId()
+        );
+
+        marketplaceListingSyncRequestMapper.insert(syncRequest);
+        syncRequest.setSyncRequestStatusCode("PENDING");
+        syncRequest.setLastErrorMessage("Waiting for sync");
+        assertThat(marketplaceListingSyncRequestMapper.update(syncRequest)).isOne();
+
+        assertThat(marketplaceListingSyncRequestMapper.findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getMarketplaceListingId()).isEqualTo(fixture.listing().getMarketplaceListingId());
+                    assertThat(found.getPricingDecisionId()).isEqualTo(decision.getPricingDecisionId());
+                    assertThat(found.getSyncRequestTypeCode()).isEqualTo("PRICE_UPDATE");
+                    assertThat(found.getSyncRequestStatusCode()).isEqualTo("PENDING");
+                    assertThat(found.getRemoteVisibilityScopeCode()).isEqualTo("STOCKROOM");
+                    assertThat(found.getRemoteIsPubliclyAvailable()).isFalse();
+                    assertThat(found.getLastErrorMessage()).isEqualTo("Waiting for sync");
+                });
+        assertThat(marketplaceListingSyncRequestMapper.findByMarketplaceListingId(fixture.listing().getMarketplaceListingId())).hasSize(1);
+        assertThat(marketplaceListingSyncRequestMapper.findBySyncRequestStatusCode("PENDING")).hasSize(1);
+        assertThat(marketplaceListingSyncRequestMapper.countBySyncRequestStatusCode("PENDING")).isOne();
+        assertThat(marketplaceListingSyncRequestMapper.countDueBySyncRequestStatusCode("PENDING", SNAPSHOT_AT)).isZero();
+        assertThat(marketplaceListingSyncRequestMapper.countDueBySyncRequestStatusCode("PENDING", SNAPSHOT_AT.plusHours(2))).isOne();
+        assertThat(marketplaceListingSyncRequestMapper.findClaimableByStatusCode("PENDING", SNAPSHOT_AT.plusHours(2), 10))
+                .extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
+                .containsExactly(syncRequest.getMarketplaceListingSyncRequestId());
+
+        assertThat(marketplaceListingSyncRequestMapper.claim(
+                syncRequest.getMarketplaceListingSyncRequestId(),
+                "PENDING",
+                "CLAIMED",
+                SNAPSHOT_AT.plusHours(2)
+        )).isOne();
+        assertThat(marketplaceListingSyncRequestMapper.claim(
+                syncRequest.getMarketplaceListingSyncRequestId(),
+                "PENDING",
+                "CLAIMED",
+                SNAPSHOT_AT.plusHours(2)
+        )).isZero();
+        assertThat(marketplaceListingSyncRequestMapper.findByMarketplaceListingSyncRequestId(syncRequest.getMarketplaceListingSyncRequestId()))
+                .hasValueSatisfying(found -> {
+                    assertThat(found.getSyncRequestStatusCode()).isEqualTo("CLAIMED");
+                    assertThat(found.getAttemptCount()).isOne();
+                    assertThat(found.getClaimedAt()).isEqualTo(SNAPSHOT_AT.plusHours(2));
+                });
+
+        syncRequest.setSyncRequestStatusCode("PENDING");
+        syncRequest.setRequestedUnitPrice(new BigDecimal("218.00"));
+        syncRequest.setNextAttemptAt(SNAPSHOT_AT.plusHours(3));
+        marketplaceListingSyncRequestMapper.upsert(syncRequest);
+        assertThat(marketplaceListingSyncRequestMapper.findByMarketplaceListingIdAndPricingDecisionIdAndSyncRequestTypeCode(
+                fixture.listing().getMarketplaceListingId(),
+                decision.getPricingDecisionId(),
+                "PRICE_UPDATE"
+        )).hasValueSatisfying(found -> {
+            assertThat(found.getMarketplaceListingSyncRequestId()).isEqualTo(syncRequest.getMarketplaceListingSyncRequestId());
+            assertThat(found.getRequestedUnitPrice()).isEqualByComparingTo("218.00");
+        });
+
+        assertThat(marketplaceListingSyncRequestMapper.findAll()).hasSize(1);
+        assertThat(marketplaceListingSyncRequestMapper.delete(syncRequest.getMarketplaceListingSyncRequestId())).isOne();
+        assertThat(marketplaceListingSyncRequestMapper.findAll()).isEmpty();
     }
 
     private PricingSnapshot insertedSnapshot(PricingFixture fixture) {

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
 DROP TABLE IF EXISTS marketplace_order_sync_run;
+DROP TABLE IF EXISTS marketplace_listing_sync_request;
 DROP TABLE IF EXISTS pricing_apply_readiness;
 DROP TABLE IF EXISTS pricing_decision;
 DROP TABLE IF EXISTS pricing_snapshot_listing;
@@ -314,7 +315,42 @@ CREATE TABLE bricklink_marketplace_listing (
     tier_price3 DECIMAL(12,2),
     my_weight DECIMAL(10,4),
     remarks CLOB,
-    last_remote_quantity INT
+    last_remote_quantity INT,
+    environment_code VARCHAR(32),
+    system_remarks_hash VARCHAR(64),
+    last_remote_verified_at TIMESTAMP,
+    last_remote_safety_status_code VARCHAR(64),
+    last_remote_safety_message CLOB
+);
+
+CREATE TABLE marketplace_listing_sync_request (
+    marketplace_listing_sync_request_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    marketplace_listing_id INT NOT NULL,
+    listing_external_service_id INT NOT NULL,
+    pricing_decision_id BIGINT,
+    pricing_apply_readiness_id BIGINT,
+    sync_request_type_code VARCHAR(64) NOT NULL,
+    sync_request_status_code VARCHAR(64) NOT NULL,
+    sync_reason_code VARCHAR(64) NOT NULL,
+    previous_unit_price DECIMAL(12,2),
+    requested_unit_price DECIMAL(12,2),
+    currency_code VARCHAR(8),
+    remote_inventory_id VARCHAR(100),
+    remote_visibility_scope_code VARCHAR(64),
+    remote_visibility_container_id VARCHAR(100),
+    remote_is_publicly_available BOOLEAN,
+    environment_code VARCHAR(32),
+    created_by_job_name VARCHAR(100),
+    last_error_message CLOB,
+    attempt_count INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 3,
+    next_attempt_at TIMESTAMP NOT NULL,
+    claimed_at TIMESTAMP,
+    applied_local_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (marketplace_listing_id, pricing_decision_id, sync_request_type_code)
 );
 
 CREATE TABLE ebay_marketplace_listing (


### PR DESCRIPTION
## Summary
- Adds the `MarketplaceListingSyncRequest` DTO, DAO, MyBatis mapper, XML result map, H2 schema support, and tests for the final Pricing Plane sync queue.
- Extends `BricklinkMarketplaceListing` persistence with non-prod remote safety metadata: environment code, system remarks hash, last verified timestamp, remote safety status, and remote safety message.
- Adds narrow update helpers for applying local listing prices and marking pricing decisions applied.

## Validation
- `mvn clean install`