### PR TITLE
[lego-data] Add shared BrickLink SET color policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ Phase 2 Inventory Read, Search, and Correction workflows add reusable data-layer
 - Transaction and transaction-item cost replacement helpers delete existing rows even when the replacement list is empty, which keeps explicit empty replacement semantics deterministic.
 
 Business rules remain in `lego-data-service`; DAOs and mappers stay focused on persistence operations.
+
+## BrickLink Inventory Color Policy
+
+The shared `BricklinkInventoryColorPolicy` keeps BrickLink listing-create color semantics consistent across
+services. BrickLink SET catalog items (`S` or `SET`) use color id `0` (`Not Applicable`) when the local color is
+missing, and reject any nonzero color. Color-specific item types require a positive color id. The policy returns an
+effective color id for valid inputs and stable error codes for invalid inputs so callers can fail closed before an
+HTTP mutation.

--- a/lego-data-model/src/main/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicy.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicy.java
@@ -1,0 +1,61 @@
+package io.legohunter.data.bricklink;
+
+import java.util.Locale;
+
+public final class BricklinkInventoryColorPolicy {
+    public static final int NOT_APPLICABLE_COLOR_ID = 0;
+    public static final String MISSING_COLOR_ID = "MISSING_BRICKLINK_COLOR_ID";
+    public static final String INVALID_COLOR_ID = "INVALID_BRICKLINK_COLOR_ID";
+
+    private BricklinkInventoryColorPolicy() {
+    }
+
+    public static Resolution resolve(String itemTypeCode, Integer requestedColorId) {
+        if (isSet(itemTypeCode)) {
+            if (requestedColorId == null || requestedColorId == NOT_APPLICABLE_COLOR_ID) {
+                return Resolution.valid(NOT_APPLICABLE_COLOR_ID);
+            }
+            return Resolution.invalid(
+                    INVALID_COLOR_ID,
+                    "BrickLink SET inventory must use colorId 0 (Not Applicable)"
+            );
+        }
+        if (requestedColorId == null) {
+            return Resolution.invalid(
+                    MISSING_COLOR_ID,
+                    "BrickLink colorId is required for item type " + displayItemType(itemTypeCode)
+            );
+        }
+        if (requestedColorId <= NOT_APPLICABLE_COLOR_ID) {
+            return Resolution.invalid(
+                    INVALID_COLOR_ID,
+                    "BrickLink colorId must be positive for item type " + displayItemType(itemTypeCode)
+            );
+        }
+        return Resolution.valid(requestedColorId);
+    }
+
+    private static boolean isSet(String itemTypeCode) {
+        String normalized = normalize(itemTypeCode);
+        return "S".equals(normalized) || "SET".equals(normalized);
+    }
+
+    private static String displayItemType(String itemTypeCode) {
+        String normalized = normalize(itemTypeCode);
+        return normalized.isEmpty() ? "UNKNOWN" : normalized;
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    public record Resolution(boolean valid, Integer effectiveColorId, String errorCode, String message) {
+        private static Resolution valid(Integer effectiveColorId) {
+            return new Resolution(true, effectiveColorId, null, null);
+        }
+
+        private static Resolution invalid(String errorCode, String message) {
+            return new Resolution(false, null, errorCode, message);
+        }
+    }
+}

--- a/lego-data-model/src/test/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicyTest.java
+++ b/lego-data-model/src/test/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicyTest.java
@@ -1,0 +1,35 @@
+package io.legohunter.data.bricklink;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BricklinkInventoryColorPolicyTest {
+    @Test
+    void resolvesMissingSetColorToNotApplicable() {
+        assertThat(BricklinkInventoryColorPolicy.resolve("SET", null))
+                .isEqualTo(new BricklinkInventoryColorPolicy.Resolution(true, 0, null, null));
+    }
+
+    @Test
+    void acceptsSetAliasWithNotApplicableColor() {
+        assertThat(BricklinkInventoryColorPolicy.resolve("s", 0).valid()).isTrue();
+    }
+
+    @Test
+    void rejectsColoredSet() {
+        BricklinkInventoryColorPolicy.Resolution result = BricklinkInventoryColorPolicy.resolve("SET", 1);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorCode()).isEqualTo(BricklinkInventoryColorPolicy.INVALID_COLOR_ID);
+    }
+
+    @Test
+    void requiresPositiveColorForColorSpecificItemType() {
+        assertThat(BricklinkInventoryColorPolicy.resolve("PART", null).errorCode())
+                .isEqualTo(BricklinkInventoryColorPolicy.MISSING_COLOR_ID);
+        assertThat(BricklinkInventoryColorPolicy.resolve("P", 0).errorCode())
+                .isEqualTo(BricklinkInventoryColorPolicy.INVALID_COLOR_ID);
+        assertThat(BricklinkInventoryColorPolicy.resolve("PART", 5).effectiveColorId()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
This PR covers the shared policy and tests portion of the BrickLink SET color-id fix. The complete cross-repository review roadmap and final PR map follows.

# BrickLink SET Color-ID Bugfix PR Review Roadmap

Status date: 2026-08-16

Feature branch used consistently in every touched repository:

- `feature/bricklink-set-color-id`

Local implementation status: complete and committed. Remote publication status: complete; all five branches are
pushed and all five PRs are open against `develop`.

## Problem being fixed

BrickLink `createInventory` rejects a SET create when the request contains a missing `color_id`. BrickLink's SET
semantics use color id `0` (`Not Applicable`), while color-specific item types require a positive color id. Before
this change, local SET drafts could retain a null color and the ingress mapper copied that null into the REST payload,
causing `PARAMETER_MISSING_OR_INVALID` during listing creation.

## Cross-repository change map

### 1. `lego-data` â€” shared policy and tests

Files:

- `README.md`
- `lego-data-model/src/main/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicy.java`
- `lego-data-model/src/test/java/io/legohunter/data/bricklink/BricklinkInventoryColorPolicyTest.java`

Changes:

- Adds one shared, dependency-light policy used by both the REST service and ingress worker.
- Normalizes item type codes case-insensitively and accepts both `S`/`SET` and the existing color-specific aliases.
- Resolves null or zero SET colors to effective color id `0`.
- Rejects nonzero SET colors with `INVALID_BRICKLINK_COLOR_ID`.
- Rejects missing or nonpositive colors for color-specific item types with stable error codes.
- Covers SET normalization, SET rejection, alias handling, and color-specific validation.

Why review first: both application repositories compile against the new shared model artifact.

### 2. `lego-database-deployer` â€” existing-data repair

Files:

- `src/main/resources/db/changelog/files/1.0.2-bricklink-set-color-not-applicable.yaml`
- `README.md`

Changes:

- Adds an idempotent MySQL Liquibase change set that updates existing null SET draft colors to `0`.
- Joins marketplace listings to their external catalog item so only `S`/`SET` rows are repaired.
- Leaves color-specific nulls unchanged because no safe color can be inferred.
- Documents ordering, verification, and the fact that terminal sync requests are not automatically requeued.
- The master changelog's existing `includeAll` picks up the new file.

Operational requirement: apply this change before retrying old failed SET `LISTING_CREATE` requests.

### 3. `lego-data-migration` â€” operational runbook checkpoint

Files:

- `runbook.md`

Changes:

- Documents when to apply the deployer's incremental SET color repair during an existing sandbox rebuild or
  hydration workflow.
- Adds the null-SET verification query and the required `DRY_RUN`/`APPLY` recovery sequence.
- Calls out that the repair does not infer color-specific values or reset terminal `LISTING_CREATE` requests.

Why review here: this is the operator-facing handoff between database repair and retrying marketplace sync work.

### 4. `lego-data-service` â€” draft and readiness enforcement

Files:

- `src/main/java/com/vattima/lego/inventory/service/dto/BricklinkListingDraftRequest.java`
- `src/main/java/com/vattima/lego/inventory/service/impl/MarketplaceListingServiceImpl.java`
- `src/main/java/com/vattima/lego/inventory/service/validation/MarketplaceListingDraftBusinessValidator.java`
- `src/test/java/com/vattima/lego/inventory/service/impl/MarketplaceListingServiceImplTest.java`
- `src/test/java/com/vattima/lego/inventory/service/validation/MarketplaceListingDraftBusinessValidatorTest.java`
- `README.md`

Changes:

- Allows API clients to submit `colorId=0`.
- Applies the shared policy on create and patch so missing SET colors persist as zero and invalid SET colors fail
  before persistence completes.
- Resolves the selected BrickLink catalog item before applying color semantics.
- Adds readiness blockers for invalid color-specific BrickLink drafts.
- Preserves partial-update behavior by retaining the existing color when a patch omits `colorId`.
- Adds coverage for normalized SET draft output and nonzero SET rejection.

Why review here: this establishes the local source-of-truth state that ingress later consumes.

### 5. `lego-data-ingress` â€” fail-closed worker and REST payload

Files:

- `src/main/java/io/legohunter/ingress/source/bricklink/pricing/BricklinkListingCreateSafetyService.java`
- `src/main/java/io/legohunter/ingress/source/bricklink/pricing/BricklinkListingCreateSafetyResult.java`
- `src/main/java/io/legohunter/ingress/source/bricklink/pricing/BricklinkListingCreateInventoryMapper.java`
- `src/test/java/io/legohunter/ingress/source/bricklink/pricing/BricklinkListingCreateSafetyServiceTest.java`
- `src/test/java/io/legohunter/ingress/source/bricklink/pricing/BricklinkListingCreateInventoryMapperTest.java`
- `runbook.md`

Changes:

- Runs the shared color policy in final listing-create preflight.
- Blocks invalid color-specific requests before any BrickLink mutation call.
- Carries the effective color id through `BricklinkListingCreateSafetyResult`.
- Maps `safety.effectiveColorId()` into the BrickLink REST `Inventory`, ensuring SET creates send `color_id: 0`.
- Tests the effective SET payload and missing-color blocking for a PART.
- Documents the database check, dry-run verification, and operator recovery sequence.
- Preserves existing stockroom, remarks, environment, identity, and remote-safety guardrails.

Why review last: this is the final mutation boundary and depends on the shared policy plus the corrected local data.

## Local commits

| Repository | Commit |
| --- | --- |
| `lego-data` | `7fbef41 Add shared BrickLink SET color policy` |
| `lego-database-deployer` | `7290a05 Repair null BrickLink SET colors` |
| `lego-data-migration` | `4a83148 Document BrickLink SET color repair` |
| `lego-data-service` | `7ce977e Validate BrickLink listing colors` |
| `lego-data-ingress` | `286c643 Normalize BrickLink listing create colors` |

## Open pull requests

| Review order | Repository | Pull request |
| ---: | --- | --- |
| 1 | `lego-data` | [PR #51](https://github.com/LegoHunter/lego-data/pull/51) |
| 2 | `lego-database-deployer` | [PR #7](https://github.com/tvattima/lego-database-deployer/pull/7) |
| 3 | `lego-data-migration` | [PR #6](https://github.com/LegoHunter/lego-data-migration/pull/6) |
| 4 | `lego-data-service` | [PR #12](https://github.com/LegoHunter/lego-data-service/pull/12) |
| 5 | `lego-data-ingress` | [PR #63](https://github.com/LegoHunter/lego-data-ingress/pull/63) |

## Recommended PR review order

1. `lego-data` â€” shared policy and tests.
2. `lego-database-deployer` â€” database repair required for legacy rows.
3. `lego-data-migration` â€” operator checkpoint for applying and verifying the repair.
4. `lego-data-service` â€” draft normalization and readiness behavior.
5. `lego-data-ingress` â€” final preflight and BrickLink payload mapping.

The service and ingress PRs are both consumers of `lego-data`; they can be reviewed in parallel after PR 1, while the
database and migration documentation should be reviewed together before the application behavior. The ordered
sequence above follows the data, deployment, operator, and mutation-boundary dependency path.

## Verification plan

Run from each repository after the shared artifact is available locally:

```powershell
mvn clean install
```

Completed verification:

- `lego-data`: `mvn clean install` passed; shared policy tests passed (4 tests).
- `lego-data-service`: `mvn clean install` passed; 140 tests passed.
- `lego-data-ingress`: `mvn clean install` passed; 289 tests passed.
- `lego-database-deployer`: `mvn clean install` passed; 1 test passed.
- `lego-data-migration`: documentation-only change; `git diff --check` passed.

Targeted tests to inspect during review:

- `BricklinkInventoryColorPolicyTest`
- `MarketplaceListingServiceImplTest`
- `MarketplaceListingDraftBusinessValidatorTest`
- `BricklinkListingCreateSafetyServiceTest`
- `BricklinkListingCreateInventoryMapperTest`

Before enabling a live sandbox/dev apply run:

1. Apply the Liquibase repair.
2. Confirm no null SET colors remain with the runbook query.
3. Explicitly recreate or reset terminal `LISTING_CREATE` requests.
4. Run marketplace sync in `DRY_RUN` and inspect that SET payloads contain `color_id: 0`.
5. Enable `APPLY` only after dry-run output and non-production stockroom safety are confirmed.

The older BrickLink OAuth signature-normalization fix is already committed on `bricklink-rest/develop` and is not part
of these five PRs.

## Push and PR status

The branch push completed successfully in every repository with:

```powershell
git push --set-upstream origin feature/bricklink-set-color-id
```

The `gh` CLI keyring still reports the older token as invalid and rejects it because it lacks `read:org`, but the
already-configured Git credential successfully authenticated both the five pushes and the five PR API requests. No
credential was printed or added to the repository.
