### PR TITLE
Add plural listing status pricing review selection

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PricingDecisionDao.java
@@ -73,6 +73,23 @@ public class PricingDecisionDao {
         );
     }
 
+    public Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            String decisionStatusCode,
+            int limit
+    ) {
+        if (listingStatusCodes == null || listingStatusCodes.isEmpty()) {
+            return Set.of();
+        }
+        return pricingDecisionMapper.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                listingExternalServiceId,
+                listingStatusCodes,
+                decisionStatusCode,
+                Math.max(1, limit)
+        );
+    }
+
     public PricingDecision insert(PricingDecision pricingDecision) {
         pricingDecisionMapper.insert(pricingDecision);
         return findByPricingDecisionId(pricingDecision.getPricingDecisionId()).orElseThrow();

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/DaoDelegationCoverageTest.java
@@ -374,6 +374,18 @@ class DaoDelegationCoverageTest {
                 "PROPOSED",
                 25
         );
+        dao.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                1,
+                Set.of("ACTIVE", "DRAFT"),
+                "PROPOSED",
+                25
+        );
+        assertThat(dao.findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                1,
+                Set.of(),
+                "PROPOSED",
+                25
+        )).isEmpty();
 
         verify(mapper).countLatestByDecisionStatusCode("PROPOSED");
         verify(mapper).countLatestUnappliedByDecisionStatusCode("PROPOSED");
@@ -381,6 +393,12 @@ class DaoDelegationCoverageTest {
         verify(mapper).findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
                 1,
                 "ACTIVE",
+                "PROPOSED",
+                25
+        );
+        verify(mapper).findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                1,
+                Set.of("ACTIVE", "DRAFT"),
                 "PROPOSED",
                 25
         );

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingDecisionMapper.java
@@ -239,6 +239,49 @@ public interface PricingDecisionMapper {
             @Param("columns") String columns
     );
 
+    @Select("""
+            <script>
+            SELECT ${columns}
+            FROM marketplace_listing ml
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            JOIN (
+                SELECT pd.*
+                FROM pricing_decision pd
+                JOIN (
+                    SELECT marketplace_listing_id,
+                           MAX(pricing_decision_id) AS pricing_decision_id
+                    FROM pricing_decision
+                    GROUP BY marketplace_listing_id
+                ) latest
+                  ON latest.pricing_decision_id = pd.pricing_decision_id
+            ) pd
+              ON pd.marketplace_listing_id = ml.marketplace_listing_id
+            LEFT JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = pd.pricing_snapshot_id
+            WHERE ml.listing_external_service_id = #{listingExternalServiceId}
+              AND ml.listing_status_code IN
+              <foreach item="listingStatusCode" collection="listingStatusCodes" open="(" separator="," close=")">
+                #{listingStatusCode}
+              </foreach>
+              AND pd.decision_status_code = #{decisionStatusCode}
+              AND pd.applied_at IS NULL
+            ORDER BY pd.created_at DESC,
+                     pd.pricing_decision_id DESC
+            LIMIT #{limit}
+            </script>
+            """)
+    @ResultMap("pricingDecisionReviewResultMap")
+    Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+            @Param("listingExternalServiceId") Integer listingExternalServiceId,
+            @Param("listingStatusCodes") Set<String> listingStatusCodes,
+            @Param("decisionStatusCode") String decisionStatusCode,
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
     default Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
             Integer listingExternalServiceId,
             String listingStatusCode,
@@ -248,6 +291,21 @@ public interface PricingDecisionMapper {
         return findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodeAndDecisionStatusCode(
                 listingExternalServiceId,
                 listingStatusCode,
+                decisionStatusCode,
+                limit,
+                REVIEW_COLUMNS
+        );
+    }
+
+    default Set<PricingDecisionReview> findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+            Integer listingExternalServiceId,
+            Set<String> listingStatusCodes,
+            String decisionStatusCode,
+            int limit
+    ) {
+        return findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                listingExternalServiceId,
+                listingStatusCodes,
                 decisionStatusCode,
                 limit,
                 REVIEW_COLUMNS

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -584,6 +584,16 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         readyDecision.setFinalPrice(new BigDecimal("212.25"));
         pricingDecisionMapper.insert(readyDecision);
 
+        PricingFixture draftFixture = pricingFixture("pricing-apply-draft");
+        draftFixture.listing().setListingStatusCode("DRAFT");
+        marketplaceListingMapper.update(draftFixture.listing());
+        PricingSnapshot draftSnapshot = insertedSnapshot(draftFixture);
+        PricingDecision draftDecision = pricingDecision(draftFixture.listing().getMarketplaceListingId(), draftSnapshot.getPricingSnapshotId());
+        draftDecision.setDecisionStatusCode("PROPOSED");
+        draftDecision.setReasonCode("MEAN_PLUS_STDDEV");
+        draftDecision.setFinalPrice(new BigDecimal("88.25"));
+        pricingDecisionMapper.insert(draftDecision);
+
         PricingFixture appliedFixture = pricingFixture("pricing-apply-applied");
         PricingSnapshot appliedSnapshot = insertedSnapshot(appliedFixture);
         PricingDecision appliedDecision = pricingDecision(appliedFixture.listing().getMarketplaceListingId(), appliedSnapshot.getPricingSnapshotId());
@@ -601,8 +611,8 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         latestFailedDecision.setFinalPrice(null);
         pricingDecisionMapper.insert(latestFailedDecision);
 
-        assertThat(pricingDecisionMapper.countLatestByDecisionStatusCode("PROPOSED")).isEqualTo(2);
-        assertThat(pricingDecisionMapper.countLatestUnappliedByDecisionStatusCode("PROPOSED")).isOne();
+        assertThat(pricingDecisionMapper.countLatestByDecisionStatusCode("PROPOSED")).isEqualTo(3);
+        assertThat(pricingDecisionMapper.countLatestUnappliedByDecisionStatusCode("PROPOSED")).isEqualTo(2);
         assertThat(pricingDecisionMapper.countLatestByDecisionStatusCode("FAILED")).isOne();
 
         Set<PricingDecisionReview> reviews = pricingDecisionMapper
@@ -616,6 +626,18 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         assertThat(reviews)
                 .extracting(PricingDecisionReview::getMarketplaceListingId)
                 .containsExactly(readyFixture.listing().getMarketplaceListingId());
+        assertThat(pricingDecisionMapper
+                .findLatestUnappliedDecisionReviewsByListingExternalServiceIdAndListingStatusCodesAndDecisionStatusCode(
+                        2,
+                        Set.of("ACTIVE", "DRAFT"),
+                        "PROPOSED",
+                        10
+                ))
+                .extracting(PricingDecisionReview::getMarketplaceListingId)
+                .containsExactlyInAnyOrder(
+                        draftFixture.listing().getMarketplaceListingId(),
+                        readyFixture.listing().getMarketplaceListingId()
+                );
         assertThat(reviews)
                 .singleElement()
                 .satisfies(review -> {


### PR DESCRIPTION
## Summary

This is the data-layer support PR for Inventory Intake Phase 5 / BrickLink sync execution.

Changes:
- Adds a plural-status PricingDecision MyBatis selector for latest unapplied decision reviews.
- Adds the matching PricingDecisionDao method with empty-set protection and minimum limit normalization.
- Extends MyBatis integration coverage so Pricing Apply readiness can select both ACTIVE and DRAFT marketplace listings.
- Adds DAO delegation coverage for the new method.

## Why

Phase 5 needs priced local BrickLink DRAFT listings to flow through the Pricing Plane before they become LISTING_CREATE sync requests. The existing selector only handled one listing status at a time.

## Verification

- `mvn clean install` passed.
- Targeted mapper/DAO tests passed before the full build.

## Review Notes

Review this PR first. `lego-data-ingress` depends on this new DAO method.