### PR TITLE
Inventory Intake Phase 4 data selectors

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingDao.java
@@ -36,7 +36,22 @@ public class MarketplaceListingDao {
         return marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCode(
                 listingExternalServiceId,
                 listingStatusCode,
-                limit
+                Math.max(1, limit)
+        );
+    }
+
+    public Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            int limit
+    ) {
+        if (listingStatusCodes == null || listingStatusCodes.isEmpty()) {
+            return Set.of();
+        }
+        return marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                listingStatusCodes,
+                Math.max(1, limit)
         );
     }
 
@@ -45,10 +60,25 @@ public class MarketplaceListingDao {
             String listingStatusCode,
             int limit
     ) {
-        return marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
                 listingExternalServiceId,
-                listingStatusCode,
+                Set.of(listingStatusCode),
                 limit
+        );
+    }
+
+    public Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            int limit
+    ) {
+        if (listingStatusCodes == null || listingStatusCodes.isEmpty()) {
+            return Set.of();
+        }
+        return marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                listingStatusCodes,
+                Math.max(1, limit)
         );
     }
 
@@ -58,16 +88,33 @@ public class MarketplaceListingDao {
             int limit,
             boolean requireCurrentSnapshot
     ) {
+        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                Set.of(listingStatusCode),
+                limit,
+                requireCurrentSnapshot
+        );
+    }
+
+    public Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            int limit,
+            boolean requireCurrentSnapshot
+    ) {
+        if (listingStatusCodes == null || listingStatusCodes.isEmpty()) {
+            return Set.of();
+        }
         if (requireCurrentSnapshot) {
-            return marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
+            return marketplaceListingMapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCodes(
                     listingExternalServiceId,
-                    listingStatusCode,
-                    limit
+                    listingStatusCodes,
+                    Math.max(1, limit)
             );
         }
-        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(
+        return findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
                 listingExternalServiceId,
-                listingStatusCode,
+                listingStatusCodes,
                 limit
         );
     }
@@ -80,13 +127,34 @@ public class MarketplaceListingDao {
             ZonedDateTime asOf,
             int limit
     ) {
-        return marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+        return findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
                 listingExternalServiceId,
-                listingStatusCode,
+                Set.of(listingStatusCode),
                 pendingStatusCode,
                 claimedStatusCode,
                 asOf,
                 limit
+        );
+    }
+
+    public Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            String pendingStatusCode,
+            String claimedStatusCode,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        if (listingStatusCodes == null || listingStatusCodes.isEmpty()) {
+            return Set.of();
+        }
+        return marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                listingStatusCodes,
+                pendingStatusCode,
+                claimedStatusCode,
+                asOf,
+                Math.max(1, limit)
         );
     }
 

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingSyncRequestDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceListingSyncRequestDao.java
@@ -30,8 +30,40 @@ public class MarketplaceListingSyncRequestDao {
         return marketplaceListingSyncRequestMapper.findBySyncRequestStatusCode(syncRequestStatusCode);
     }
 
+    public Set<MarketplaceListingSyncRequest> findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+            Integer marketplaceListingId,
+            String syncRequestTypeCode,
+            Set<String> syncRequestStatusCodes
+    ) {
+        if (syncRequestStatusCodes == null || syncRequestStatusCodes.isEmpty()) {
+            return Set.of();
+        }
+        return marketplaceListingSyncRequestMapper.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                marketplaceListingId,
+                syncRequestTypeCode,
+                syncRequestStatusCodes
+        );
+    }
+
     public Set<MarketplaceListingSyncRequest> findClaimableByStatusCode(String syncRequestStatusCode, ZonedDateTime asOf, int limit) {
         return marketplaceListingSyncRequestMapper.findClaimableByStatusCode(syncRequestStatusCode, asOf, Math.max(1, limit));
+    }
+
+    public Set<MarketplaceListingSyncRequest> findClaimableByStatusCodeAndSyncRequestTypeCodes(
+            String syncRequestStatusCode,
+            Set<String> syncRequestTypeCodes,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        if (syncRequestTypeCodes == null || syncRequestTypeCodes.isEmpty()) {
+            return Set.of();
+        }
+        return marketplaceListingSyncRequestMapper.findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                syncRequestStatusCode,
+                syncRequestTypeCodes,
+                asOf,
+                Math.max(1, limit)
+        );
     }
 
     public long countBySyncRequestStatusCode(String syncRequestStatusCode) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -5,6 +5,7 @@ import io.legohunter.data.dto.Condition;
 import io.legohunter.data.dto.CostType;
 import io.legohunter.data.dto.InventoryIndex;
 import io.legohunter.data.dto.MarketplaceListing;
+import io.legohunter.data.dto.MarketplaceListingSyncRequest;
 import io.legohunter.data.dto.Payment;
 import io.legohunter.data.dto.PaymentPlatform;
 import io.legohunter.data.dto.PricingApplyReadiness;
@@ -22,6 +23,7 @@ import io.legohunter.data.mybatis.mapper.ConditionMapper;
 import io.legohunter.data.mybatis.mapper.CostTypeMapper;
 import io.legohunter.data.mybatis.mapper.InventoryIndexMapper;
 import io.legohunter.data.mybatis.mapper.MarketplaceListingMapper;
+import io.legohunter.data.mybatis.mapper.MarketplaceListingSyncRequestMapper;
 import io.legohunter.data.mybatis.mapper.PartyMapper;
 import io.legohunter.data.mybatis.mapper.PaymentMapper;
 import io.legohunter.data.mybatis.mapper.PaymentPlatformMapper;
@@ -281,17 +283,22 @@ class DaoDelegationCoverageTest {
                 .externalListingId("remote-1")
                 .build();
 
-        when(mapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5))
+        when(mapper.findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCodes(1, Set.of("ACTIVE"), 5))
                 .thenReturn(Set.of(listing));
         assertThat(dao.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5, true))
                 .containsExactly(listing);
+        assertThat(dao.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(1, Set.of(), 5, true))
+                .isEmpty();
 
-        when(mapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
-                1, "ACTIVE", "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
+        when(mapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                1, Set.of("ACTIVE"), "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
         )).thenReturn(Set.of(listing));
         assertThat(dao.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
                 1, "ACTIVE", "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
         )).containsExactly(listing);
+        assertThat(dao.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                1, Set.of(), "PENDING", "CLAIMED", ZonedDateTime.parse("2026-06-24T10:00:00Z"), 5
+        )).isEmpty();
 
         dao.findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 0);
         verify(mapper).findPricingHydrationGapsByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 1);
@@ -310,6 +317,47 @@ class DaoDelegationCoverageTest {
 
         assertThat(dao.upsert(missingIdListing)).isSameAs(hydratedListing);
         verify(mapper).upsert(missingIdListing);
+    }
+
+    @Test
+    void marketplaceListingSyncRequestDaoCoversFilteredLookupBranches() {
+        MarketplaceListingSyncRequestMapper mapper = mock(MarketplaceListingSyncRequestMapper.class);
+        MarketplaceListingSyncRequestDao dao = new MarketplaceListingSyncRequestDao(mapper);
+        MarketplaceListingSyncRequest syncRequest = MarketplaceListingSyncRequest.builder()
+                .marketplaceListingSyncRequestId(100L)
+                .marketplaceListingId(200)
+                .syncRequestTypeCode("LISTING_CREATE")
+                .syncRequestStatusCode("PENDING")
+                .build();
+        ZonedDateTime dueAt = ZonedDateTime.parse("2026-06-24T10:00:00Z");
+
+        when(mapper.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                200,
+                "LISTING_CREATE",
+                Set.of("PENDING", "CLAIMED")
+        )).thenReturn(Set.of(syncRequest));
+        when(mapper.findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                "PENDING",
+                Set.of("PRICE_UPDATE"),
+                dueAt,
+                5
+        )).thenReturn(Set.of(syncRequest));
+
+        assertThat(dao.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                200,
+                "LISTING_CREATE",
+                Set.of("PENDING", "CLAIMED")
+        )).containsExactly(syncRequest);
+        assertThat(dao.findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                "PENDING",
+                Set.of("PRICE_UPDATE"),
+                dueAt,
+                5
+        )).containsExactly(syncRequest);
+        assertThat(dao.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(200, "LISTING_CREATE", Set.of()))
+                .isEmpty();
+        assertThat(dao.findClaimableByStatusCodeAndSyncRequestTypeCodes("PENDING", Set.of(), dueAt, 5))
+                .isEmpty();
     }
 
     @Test

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -181,6 +182,26 @@ class PricingPlaneDaoTest {
         assertThat(marketplaceListingSyncRequestDao.countDueBySyncRequestStatusCode("PENDING", SNAPSHOT_AT.plusHours(2))).isOne();
         assertThat(marketplaceListingSyncRequestDao.findClaimableByStatusCode("PENDING", SNAPSHOT_AT.plusHours(2), 10)).hasSize(1);
 
+        MarketplaceListingSyncRequest listingCreateRequest = marketplaceListingSyncRequest(fixture, decision);
+        listingCreateRequest.setPricingDecisionId(null);
+        listingCreateRequest.setSyncRequestTypeCode("LISTING_CREATE");
+        listingCreateRequest.setSyncReasonCode("MANUAL_LISTING_CREATE");
+        listingCreateRequest.setRemoteInventoryId(null);
+        listingCreateRequest = marketplaceListingSyncRequestDao.insert(listingCreateRequest);
+        assertThat(marketplaceListingSyncRequestDao.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                fixture.listing().getMarketplaceListingId(),
+                "LISTING_CREATE",
+                Set.of("PENDING", "CLAIMED")
+        )).extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
+                .containsExactly(listingCreateRequest.getMarketplaceListingSyncRequestId());
+        assertThat(marketplaceListingSyncRequestDao.findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                "PENDING",
+                Set.of("PRICE_UPDATE"),
+                SNAPSHOT_AT.plusHours(2),
+                10
+        )).extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
+                .containsExactly(syncRequest.getMarketplaceListingSyncRequestId());
+
         assertThat(marketplaceListingSyncRequestDao.claim(
                 syncRequest.getMarketplaceListingSyncRequestId(),
                 "PENDING",
@@ -201,8 +222,9 @@ class PricingPlaneDaoTest {
         syncRequest.setRequestedUnitPrice(new BigDecimal("218.00"));
         syncRequest = marketplaceListingSyncRequestDao.upsert(syncRequest);
         assertThat(syncRequest.getRequestedUnitPrice()).isEqualByComparingTo("218.00");
-        assertThat(marketplaceListingSyncRequestDao.findAll()).hasSize(1);
+        assertThat(marketplaceListingSyncRequestDao.findAll()).hasSize(2);
 
+        marketplaceListingSyncRequestDao.delete(listingCreateRequest.getMarketplaceListingSyncRequestId());
         marketplaceListingSyncRequestDao.delete(syncRequest.getMarketplaceListingSyncRequestId());
         assertThat(marketplaceListingSyncRequestDao.findAll()).isEmpty();
     }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/RemainingDaoCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/RemainingDaoCoverageTest.java
@@ -32,7 +32,7 @@ class RemainingDaoCoverageTest {
                 .externalListingId("remote-1")
                 .build();
 
-        when(mapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(1, "ACTIVE", 5))
+        when(mapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(1, Set.of("ACTIVE"), 5))
                 .thenReturn(Set.of(listing));
         when(mapper.findByListingExternalServiceIdAndExternalListingId(1, "remote-1"))
                 .thenReturn(Optional.of(listing));

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.java
@@ -108,10 +108,51 @@ public interface MarketplaceListingMapper {
     }
 
     @Select("""
+            <script>
             SELECT ${columns}
             ${fromClause}
             WHERE ml.listing_external_service_id = #{listingExternalServiceId}
-              AND ml.listing_status_code = #{listingStatusCode}
+              AND ml.listing_status_code IN
+              <foreach item="listingStatusCode" collection="listingStatusCodes" open="(" separator="," close=")">
+                #{listingStatusCode}
+              </foreach>
+              AND ml.external_catalog_item_id IS NOT NULL
+            ORDER BY ml.marketplace_listing_id
+            LIMIT #{limit}
+            </script>
+            """)
+    @ResultMap("marketplaceListingResultMap")
+    Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCodes(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCodes") Set<String> listingStatusCodes,
+            @Param("limit") int limit,
+            @Param("columns") String columns,
+            @Param("fromClause") String fromClause
+    );
+
+    default Set<MarketplaceListing> findByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            int limit
+    ) {
+        return findByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                listingStatusCodes,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    @Select("""
+            <script>
+            SELECT ${columns}
+            ${fromClause}
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code IN
+              <foreach item="listingStatusCode" collection="listingStatusCodes" open="(" separator="," close=")">
+                #{listingStatusCode}
+              </foreach>
               AND ml.external_catalog_item_id IS NOT NULL
               AND NOT EXISTS (
                   SELECT 1
@@ -124,11 +165,12 @@ public interface MarketplaceListingMapper {
               )
             ORDER BY ml.marketplace_listing_id
             LIMIT #{limit}
+            </script>
             """)
     @ResultMap("marketplaceListingResultMap")
-    Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+    Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
-            @Param("listingStatusCode") String listingStatusCode,
+            @Param("listingStatusCodes") Set<String> listingStatusCodes,
             @Param("pendingStatusCode") String pendingStatusCode,
             @Param("claimedStatusCode") String claimedStatusCode,
             @Param("asOf") ZonedDateTime asOf,
@@ -145,9 +187,29 @@ public interface MarketplaceListingMapper {
             ZonedDateTime asOf,
             int limit
     ) {
-        return findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
+        return findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
                 listingExternalServiceId,
-                listingStatusCode,
+                Set.of(listingStatusCode),
+                pendingStatusCode,
+                claimedStatusCode,
+                asOf,
+                limit,
+                ALL_COLUMNS,
+                FROM_CLAUSE
+        );
+    }
+
+    default Set<MarketplaceListing> findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            String pendingStatusCode,
+            String claimedStatusCode,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        return findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                listingExternalServiceId,
+                listingStatusCodes,
                 pendingStatusCode,
                 claimedStatusCode,
                 asOf,
@@ -163,9 +225,21 @@ public interface MarketplaceListingMapper {
             @Param("limit") int limit
     );
 
+    Set<MarketplaceListing> findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCodes") Set<String> listingStatusCodes,
+            @Param("limit") int limit
+    );
+
     Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode(
             @Param("listingExternalServiceId") Integer listingExternalServiceId,
             @Param("listingStatusCode") String listingStatusCode,
+            @Param("limit") int limit
+    );
+
+    Set<MarketplaceListing> findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCodes(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCodes") Set<String> listingStatusCodes,
             @Param("limit") int limit
     );
 

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceListingSyncRequestMapper.java
@@ -88,6 +88,64 @@ public interface MarketplaceListingSyncRequestMapper {
     }
 
     @Select("""
+            <script>
+            SELECT ${columns}
+            FROM marketplace_listing_sync_request
+            WHERE marketplace_listing_id = #{marketplaceListingId}
+              AND sync_request_type_code = #{syncRequestTypeCode}
+              AND sync_request_status_code IN
+              <foreach item="syncRequestStatusCode" collection="syncRequestStatusCodes" open="(" separator="," close=")">
+                #{syncRequestStatusCode}
+              </foreach>
+            ORDER BY marketplace_listing_sync_request_id
+            </script>
+            """)
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+            @Param("marketplaceListingId") Integer marketplaceListingId,
+            @Param("syncRequestTypeCode") String syncRequestTypeCode,
+            @Param("syncRequestStatusCodes") Set<String> syncRequestStatusCodes,
+            @Param("columns") String columns
+    );
+
+    default Set<MarketplaceListingSyncRequest> findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+            Integer marketplaceListingId,
+            String syncRequestTypeCode,
+            Set<String> syncRequestStatusCodes
+    ) {
+        return findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                marketplaceListingId,
+                syncRequestTypeCode,
+                syncRequestStatusCodes,
+                ALL_COLUMNS
+        );
+    }
+
+    @Select("""
+            <script>
+            SELECT ${columns}
+            FROM marketplace_listing_sync_request
+            WHERE sync_request_status_code = #{syncRequestStatusCode}
+              AND next_attempt_at &lt;= #{asOf}
+              AND attempt_count &lt; max_attempts
+              AND sync_request_type_code IN
+              <foreach item="syncRequestTypeCode" collection="syncRequestTypeCodes" open="(" separator="," close=")">
+                #{syncRequestTypeCode}
+              </foreach>
+            ORDER BY next_attempt_at, marketplace_listing_sync_request_id
+            LIMIT #{limit}
+            </script>
+            """)
+    @ResultMap("marketplaceListingSyncRequestResultMap")
+    Set<MarketplaceListingSyncRequest> findClaimableByStatusCodeAndSyncRequestTypeCodes(
+            @Param("syncRequestStatusCode") String syncRequestStatusCode,
+            @Param("syncRequestTypeCodes") Set<String> syncRequestTypeCodes,
+            @Param("asOf") ZonedDateTime asOf,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
+    @Select("""
             SELECT ${columns}
             FROM marketplace_listing_sync_request
             WHERE sync_request_status_code = #{syncRequestStatusCode}
@@ -106,6 +164,21 @@ public interface MarketplaceListingSyncRequestMapper {
 
     default Set<MarketplaceListingSyncRequest> findClaimableByStatusCode(String syncRequestStatusCode, ZonedDateTime asOf, int limit) {
         return findClaimableByStatusCode(syncRequestStatusCode, asOf, limit, ALL_COLUMNS);
+    }
+
+    default Set<MarketplaceListingSyncRequest> findClaimableByStatusCodeAndSyncRequestTypeCodes(
+            String syncRequestStatusCode,
+            Set<String> syncRequestTypeCodes,
+            ZonedDateTime asOf,
+            int limit
+    ) {
+        return findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                syncRequestStatusCode,
+                syncRequestTypeCodes,
+                asOf,
+                limit,
+                ALL_COLUMNS
+        );
     }
 
     @Select("SELECT COUNT(*) FROM marketplace_listing_sync_request WHERE sync_request_status_code = #{syncRequestStatusCode}")

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/MarketplaceListingMapper.xml
@@ -233,6 +233,41 @@
     LIMIT #{limit}
   </select>
 
+  <select id="findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes"
+          resultMap="marketplaceListingResultMap">
+    SELECT <include refid="marketplaceListingColumns"/>
+    <include refid="marketplaceListingFromClause"/>
+    JOIN item_inventory ii
+      ON ii.item_inventory_id = ml.item_inventory_id
+    WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+      AND ml.listing_status_code IN
+      <foreach item="listingStatusCode" collection="listingStatusCodes" open="(" separator="," close=")">
+        #{listingStatusCode}
+      </foreach>
+      AND ml.external_catalog_item_id IS NOT NULL
+      AND (
+        (
+          <include refid="fixedPriceNotAlreadyDecided"/>
+        )
+        OR (
+          COALESCE(ml.fixed_price, FALSE) &lt;&gt; TRUE
+          AND
+          <include refid="priceableInventoryConditionPresent"/>
+          AND (
+            NOT <include refid="latestPricingDecisionExists"/>
+            OR (
+              (
+                <include refid="latestMatchingPricingSnapshotId"/>
+              ) IS NOT NULL
+              AND <include refid="notAlreadyDecidedForLatestMatchingSnapshot"/>
+            )
+          )
+        )
+      )
+    ORDER BY ml.marketplace_listing_id
+    LIMIT #{limit}
+  </select>
+
   <select id="findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCode"
           resultMap="marketplaceListingResultMap">
     SELECT <include refid="marketplaceListingColumns"/>
@@ -241,6 +276,34 @@
       ON ii.item_inventory_id = ml.item_inventory_id
     WHERE ml.listing_external_service_id = #{listingExternalServiceId}
       AND ml.listing_status_code = #{listingStatusCode}
+      AND ml.external_catalog_item_id IS NOT NULL
+      AND (
+        (
+          <include refid="fixedPriceNotAlreadyDecided"/>
+        )
+        OR (
+          COALESCE(ml.fixed_price, FALSE) &lt;&gt; TRUE
+          AND
+          <include refid="priceableInventoryConditionPresent"/>
+          AND <include refid="matchingPricingSnapshotExists"/>
+          AND <include refid="notAlreadyDecidedForLatestMatchingSnapshot"/>
+        )
+      )
+    ORDER BY ml.marketplace_listing_id
+    LIMIT #{limit}
+  </select>
+
+  <select id="findPricingDecisionCandidatesWithCurrentSnapshotByListingExternalServiceIdAndListingStatusCodes"
+          resultMap="marketplaceListingResultMap">
+    SELECT <include refid="marketplaceListingColumns"/>
+    <include refid="marketplaceListingFromClause"/>
+    JOIN item_inventory ii
+      ON ii.item_inventory_id = ml.item_inventory_id
+    WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+      AND ml.listing_status_code IN
+      <foreach item="listingStatusCode" collection="listingStatusCodes" open="(" separator="," close=")">
+        #{listingStatusCode}
+      </foreach>
       AND ml.external_catalog_item_id IS NOT NULL
       AND (
         (

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceListingMapperTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,12 +84,24 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         fixedPriceListing.setFixedPrice(true);
         marketplaceListingMapper.insert(fixedPriceListing);
 
+        ListingFixture draftFixture = listingFixture("listing-draft-priceable");
+        MarketplaceListing draftListing = marketplaceListing(draftFixture.inventory().getItemInventoryId(), draftFixture.item().getExternalCatalogItemId(), 2, "BL-DRAFT-PRICEABLE");
+        draftListing.setListingStatusCode("DRAFT");
+        draftListing.setFixedPrice(false);
+        marketplaceListingMapper.insert(draftListing);
+
         assertThat(marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactlyInAnyOrder("BL-UNPRICEABLE", "BL-PRICEABLE", "BL-FIXED");
+        assertThat(marketplaceListingMapper.findByListingExternalServiceIdAndListingStatusCodes(2, Set.of("ACTIVE", "DRAFT"), 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-UNPRICEABLE", "BL-PRICEABLE", "BL-FIXED", "BL-DRAFT-PRICEABLE");
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 10))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactlyInAnyOrder("BL-PRICEABLE", "BL-FIXED");
+        assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCodes(2, Set.of("ACTIVE", "DRAFT"), 10))
+                .extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-PRICEABLE", "BL-FIXED", "BL-DRAFT-PRICEABLE");
         assertThat(marketplaceListingMapper.findPricingDecisionCandidatesByListingExternalServiceIdAndListingStatusCode(2, "ACTIVE", 1))
                 .extracting(MarketplaceListing::getExternalListingId)
                 .containsExactly("BL-PRICEABLE");
@@ -288,6 +301,16 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
         dueWorkItem.setWorkStatusCode("SUCCEEDED");
         pricingCrawlWorkItemMapper.insert(dueWorkItem);
 
+        ListingFixture draftFixture = listingFixture("crawl-draft");
+        MarketplaceListing draftListing = marketplaceListing(
+                draftFixture.inventory().getItemInventoryId(),
+                draftFixture.item().getExternalCatalogItemId(),
+                2,
+                "BL-CRAWL-DRAFT"
+        );
+        draftListing.setListingStatusCode("DRAFT");
+        marketplaceListingMapper.insert(draftListing);
+
         assertThat(marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCode(
                 2,
                 "ACTIVE",
@@ -297,6 +320,15 @@ class MarketplaceListingMapperTest extends MapperTestSupport {
                 10
         )).extracting(MarketplaceListing::getExternalListingId)
                 .containsExactlyInAnyOrder("BL-CRAWL-AVAILABLE", "BL-CRAWL-DUE");
+        assertThat(marketplaceListingMapper.findPricingCrawlSchedulingCandidatesByListingExternalServiceIdAndListingStatusCodes(
+                2,
+                Set.of("ACTIVE", "DRAFT"),
+                "PENDING",
+                "CLAIMED",
+                CRAWL_AT,
+                10
+        )).extracting(MarketplaceListing::getExternalListingId)
+                .containsExactlyInAnyOrder("BL-CRAWL-AVAILABLE", "BL-CRAWL-DUE", "BL-CRAWL-DRAFT");
     }
 
     @Test

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -689,6 +689,29 @@ class PricingPlaneMapperTest extends MapperTestSupport {
                 .extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
                 .containsExactly(syncRequest.getMarketplaceListingSyncRequestId());
 
+        MarketplaceListingSyncRequest listingCreateRequest = marketplaceListingSyncRequest(
+                fixture.listing().getMarketplaceListingId(),
+                2,
+                null
+        );
+        listingCreateRequest.setSyncRequestTypeCode("LISTING_CREATE");
+        listingCreateRequest.setSyncReasonCode("MANUAL_LISTING_CREATE");
+        listingCreateRequest.setRemoteInventoryId(null);
+        marketplaceListingSyncRequestMapper.insert(listingCreateRequest);
+        assertThat(marketplaceListingSyncRequestMapper.findByMarketplaceListingIdAndSyncRequestTypeCodeAndSyncRequestStatusCodes(
+                fixture.listing().getMarketplaceListingId(),
+                "LISTING_CREATE",
+                Set.of("PENDING", "CLAIMED")
+        )).extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
+                .containsExactly(listingCreateRequest.getMarketplaceListingSyncRequestId());
+        assertThat(marketplaceListingSyncRequestMapper.findClaimableByStatusCodeAndSyncRequestTypeCodes(
+                "PENDING",
+                Set.of("PRICE_UPDATE"),
+                SNAPSHOT_AT.plusHours(2),
+                10
+        )).extracting(MarketplaceListingSyncRequest::getMarketplaceListingSyncRequestId)
+                .containsExactly(syncRequest.getMarketplaceListingSyncRequestId());
+
         assertThat(marketplaceListingSyncRequestMapper.claim(
                 syncRequest.getMarketplaceListingSyncRequestId(),
                 "PENDING",
@@ -721,7 +744,8 @@ class PricingPlaneMapperTest extends MapperTestSupport {
             assertThat(found.getRequestedUnitPrice()).isEqualByComparingTo("218.00");
         });
 
-        assertThat(marketplaceListingSyncRequestMapper.findAll()).hasSize(1);
+        assertThat(marketplaceListingSyncRequestMapper.findAll()).hasSize(2);
+        assertThat(marketplaceListingSyncRequestMapper.delete(listingCreateRequest.getMarketplaceListingSyncRequestId())).isOne();
         assertThat(marketplaceListingSyncRequestMapper.delete(syncRequest.getMarketplaceListingSyncRequestId())).isOne();
         assertThat(marketplaceListingSyncRequestMapper.findAll()).isEmpty();
     }


### PR DESCRIPTION
## Summary
- Add multi-status marketplace listing selectors so Pricing Plane can include local DRAFT listings alongside ACTIVE listings.
- Add marketplace listing sync request selectors for duplicate active LISTING_CREATE checks and claimable work by supported sync type.
- Preserve existing single-status DAO APIs for compatibility.

## Safety / Scope
- No schema changes.
- No BrickLink or eBay API calls.
- This only adds DAO/mapper query support needed by Phase 4 service and ingress changes.

## Verification
- mvn clean install passed.