### PR TITLE
Add inventory search and correction DAO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ Money-bearing payment fields use `BigDecimal`. Existing transaction cost and tra
 `transactions.transaction_date` and `payment.payment_date` are date-only fields. The DTOs use `LocalDate`, the mappers bind them with `jdbcType=DATE`, and H2 test schemas define both columns as `DATE`.
 
 `current_schema.ddl` is single-sourced from `lego-data-mybatis/src/test/resources`. The MyBatis module publishes its test resources through a Maven `tests` classifier artifact, and the DAO module consumes that artifact as a test-scoped `test-jar` dependency so DAO and mapper integration tests run against the same H2 schema file.
+
+## Inventory Read And Correction Data Support
+
+Phase 2 Inventory Read, Search, and Correction workflows add reusable data-layer support for `lego-data-service`:
+
+- `ItemInventorySearchCriteria` models optional search filters for owned inventory.
+- `ItemInventoryDao.search(...)` and `ItemInventoryDao.countSearch(...)` delegate to dynamic MyBatis search queries.
+- `ItemInventoryMapper.search(...)` supports filters for catalog item number, description, box number, inventory state, sale intent, active flag, physical item facts, condition codes, and transaction date range.
+- `TransactionCostDao` now exposes row-scoped transaction-item cost operations: find by id, find by transaction item and cost type, update, and delete.
+- Transaction and transaction-item cost replacement helpers delete existing rows even when the replacement list is empty, which keeps explicit empty replacement semantics deterministic.
+
+Business rules remain in `lego-data-service`; DAOs and mappers stay focused on persistence operations.

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ItemInventoryDao.java
@@ -3,6 +3,7 @@ package io.legohunter.data.dao;
 import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventorySearchCriteria;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,14 @@ public class ItemInventoryDao {
 
     public Optional<ItemInventory> findByUuid(String uuid) {
         return itemInventoryMapper.findByUuid(uuid);
+    }
+
+    public Set<ItemInventory> search(ItemInventorySearchCriteria criteria) {
+        return itemInventoryMapper.search(criteria);
+    }
+
+    public int countSearch(ItemInventorySearchCriteria criteria) {
+        return itemInventoryMapper.countSearch(criteria);
     }
 
     public Optional<ExternalCatalogItem> getPrimaryExternalCatalogItem(ItemInventory itemInventory) {

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionCostDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionCostDao.java
@@ -18,8 +18,8 @@ public class TransactionCostDao {
     private final TransactionItemCostMapper transactionItemCostMapper;
 
     public void setTransactionCosts(Long transactionId, List<TransactionCost> transactionCosts) {
+        deleteTransactionCosts(transactionId);
         if (!CollectionUtils.isEmpty(transactionCosts)) {
-            deleteTransactionCosts(transactionId);
             transactionCosts.forEach(transactionCost -> {
                 transactionCost.setTransactionId(transactionId);
                 insert(transactionCost);
@@ -28,8 +28,8 @@ public class TransactionCostDao {
     }
 
     public void setTransactionItemCosts(Long transactionItemId, List<TransactionItemCost> transactionItemCosts) {
+        deleteTransactionItemCosts(transactionItemId);
         if (!CollectionUtils.isEmpty(transactionItemCosts)) {
-            deleteTransactionItemCosts(transactionItemId);
             transactionItemCosts.forEach(transactionItemCost -> {
                 transactionItemCost.setTransactionItemId(transactionItemId);
                 insert(transactionItemCost);
@@ -49,6 +49,10 @@ public class TransactionCostDao {
         transactionCostMapper.delete(transactionCostId);
     }
 
+    public void deleteTransactionItemCost(Long transactionItemCostId) {
+        transactionItemCostMapper.delete(transactionItemCostId);
+    }
+
     public void insert(TransactionCost transactionCost) {
         transactionCostMapper.insert(transactionCost);
     }
@@ -64,6 +68,10 @@ public class TransactionCostDao {
 
     public void update(TransactionCost transactionCost) {
         transactionCostMapper.update(transactionCost);
+    }
+
+    public void update(TransactionItemCost transactionItemCost) {
+        transactionItemCostMapper.update(transactionItemCost);
     }
 
     public List<TransactionCost> findAll() {
@@ -86,5 +94,15 @@ public class TransactionCostDao {
 
     public List<TransactionItemCost> findByTransactionItemId(Long transactionItemId) {
         return transactionItemCostMapper.findByTransactionItemId(transactionItemId);
+    }
+
+    public Optional<TransactionItemCost> findTransactionItemCostById(Long transactionItemCostId) {
+        return transactionItemCostMapper.findById(transactionItemCostId);
+    }
+
+    public Optional<TransactionItemCost> findByTransactionItemIdAndCostTypeCode(Long transactionItemId, String costTypeCode) {
+        return transactionItemCostMapper.findByTransactionItemIdAndCostTypeCode(transactionItemId, costTypeCode)
+                .stream()
+                .findFirst();
     }
 }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 class DaoDelegationCoverageTest {
 
     @Test
-    void transactionCostDaoDelegatesAllMapperOperationsAndSkipsEmptyCostLists() {
+    void transactionCostDaoDelegatesAllMapperOperationsAndSupportsEmptyReplacementLists() {
         TransactionCostMapper transactionCostMapper = mock(TransactionCostMapper.class);
         TransactionItemCostMapper transactionItemCostMapper = mock(TransactionItemCostMapper.class);
         TransactionCostDao dao = new TransactionCostDao(transactionCostMapper, transactionItemCostMapper);
@@ -65,16 +65,13 @@ class DaoDelegationCoverageTest {
 
         dao.setTransactionCosts(10L, null);
         dao.setTransactionItemCosts(20L, List.of());
-        verifyNoInteractions(transactionCostMapper, transactionItemCostMapper);
 
         dao.setTransactionCosts(10L, List.of(transactionCost));
         assertThat(transactionCost.getTransactionId()).isEqualTo(10L);
-        verify(transactionCostMapper).deleteTransactionCosts(10L);
         verify(transactionCostMapper).insert(transactionCost);
 
         dao.setTransactionItemCosts(20L, List.of(transactionItemCost));
         assertThat(transactionItemCost.getTransactionItemId()).isEqualTo(20L);
-        verify(transactionItemCostMapper).deleteTransactionCosts(20L);
         verify(transactionItemCostMapper).insert(transactionItemCost);
 
         when(transactionCostMapper.findAll()).thenReturn(List.of(transactionCost));
@@ -82,6 +79,8 @@ class DaoDelegationCoverageTest {
         when(transactionCostMapper.findByTransactionId(10L)).thenReturn(List.of(transactionCost));
         when(transactionCostMapper.findByTransactionIdAndCostTypeCode(10L, "SHIP")).thenReturn(List.of(transactionCost));
         when(transactionItemCostMapper.findByTransactionItemId(20L)).thenReturn(List.of(transactionItemCost));
+        when(transactionItemCostMapper.findById(40L)).thenReturn(Optional.of(transactionItemCost));
+        when(transactionItemCostMapper.findByTransactionItemIdAndCostTypeCode(20L, "PRICE")).thenReturn(List.of(transactionItemCost));
 
         dao.deleteTransactionCosts(10L);
         dao.deleteTransactionItemCosts(20L);
@@ -90,18 +89,24 @@ class DaoDelegationCoverageTest {
         dao.insert(transactionItemCost);
         dao.migrate(transactionCost);
         dao.update(transactionCost);
+        dao.update(transactionItemCost);
+        dao.deleteTransactionItemCost(40L);
 
         assertThat(dao.findAll()).containsExactly(transactionCost);
         assertThat(dao.findById(30L)).contains(transactionCost);
         assertThat(dao.findByTransactionId(10L)).containsExactly(transactionCost);
         assertThat(dao.findByTransactionIdAndCostTypeCode(10L, "SHIP")).contains(transactionCost);
         assertThat(dao.findByTransactionItemId(20L)).containsExactly(transactionItemCost);
+        assertThat(dao.findTransactionItemCostById(40L)).contains(transactionItemCost);
+        assertThat(dao.findByTransactionItemIdAndCostTypeCode(20L, "PRICE")).contains(transactionItemCost);
 
-        verify(transactionCostMapper, times(2)).deleteTransactionCosts(10L);
-        verify(transactionItemCostMapper, times(2)).deleteTransactionCosts(20L);
+        verify(transactionCostMapper, times(3)).deleteTransactionCosts(10L);
+        verify(transactionItemCostMapper, times(3)).deleteTransactionCosts(20L);
         verify(transactionCostMapper).delete(30L);
+        verify(transactionItemCostMapper).delete(40L);
         verify(transactionCostMapper).migrate(transactionCost);
         verify(transactionCostMapper).update(transactionCost);
+        verify(transactionItemCostMapper).update(transactionItemCost);
     }
 
     @Test

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/ItemInventoryDaoUnitTest.java
@@ -3,6 +3,7 @@ package io.legohunter.data.dao;
 import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventorySearchCriteria;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.mybatis.mapper.ItemInventoryMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,6 +94,19 @@ class ItemInventoryDaoUnitTest {
         assertThat(itemInventoryDao.findMarketplaceListings(inventory)).containsExactly(marketplaceListing);
 
         verify(marketplaceListingDao).findByItemInventoryId(200);
+    }
+
+    @Test
+    void searchDelegatesToMapper() {
+        ItemInventorySearchCriteria criteria = ItemInventorySearchCriteria.builder()
+                .itemNumber("6390-1")
+                .build();
+        ItemInventory inventory = new ItemInventory();
+        when(itemInventoryMapper.search(criteria)).thenReturn(Set.of(inventory));
+        when(itemInventoryMapper.countSearch(criteria)).thenReturn(1);
+
+        assertThat(itemInventoryDao.search(criteria)).containsExactly(inventory);
+        assertThat(itemInventoryDao.countSearch(criteria)).isOne();
     }
 
     @Test

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySearchCriteria.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySearchCriteria.java
@@ -5,6 +5,10 @@ import lombok.Data;
 
 import java.time.LocalDate;
 
+/**
+ * Search filters plus offset pagination controls for owned inventory queries.
+ * Service callers should validate the supported limit range before invoking DAO search.
+ */
 @Data
 @Builder
 public class ItemInventorySearchCriteria {

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySearchCriteria.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/ItemInventorySearchCriteria.java
@@ -1,0 +1,28 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class ItemInventorySearchCriteria {
+    private String itemNumber;
+    private String description;
+    private Integer boxNumber;
+    private String inventoryStateCode;
+    private String saleIntentCode;
+    private Boolean active;
+    private String newOrUsed;
+    private String completeness;
+    private String itemConditionCode;
+    private String boxConditionCode;
+    private String instructionsConditionCode;
+    private LocalDate transactionDateFrom;
+    private LocalDate transactionDateTo;
+    @Builder.Default
+    private Integer limit = 100;
+    @Builder.Default
+    private Integer offset = 0;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
@@ -69,14 +69,7 @@ public interface ItemInventoryMapper {
                 ON est.external_service_type_id = es.external_service_type_id
             """;
 
-    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
-    @ResultMap("itemInventoryResultMap")
-    Set<ItemInventory> findAll();
-
-    @Select("""
-            <script>
-            SELECT ${columns}
-            ${fromClause}
+    String SEARCH_WHERE_CLAUSE = """
             <where>
                 <if test="criteria.itemNumber != null and criteria.itemNumber != ''">
                     AND eci.external_item_key = #{criteria.itemNumber}
@@ -130,6 +123,17 @@ public interface ItemInventoryMapper {
                     )
                 </if>
             </where>
+            """;
+
+    @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
+    @ResultMap("itemInventoryResultMap")
+    Set<ItemInventory> findAll();
+
+    @Select("""
+            <script>
+            SELECT ${columns}
+            ${fromClause}
+            """ + SEARCH_WHERE_CLAUSE + """
             ORDER BY ii.item_inventory_id
             LIMIT #{criteria.limit} OFFSET #{criteria.offset}
             </script>
@@ -149,59 +153,7 @@ public interface ItemInventoryMapper {
             <script>
             SELECT COUNT(DISTINCT ii.item_inventory_id)
             ${fromClause}
-            <where>
-                <if test="criteria.itemNumber != null and criteria.itemNumber != ''">
-                    AND eci.external_item_key = #{criteria.itemNumber}
-                </if>
-                <if test="criteria.description != null and criteria.description != ''">
-                    AND LOWER(ii.description) LIKE LOWER(CONCAT('%', #{criteria.description}, '%'))
-                </if>
-                <if test="criteria.boxNumber != null">
-                    AND ii.box_number = #{criteria.boxNumber}
-                </if>
-                <if test="criteria.inventoryStateCode != null and criteria.inventoryStateCode != ''">
-                    AND ii.inventory_state_code = #{criteria.inventoryStateCode}
-                </if>
-                <if test="criteria.saleIntentCode != null and criteria.saleIntentCode != ''">
-                    AND ii.sale_intent_code = #{criteria.saleIntentCode}
-                </if>
-                <if test="criteria.active != null">
-                    AND ii.active = #{criteria.active}
-                </if>
-                <if test="criteria.newOrUsed != null and criteria.newOrUsed != ''">
-                    AND ii.new_or_used = #{criteria.newOrUsed}
-                </if>
-                <if test="criteria.completeness != null and criteria.completeness != ''">
-                    AND ii.completeness = #{criteria.completeness}
-                </if>
-                <if test="criteria.itemConditionCode != null and criteria.itemConditionCode != ''">
-                    AND ii.item_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.itemConditionCode})
-                </if>
-                <if test="criteria.boxConditionCode != null and criteria.boxConditionCode != ''">
-                    AND ii.box_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.boxConditionCode})
-                </if>
-                <if test="criteria.instructionsConditionCode != null and criteria.instructionsConditionCode != ''">
-                    AND ii.instructions_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.instructionsConditionCode})
-                </if>
-                <if test="criteria.transactionDateFrom != null">
-                    AND EXISTS (
-                        SELECT 1
-                        FROM transaction_item ti
-                        JOIN transactions t ON t.transaction_id = ti.transaction_id
-                        WHERE ti.item_inventory_id = ii.item_inventory_id
-                        AND t.transaction_date &gt;= #{criteria.transactionDateFrom,jdbcType=DATE}
-                    )
-                </if>
-                <if test="criteria.transactionDateTo != null">
-                    AND EXISTS (
-                        SELECT 1
-                        FROM transaction_item ti
-                        JOIN transactions t ON t.transaction_id = ti.transaction_id
-                        WHERE ti.item_inventory_id = ii.item_inventory_id
-                        AND t.transaction_date &lt;= #{criteria.transactionDateTo,jdbcType=DATE}
-                    )
-                </if>
-            </where>
+            """ + SEARCH_WHERE_CLAUSE + """
             </script>
             """)
     int countSearch(

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapper.java
@@ -1,6 +1,7 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.ItemInventory;
+import io.legohunter.data.dto.ItemInventorySearchCriteria;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
@@ -71,6 +72,146 @@ public interface ItemInventoryMapper {
     @Select("SELECT " + ALL_COLUMNS + " " + FROM_CLAUSE)
     @ResultMap("itemInventoryResultMap")
     Set<ItemInventory> findAll();
+
+    @Select("""
+            <script>
+            SELECT ${columns}
+            ${fromClause}
+            <where>
+                <if test="criteria.itemNumber != null and criteria.itemNumber != ''">
+                    AND eci.external_item_key = #{criteria.itemNumber}
+                </if>
+                <if test="criteria.description != null and criteria.description != ''">
+                    AND LOWER(ii.description) LIKE LOWER(CONCAT('%', #{criteria.description}, '%'))
+                </if>
+                <if test="criteria.boxNumber != null">
+                    AND ii.box_number = #{criteria.boxNumber}
+                </if>
+                <if test="criteria.inventoryStateCode != null and criteria.inventoryStateCode != ''">
+                    AND ii.inventory_state_code = #{criteria.inventoryStateCode}
+                </if>
+                <if test="criteria.saleIntentCode != null and criteria.saleIntentCode != ''">
+                    AND ii.sale_intent_code = #{criteria.saleIntentCode}
+                </if>
+                <if test="criteria.active != null">
+                    AND ii.active = #{criteria.active}
+                </if>
+                <if test="criteria.newOrUsed != null and criteria.newOrUsed != ''">
+                    AND ii.new_or_used = #{criteria.newOrUsed}
+                </if>
+                <if test="criteria.completeness != null and criteria.completeness != ''">
+                    AND ii.completeness = #{criteria.completeness}
+                </if>
+                <if test="criteria.itemConditionCode != null and criteria.itemConditionCode != ''">
+                    AND ii.item_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.itemConditionCode})
+                </if>
+                <if test="criteria.boxConditionCode != null and criteria.boxConditionCode != ''">
+                    AND ii.box_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.boxConditionCode})
+                </if>
+                <if test="criteria.instructionsConditionCode != null and criteria.instructionsConditionCode != ''">
+                    AND ii.instructions_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.instructionsConditionCode})
+                </if>
+                <if test="criteria.transactionDateFrom != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM transaction_item ti
+                        JOIN transactions t ON t.transaction_id = ti.transaction_id
+                        WHERE ti.item_inventory_id = ii.item_inventory_id
+                        AND t.transaction_date &gt;= #{criteria.transactionDateFrom,jdbcType=DATE}
+                    )
+                </if>
+                <if test="criteria.transactionDateTo != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM transaction_item ti
+                        JOIN transactions t ON t.transaction_id = ti.transaction_id
+                        WHERE ti.item_inventory_id = ii.item_inventory_id
+                        AND t.transaction_date &lt;= #{criteria.transactionDateTo,jdbcType=DATE}
+                    )
+                </if>
+            </where>
+            ORDER BY ii.item_inventory_id
+            LIMIT #{criteria.limit} OFFSET #{criteria.offset}
+            </script>
+            """)
+    @ResultMap("itemInventoryResultMap")
+    Set<ItemInventory> search(
+            @Param("criteria") ItemInventorySearchCriteria criteria,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<ItemInventory> search(ItemInventorySearchCriteria criteria) {
+        return search(criteria, ALL_COLUMNS, FROM_CLAUSE);
+    }
+
+    @Select("""
+            <script>
+            SELECT COUNT(DISTINCT ii.item_inventory_id)
+            ${fromClause}
+            <where>
+                <if test="criteria.itemNumber != null and criteria.itemNumber != ''">
+                    AND eci.external_item_key = #{criteria.itemNumber}
+                </if>
+                <if test="criteria.description != null and criteria.description != ''">
+                    AND LOWER(ii.description) LIKE LOWER(CONCAT('%', #{criteria.description}, '%'))
+                </if>
+                <if test="criteria.boxNumber != null">
+                    AND ii.box_number = #{criteria.boxNumber}
+                </if>
+                <if test="criteria.inventoryStateCode != null and criteria.inventoryStateCode != ''">
+                    AND ii.inventory_state_code = #{criteria.inventoryStateCode}
+                </if>
+                <if test="criteria.saleIntentCode != null and criteria.saleIntentCode != ''">
+                    AND ii.sale_intent_code = #{criteria.saleIntentCode}
+                </if>
+                <if test="criteria.active != null">
+                    AND ii.active = #{criteria.active}
+                </if>
+                <if test="criteria.newOrUsed != null and criteria.newOrUsed != ''">
+                    AND ii.new_or_used = #{criteria.newOrUsed}
+                </if>
+                <if test="criteria.completeness != null and criteria.completeness != ''">
+                    AND ii.completeness = #{criteria.completeness}
+                </if>
+                <if test="criteria.itemConditionCode != null and criteria.itemConditionCode != ''">
+                    AND ii.item_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.itemConditionCode})
+                </if>
+                <if test="criteria.boxConditionCode != null and criteria.boxConditionCode != ''">
+                    AND ii.box_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.boxConditionCode})
+                </if>
+                <if test="criteria.instructionsConditionCode != null and criteria.instructionsConditionCode != ''">
+                    AND ii.instructions_condition_id IN (SELECT condition_id FROM `condition` WHERE condition_code = #{criteria.instructionsConditionCode})
+                </if>
+                <if test="criteria.transactionDateFrom != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM transaction_item ti
+                        JOIN transactions t ON t.transaction_id = ti.transaction_id
+                        WHERE ti.item_inventory_id = ii.item_inventory_id
+                        AND t.transaction_date &gt;= #{criteria.transactionDateFrom,jdbcType=DATE}
+                    )
+                </if>
+                <if test="criteria.transactionDateTo != null">
+                    AND EXISTS (
+                        SELECT 1
+                        FROM transaction_item ti
+                        JOIN transactions t ON t.transaction_id = ti.transaction_id
+                        WHERE ti.item_inventory_id = ii.item_inventory_id
+                        AND t.transaction_date &lt;= #{criteria.transactionDateTo,jdbcType=DATE}
+                    )
+                </if>
+            </where>
+            </script>
+            """)
+    int countSearch(
+            @Param("criteria") ItemInventorySearchCriteria criteria,
+            @Param("fromClause") String fromClause
+    );
+
+    default int countSearch(ItemInventorySearchCriteria criteria) {
+        return countSearch(criteria, FROM_CLAUSE);
+    }
 
     @Select("""
             SELECT ${columns}

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/ItemInventoryMapperTest.java
@@ -4,6 +4,9 @@ import io.legohunter.data.dto.ExternalCatalogItem;
 import io.legohunter.data.dto.ExternalCategory;
 import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.ItemInventoryExternalCatalogItem;
+import io.legohunter.data.dto.ItemInventorySearchCriteria;
+import io.legohunter.data.dto.TransactionItem;
+import io.legohunter.data.dto.Transactions;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -91,6 +94,67 @@ class ItemInventoryMapperTest extends MapperTestSupport {
         )).isOne();
         assertThat(itemInventoryMapper.delete(itemInventory.getItemInventoryId())).isOne();
         assertThat(itemInventoryMapper.findByUuid("uuid-inventory")).isEmpty();
+    }
+
+    @Test
+    void searchFiltersByInventoryCatalogConditionAndTransactionFields() {
+        seedDefaultCondition();
+        insertTransactionType();
+        ExternalCatalogItem externalCatalogItem = insertExternalCatalogItem("6390-1");
+        externalServiceCapabilityMapper.insert(externalServiceCapability(2, "CATALOG"));
+        ExternalCatalogItem otherCatalogItem = insertExternalCatalogItem("6542-1");
+        ItemInventory matching = itemInventory("uuid-search-match");
+        matching.setDescription("Main Street complete set");
+        matching.setBoxNumber(7);
+        matching.setNewOrUsed("U");
+        matching.setCompleteness("C");
+        matching.setSaleIntentCode("KEEP");
+        matching.setInventoryStateCode("AVAILABLE");
+        itemInventoryMapper.insert(matching);
+        itemInventoryExternalCatalogItemMapper.insert(itemInventoryExternalCatalogItem(
+                matching.getItemInventoryId(),
+                externalCatalogItem.getExternalCatalogItemId()
+        ));
+        Transactions transaction = insertTransaction();
+        TransactionItem transactionItem = TransactionItem.builder()
+                .transactionId(transaction.getTransactionId())
+                .transactionTypeCode("BUY")
+                .itemInventoryId(matching.getItemInventoryId())
+                .notes("Search item")
+                .build();
+        transactionItemMapper.insert(transactionItem);
+
+        ItemInventory other = itemInventory("uuid-search-other");
+        other.setDescription("Launch seaport");
+        other.setBoxNumber(8);
+        itemInventoryMapper.insert(other);
+        itemInventoryExternalCatalogItemMapper.insert(itemInventoryExternalCatalogItem(
+                other.getItemInventoryId(),
+                otherCatalogItem.getExternalCatalogItemId()
+        ));
+
+        ItemInventorySearchCriteria criteria = ItemInventorySearchCriteria.builder()
+                .itemNumber("6390-1")
+                .description("street")
+                .boxNumber(7)
+                .inventoryStateCode("AVAILABLE")
+                .saleIntentCode("KEEP")
+                .active(true)
+                .newOrUsed("U")
+                .completeness("C")
+                .itemConditionCode("G")
+                .boxConditionCode("G")
+                .instructionsConditionCode("G")
+                .transactionDateFrom(java.time.LocalDate.parse("2026-01-01"))
+                .transactionDateTo(java.time.LocalDate.parse("2026-01-01"))
+                .limit(10)
+                .offset(0)
+                .build();
+
+        assertThat(itemInventoryMapper.search(criteria))
+                .extracting(ItemInventory::getUuid)
+                .containsExactly("uuid-search-match");
+        assertThat(itemInventoryMapper.countSearch(criteria)).isOne();
     }
 
     private void assertHydratedCatalogLink(ItemInventoryExternalCatalogItem link) {


### PR DESCRIPTION
## Summary
- Add `ItemInventorySearchCriteria` for Phase 2 owned inventory search.
- Add DAO and MyBatis search/count support for `item_inventory` across catalog, physical, condition, sale intent, inventory state, and transaction date filters.
- Add row-scoped transaction-item cost DAO operations needed by service correction workflows.
- Make explicit empty cost replacement delete existing transaction or transaction-item costs deterministically.
- Document Phase 2 data-layer support in the README.

## Business Context
Phase 2 introduces Inventory Read, Search, and Correction workflows in `lego-data-service`. Business rules still live in the service layer; this PR keeps `lego-data` focused on persistence primitives and search query support.

## Validation
- `mvn test`
- `mvn clean install`

## Review Notes
Review this PR before `lego-data-service` because the service branch imports `ItemInventorySearchCriteria` and calls the new DAO methods.