### PR TITLE
Exclude applied decisions from pricing readiness selection

### DIFF
--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/PricingPlaneDaoTest.java
@@ -134,8 +134,8 @@ class PricingPlaneDaoTest {
         assertThat(pricingApplyReadinessDao.findByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).hasSize(1);
         assertThat(pricingApplyReadinessDao.countByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).isOne();
         assertThat(pricingApplyReadinessDao.countByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
-        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).isOne();
-        assertThat(pricingApplyReadinessDao.countLatestByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isOne();
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("BLOCKED_BELOW_MINIMUM_DELTA_PERCENT")).isZero();
+        assertThat(pricingApplyReadinessDao.countLatestByBlockReasonCode("BELOW_MINIMUM_DELTA_PERCENT")).isZero();
         assertThat(pricingApplyReadinessDao.findLatestByMarketplaceListingId(fixture.listing().getMarketplaceListingId()))
                 .map(PricingApplyReadiness::getPricingApplyReadinessId)
                 .contains(applyReadiness.getPricingApplyReadinessId());
@@ -143,12 +143,8 @@ class PricingPlaneDaoTest {
         applyReadiness.setReadinessStatusCode("READY_TO_APPLY");
         applyReadiness.setBlockReasonCode(null);
         assertThat(pricingApplyReadinessDao.upsert(applyReadiness).getReadinessStatusCode()).isEqualTo("READY_TO_APPLY");
-        assertThat(pricingApplyReadinessDao.findLatestReviews("READY_TO_APPLY", null, 10))
-                .extracting(PricingApplyReadinessReview::getPricingApplyReadinessId)
-                .containsExactly(applyReadiness.getPricingApplyReadinessId());
-        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10))
-                .extracting(PricingApplyReadinessReview::getExternalListingId)
-                .containsExactly("BL-PRICING-1");
+        assertThat(pricingApplyReadinessDao.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10)).isEmpty();
 
         pricingApplyReadinessDao.delete(applyReadiness.getPricingApplyReadinessId());
         pricingDecisionDao.delete(decision.getPricingDecisionId());
@@ -279,6 +275,22 @@ class PricingPlaneDaoTest {
         assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10)).isEmpty();
         assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
         assertThat(pricingApplyReadinessDao.countLatestByBlockReasonCode("STALE_DECISION")).isZero();
+    }
+
+    @Test
+    void pricingApplyReadinessDaoExcludesAlreadyAppliedDecisionFromCurrentReports() {
+        PricingFixture fixture = pricingFixture();
+        PricingCrawlWorkItem workItem = pricingCrawlWorkItemDao.insert(pricingCrawlWorkItem(fixture));
+        PricingSnapshot snapshot = pricingSnapshotDao.insert(pricingSnapshot(workItem, fixture));
+        PricingDecision decision = pricingDecisionDao.insert(pricingDecision(snapshot, fixture));
+        PricingApplyReadiness readiness = pricingApplyReadinessDao.insert(pricingApplyReadiness(decision, snapshot, fixture));
+
+        assertThat(pricingDecisionDao.markApplied(decision.getPricingDecisionId(), SNAPSHOT_AT.plusMinutes(5))).isPresent();
+
+        assertThat(pricingApplyReadinessDao.findByPricingApplyReadinessId(readiness.getPricingApplyReadinessId())).isPresent();
+        assertThat(pricingApplyReadinessDao.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.findLatestReadyToApplyReviews(10)).isEmpty();
+        assertThat(pricingApplyReadinessDao.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
     }
 
     @Test

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
@@ -130,6 +130,7 @@ public interface PricingApplyReadinessMapper {
               ON ps.pricing_snapshot_id = par.pricing_snapshot_id
             WHERE (#{readinessStatusCode} IS NULL OR par.readiness_status_code = #{readinessStatusCode})
               AND (#{blockReasonCode} IS NULL OR par.block_reason_code = #{blockReasonCode})
+              AND pd.applied_at IS NULL
             ORDER BY par.evaluated_at DESC,
                      par.pricing_apply_readiness_id DESC
             LIMIT #{limit}
@@ -167,7 +168,10 @@ public interface PricingApplyReadinessMapper {
             ) latest_decision
               ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
              AND latest_decision.pricing_decision_id = par.pricing_decision_id
+            JOIN pricing_decision pd
+              ON pd.pricing_decision_id = par.pricing_decision_id
             WHERE par.readiness_status_code = #{readinessStatusCode}
+              AND pd.applied_at IS NULL
             """)
     long countLatestByReadinessStatusCode(String readinessStatusCode);
 
@@ -182,7 +186,10 @@ public interface PricingApplyReadinessMapper {
             ) latest_decision
               ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
              AND latest_decision.pricing_decision_id = par.pricing_decision_id
+            JOIN pricing_decision pd
+              ON pd.pricing_decision_id = par.pricing_decision_id
             WHERE par.block_reason_code = #{blockReasonCode}
+              AND pd.applied_at IS NULL
             """)
     long countLatestByBlockReasonCode(String blockReasonCode);
 

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -676,6 +676,24 @@ class PricingPlaneMapperTest extends MapperTestSupport {
     }
 
     @Test
+    void pricingApplyReadinessCurrentReviewsIgnoreAlreadyAppliedDecision() {
+        PricingFixture fixture = pricingFixture("pricing-readiness-applied");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingDecision decision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        decision.setDecisionStatusCode("PROPOSED");
+        pricingDecisionMapper.insert(decision);
+        PricingApplyReadiness readiness = pricingApplyReadiness(decision, snapshot, fixture);
+        pricingApplyReadinessMapper.insert(readiness);
+
+        assertThat(pricingDecisionMapper.markApplied(decision.getPricingDecisionId(), SNAPSHOT_AT.plusMinutes(5))).isOne();
+
+        assertThat(pricingApplyReadinessMapper.findByPricingApplyReadinessId(readiness.getPricingApplyReadinessId())).isPresent();
+        assertThat(pricingApplyReadinessMapper.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessMapper.findLatestReadyToApplyReviews(10)).isEmpty();
+        assertThat(pricingApplyReadinessMapper.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
+    }
+
+    @Test
     void marketplaceListingSyncRequestSupportsCrudClaimAndIdempotentUpsert() {
         PricingFixture fixture = pricingFixture("pricing-sync-request");
         PricingSnapshot snapshot = insertedSnapshot(fixture);


### PR DESCRIPTION
## Summary
- Exclude already-applied pricing decisions from current pricing apply readiness review selection.
- Apply the same unapplied filter to current readiness status and block reason counts.
- Add MyBatis and DAO coverage for latest readiness rows whose pricing decision has already been applied.

## Why
Sandbox Pricing Apply repeatedly selected stale READY_TO_APPLY rows after local apply had already populated pricing_decision.applied_at. These rows should remain historical, but they are no longer actionable apply work.

## Validation
- mvn clean install