### PR TITLE
Use cost type code for cost type equality

### DIFF
--- a/lego-data-model/src/main/java/io/legohunter/data/dto/CostType.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/CostType.java
@@ -2,10 +2,13 @@ package io.legohunter.data.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Builder
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CostType {
+    @EqualsAndHashCode.Include
     private String costTypeCode;
     private String costTypeName;
     private String costTypeDescription;

--- a/lego-data-model/src/test/java/io/legohunter/data/dto/CostTypeTest.java
+++ b/lego-data-model/src/test/java/io/legohunter/data/dto/CostTypeTest.java
@@ -1,0 +1,32 @@
+package io.legohunter.data.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CostTypeTest {
+
+    @Test
+    void equalityUsesCostTypeCodeOnly() {
+        CostType price = CostType.builder()
+                .costTypeCode("PRICE")
+                .costTypeName("Price")
+                .costTypeDescription("Original item price")
+                .build();
+        CostType renamedPrice = CostType.builder()
+                .costTypeCode("PRICE")
+                .costTypeName("Updated Price")
+                .costTypeDescription("Updated description")
+                .build();
+        CostType shipping = CostType.builder()
+                .costTypeCode("SHIPPING")
+                .costTypeName("Shipping")
+                .costTypeDescription("Shipping fee")
+                .build();
+
+        assertThat(price)
+                .isEqualTo(renamedPrice)
+                .isNotEqualTo(shipping);
+        assertThat(price.hashCode()).isEqualTo(renamedPrice.hashCode());
+    }
+}


### PR DESCRIPTION
## Summary
- Add Lombok equality/hash-code semantics for CostType using only costTypeCode.
- Add a model test documenting that mutable display/description fields do not affect CostType identity.

## Verification
- mvn clean install