### PR TITLE
Add transaction item lookup by inventory id

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemDao.java
@@ -33,6 +33,10 @@ public class TransactionItemDao {
         return transactionItemMapper.findByTransactionId(transactionId);
     }
 
+    public List<TransactionItem> findByItemInventoryId(Integer itemInventoryId) {
+        return transactionItemMapper.findByItemInventoryId(itemInventoryId);
+    }
+
     public Optional<TransactionItem> findById(Long transactionItemId) {
         return transactionItemMapper.findById(transactionItemId);
     }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -210,12 +210,14 @@ class DaoDelegationCoverageTest {
         when(transactionItemMapper.findAll()).thenReturn(List.of(transactionItem));
         when(transactionItemMapper.findById(50L)).thenReturn(Optional.of(transactionItem));
         when(transactionItemMapper.findByTransactionId(40L)).thenReturn(List.of(transactionItem));
+        when(transactionItemMapper.findByItemInventoryId(70)).thenReturn(List.of(transactionItem));
         TransactionItemDao transactionItemDao = new TransactionItemDao(transactionItemMapper);
         transactionItemDao.insert(transactionItem);
         transactionItemDao.migrate(transactionItem);
         transactionItemDao.update(transactionItem);
         assertThat(transactionItemDao.findAll()).containsExactly(transactionItem);
         assertThat(transactionItemDao.findByTransactionId(40L)).containsExactly(transactionItem);
+        assertThat(transactionItemDao.findByItemInventoryId(70)).containsExactly(transactionItem);
         assertThat(transactionItemDao.findById(50L)).contains(transactionItem);
         verify(transactionItemMapper).insert(transactionItem);
         verify(transactionItemMapper).migrate(transactionItem);

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemMapper.java
@@ -64,6 +64,19 @@ public interface TransactionItemMapper {
                    item_inventory_id,
                    notes
             from transaction_item
+            where item_inventory_id = #{itemInventoryId}
+            order by transaction_item_id
+            """)
+    @ResultMap("transactionItemResultMap")
+    List<TransactionItem> findByItemInventoryId(Integer itemInventoryId);
+
+    @Select("""
+            select transaction_item_id,
+                   transaction_id,
+                   transaction_type_code,
+                   item_inventory_id,
+                   notes
+            from transaction_item
             where transaction_item_id = #{transactionItemId}
             """)
     @ResultMap("transactionItemResultMap")

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/TransactionItemMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/TransactionItemMapperTest.java
@@ -31,6 +31,9 @@ class TransactionItemMapperTest extends MapperTestSupport {
         assertThat(transactionItemMapper.findByTransactionId(transaction.getTransactionId()))
                 .extracting(TransactionItem::getTransactionItemId)
                 .containsExactly(transactionItem.getTransactionItemId());
+        assertThat(transactionItemMapper.findByItemInventoryId(itemInventory.getItemInventoryId()))
+                .extracting(TransactionItem::getTransactionItemId)
+                .containsExactly(transactionItem.getTransactionItemId());
         assertThat(transactionItemMapper.findAll()).hasSize(1);
 
         TransactionItem migratedItem = TransactionItem.builder()


### PR DESCRIPTION
## Summary
- Add TransactionItemMapper.findByItemInventoryId for reading transaction appearances by owned inventory row.
- Add TransactionItemDao delegation for the new lookup.
- Cover the mapper query and DAO delegation in tests.

## Validation
- mvn test
- mvn clean install

## Review Notes
This PR is required before the lego-data-service search response enrichment can compile in CI, because the service uses the new TransactionItemDao.findByItemInventoryId method.