### PR TITLE
Allow initial-price readiness rows

### DIFF
--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PricingApplyReadinessMapper.java
@@ -147,8 +147,41 @@ public interface PricingApplyReadinessMapper {
         return findLatestReviews(readinessStatusCode, blockReasonCode, limit, REVIEW_COLUMNS);
     }
 
+    @Select("""
+            SELECT ${columns}
+            FROM pricing_apply_readiness par
+            JOIN (
+                SELECT marketplace_listing_id,
+                       MAX(pricing_decision_id) AS pricing_decision_id
+                FROM pricing_decision
+                GROUP BY marketplace_listing_id
+            ) latest_decision
+              ON latest_decision.marketplace_listing_id = par.marketplace_listing_id
+             AND latest_decision.pricing_decision_id = par.pricing_decision_id
+            JOIN marketplace_listing ml
+              ON ml.marketplace_listing_id = par.marketplace_listing_id
+            JOIN item_inventory ii
+              ON ii.item_inventory_id = ml.item_inventory_id
+            LEFT JOIN external_catalog_item eci
+              ON eci.external_catalog_item_id = ml.external_catalog_item_id
+            JOIN pricing_decision pd
+              ON pd.pricing_decision_id = par.pricing_decision_id
+            LEFT JOIN pricing_snapshot ps
+              ON ps.pricing_snapshot_id = par.pricing_snapshot_id
+            WHERE par.readiness_status_code IN ('READY_TO_APPLY', 'READY_TO_APPLY_INITIAL_PRICE')
+              AND pd.applied_at IS NULL
+            ORDER BY par.evaluated_at DESC,
+                     par.pricing_apply_readiness_id DESC
+            LIMIT #{limit}
+            """)
+    @ResultMap("pricingApplyReadinessReviewResultMap")
+    Set<PricingApplyReadinessReview> findLatestReadyToApplyReviews(
+            @Param("limit") int limit,
+            @Param("columns") String columns
+    );
+
     default Set<PricingApplyReadinessReview> findLatestReadyToApplyReviews(int limit) {
-        return findLatestReviews("READY_TO_APPLY", null, limit);
+        return findLatestReadyToApplyReviews(limit, REVIEW_COLUMNS);
     }
 
     @Select("SELECT COUNT(*) FROM pricing_apply_readiness WHERE readiness_status_code = #{readinessStatusCode}")

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/PricingPlaneMapperTest.java
@@ -5,6 +5,7 @@ import io.legohunter.data.dto.ItemInventory;
 import io.legohunter.data.dto.MarketplaceListing;
 import io.legohunter.data.dto.MarketplaceListingSyncRequest;
 import io.legohunter.data.dto.PricingApplyReadiness;
+import io.legohunter.data.dto.PricingApplyReadinessReview;
 import io.legohunter.data.dto.PricingCrawlWorkItem;
 import io.legohunter.data.dto.PricingCrawlWorkItemDuplicate;
 import io.legohunter.data.dto.PricingCrawlWorkItemFailure;
@@ -691,6 +692,28 @@ class PricingPlaneMapperTest extends MapperTestSupport {
         assertThat(pricingApplyReadinessMapper.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
         assertThat(pricingApplyReadinessMapper.findLatestReadyToApplyReviews(10)).isEmpty();
         assertThat(pricingApplyReadinessMapper.countLatestByReadinessStatusCode("READY_TO_APPLY")).isZero();
+    }
+
+    @Test
+    void pricingApplyReadinessReadySelectionIncludesInitialPriceRows() {
+        PricingFixture fixture = pricingFixture("pricing-readiness-initial-price");
+        PricingSnapshot snapshot = insertedSnapshot(fixture);
+        PricingDecision decision = pricingDecision(fixture.listing().getMarketplaceListingId(), snapshot.getPricingSnapshotId());
+        decision.setDecisionStatusCode("PROPOSED");
+        pricingDecisionMapper.insert(decision);
+
+        PricingApplyReadiness readiness = pricingApplyReadiness(decision, snapshot, fixture);
+        readiness.setReadinessStatusCode("READY_TO_APPLY_INITIAL_PRICE");
+        readiness.setCurrentPrice(null);
+        readiness.setDeltaAmount(null);
+        readiness.setDeltaPercent(null);
+        readiness.setMinimumRequiredDelta(null);
+        pricingApplyReadinessMapper.insert(readiness);
+
+        assertThat(pricingApplyReadinessMapper.findLatestReviews("READY_TO_APPLY", null, 10)).isEmpty();
+        assertThat(pricingApplyReadinessMapper.findLatestReadyToApplyReviews(10))
+                .extracting(PricingApplyReadinessReview::getPricingApplyReadinessId)
+                .containsExactly(readiness.getPricingApplyReadinessId());
     }
 
     @Test


### PR DESCRIPTION
Summary: include READY_TO_APPLY_INITIAL_PRICE readiness rows in the shared apply-selection mapper while preserving latest-unapplied decision filtering. Add mapper coverage for null-baseline initial-price rows. Tests: mvn clean install.