### PR TITLE
Include item number in validation error

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/validation/ConditionCodeValidator.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/validation/ConditionCodeValidator.java
@@ -35,7 +35,7 @@ public class ConditionCodeValidator implements ConstraintValidator<ConditionCode
                 .map(condition -> true)
                 .orElseGet(() -> {
                     context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(String.format("Must be one of %s", acceptedValues))
+                    context.buildConstraintViolationWithTemplate(String.format("Condition Code [%s] is invalid. Must be one of %s", value, acceptedValues))
                             .addConstraintViolation();
                     return false;
                 });

--- a/lego-data-dao/src/main/java/io/legohunter/data/validation/ItemNumberValidator.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/validation/ItemNumberValidator.java
@@ -33,7 +33,7 @@ public class ItemNumberValidator implements ConstraintValidator<ItemNumberExists
                 .map(externalCatalogItem -> true)
                 .orElseGet(() -> {
                     context.disableDefaultConstraintViolation();
-                    context.buildConstraintViolationWithTemplate(String.format("Item Number was not found in external service %s", externalServiceCode))
+                    context.buildConstraintViolationWithTemplate(String.format("Item Number [%s] was not found in external service %s", value, externalServiceCode))
                             .addConstraintViolation();
                     return false;
                 });

--- a/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
@@ -55,7 +55,7 @@ class ValidatorCoverageTest {
 
         when(catalogItemDao.findByExternalServiceIdAndExternalItemKey(1, "missing")).thenReturn(Optional.empty());
         assertThat(validator.isValid("missing", context)).isFalse();
-        verify(context).buildConstraintViolationWithTemplate("Item Number was not found in external service BRICKLINK");
+        verify(context).buildConstraintViolationWithTemplate("Item Number [missing] was not found in external service BRICKLINK");
     }
 
     @Test

--- a/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/validation/ValidatorCoverageTest.java
@@ -74,7 +74,7 @@ class ValidatorCoverageTest {
 
         when(dao.findByConditionCode("BAD")).thenReturn(Optional.empty());
         assertThat(validator.isValid("BAD", context)).isFalse();
-        verify(context).buildConstraintViolationWithTemplate("Must be one of [G]");
+        verify(context).buildConstraintViolationWithTemplate("Condition Code [BAD] is invalid. Must be one of [G]");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Include the rejected BrickLink item number in @ItemNumberExists validation failures.
- Update validator coverage to assert the new message shape.

## Verification
- mvn -pl lego-data-dao test
- mvn clean install
- lego-data-service: mvn test