### PR TITLE
Phase 1 — Add BrickLink order accounting persistence

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PartyExternalIdentityDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PartyExternalIdentityDao.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PartyExternalIdentity;
+import io.legohunter.data.mybatis.mapper.PartyExternalIdentityMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+@Component @RequiredArgsConstructor
+public class PartyExternalIdentityDao {
+    private final PartyExternalIdentityMapper mapper;
+    public Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(Integer platformId, String externalPartyId) { return mapper.findByPlatformAndExternalPartyId(platformId, externalPartyId); }
+    public void insert(PartyExternalIdentity identity) { mapper.insert(identity); }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/PartyExternalIdentityDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/PartyExternalIdentityDao.java
@@ -4,11 +4,16 @@ import io.legohunter.data.dto.PartyExternalIdentity;
 import io.legohunter.data.mybatis.mapper.PartyExternalIdentityMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import java.util.List;
 import java.util.Optional;
 
 @Component @RequiredArgsConstructor
 public class PartyExternalIdentityDao {
     private final PartyExternalIdentityMapper mapper;
+    public List<PartyExternalIdentity> findAll() { return mapper.findAll(); }
+    public Optional<PartyExternalIdentity> findByPartyExternalIdentityId(Long partyExternalIdentityId) { return mapper.findByPartyExternalIdentityId(partyExternalIdentityId); }
     public Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(Integer platformId, String externalPartyId) { return mapper.findByPlatformAndExternalPartyId(platformId, externalPartyId); }
-    public void insert(PartyExternalIdentity identity) { mapper.insert(identity); }
+    public PartyExternalIdentity insert(PartyExternalIdentity identity) { mapper.insert(identity); return identity; }
+    public PartyExternalIdentity upsert(PartyExternalIdentity identity) { mapper.upsert(identity); return identity; }
+    public int delete(Long partyExternalIdentityId) { return mapper.delete(partyExternalIdentityId); }
 }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
@@ -1,0 +1,15 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.Shipment;
+import io.legohunter.data.mybatis.mapper.ShipmentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+@Component @RequiredArgsConstructor
+public class ShipmentDao {
+    private final ShipmentMapper mapper;
+    public void insert(Shipment shipment) { mapper.insert(shipment); }
+    public Optional<Shipment> findByPlatformAndExternalShipmentId(String platformCode, String externalShipmentId) { return mapper.findByPlatformAndExternalShipmentId(platformCode, externalShipmentId); }
+    public void linkTransactionItem(Long transactionItemId, Long shipmentId) { mapper.linkTransactionItem(transactionItemId, shipmentId); }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
@@ -4,12 +4,17 @@ import io.legohunter.data.dto.Shipment;
 import io.legohunter.data.mybatis.mapper.ShipmentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import java.util.List;
 import java.util.Optional;
 
 @Component @RequiredArgsConstructor
 public class ShipmentDao {
     private final ShipmentMapper mapper;
-    public void insert(Shipment shipment) { mapper.insert(shipment); }
+    public List<Shipment> findAll() { return mapper.findAll(); }
+    public Optional<Shipment> findByShipmentId(Long shipmentId) { return mapper.findByShipmentId(shipmentId); }
+    public Shipment insert(Shipment shipment) { mapper.insert(shipment); return shipment; }
+    public Shipment upsert(Shipment shipment) { mapper.upsert(shipment); return shipment; }
+    public int delete(Long shipmentId) { return mapper.delete(shipmentId); }
     public Optional<Shipment> findByPlatformAndExternalShipmentId(String platformCode, String externalShipmentId) { return mapper.findByPlatformAndExternalShipmentId(platformCode, externalShipmentId); }
     public void linkTransactionItem(Long transactionItemId, Long shipmentId) { mapper.linkTransactionItem(transactionItemId, shipmentId); }
 }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemRevenueDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemRevenueDao.java
@@ -4,11 +4,16 @@ import io.legohunter.data.dto.TransactionItemRevenue;
 import io.legohunter.data.mybatis.mapper.TransactionItemRevenueMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import java.util.List;
 import java.util.Optional;
 
 @Component @RequiredArgsConstructor
 public class TransactionItemRevenueDao {
     private final TransactionItemRevenueMapper mapper;
-    public void insert(TransactionItemRevenue revenue) { mapper.insert(revenue); }
+    public List<TransactionItemRevenue> findAll() { return mapper.findAll(); }
+    public Optional<TransactionItemRevenue> findByTransactionItemRevenueId(Long transactionItemRevenueId) { return mapper.findByTransactionItemRevenueId(transactionItemRevenueId); }
+    public TransactionItemRevenue insert(TransactionItemRevenue revenue) { mapper.insert(revenue); return revenue; }
+    public TransactionItemRevenue upsert(TransactionItemRevenue revenue) { mapper.upsert(revenue); return revenue; }
+    public int delete(Long transactionItemRevenueId) { return mapper.delete(transactionItemRevenueId); }
     public Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId) { return mapper.findByTransactionItemId(transactionItemId); }
 }

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemRevenueDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionItemRevenueDao.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.TransactionItemRevenue;
+import io.legohunter.data.mybatis.mapper.TransactionItemRevenueMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.Optional;
+
+@Component @RequiredArgsConstructor
+public class TransactionItemRevenueDao {
+    private final TransactionItemRevenueMapper mapper;
+    public void insert(TransactionItemRevenue revenue) { mapper.insert(revenue); }
+    public Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId) { return mapper.findByTransactionItemId(transactionItemId); }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionPartySnapshotDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionPartySnapshotDao.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.TransactionPartySnapshot;
+import io.legohunter.data.mybatis.mapper.TransactionPartySnapshotMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component @RequiredArgsConstructor
+public class TransactionPartySnapshotDao {
+    private final TransactionPartySnapshotMapper mapper;
+    public void insert(TransactionPartySnapshot snapshot) { mapper.insert(snapshot); }
+    public List<TransactionPartySnapshot> findByTransactionId(Long transactionId) { return mapper.findByTransactionId(transactionId); }
+}

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionPartySnapshotDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionPartySnapshotDao.java
@@ -5,10 +5,15 @@ import io.legohunter.data.mybatis.mapper.TransactionPartySnapshotMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import java.util.List;
+import java.util.Optional;
 
 @Component @RequiredArgsConstructor
 public class TransactionPartySnapshotDao {
     private final TransactionPartySnapshotMapper mapper;
-    public void insert(TransactionPartySnapshot snapshot) { mapper.insert(snapshot); }
+    public List<TransactionPartySnapshot> findAll() { return mapper.findAll(); }
+    public Optional<TransactionPartySnapshot> findByTransactionPartySnapshotId(Long transactionPartySnapshotId) { return mapper.findByTransactionPartySnapshotId(transactionPartySnapshotId); }
+    public TransactionPartySnapshot insert(TransactionPartySnapshot snapshot) { mapper.insert(snapshot); return snapshot; }
+    public TransactionPartySnapshot upsert(TransactionPartySnapshot snapshot) { mapper.upsert(snapshot); return snapshot; }
+    public int delete(Long transactionPartySnapshotId) { return mapper.delete(transactionPartySnapshotId); }
     public List<TransactionPartySnapshot> findByTransactionId(Long transactionId) { return mapper.findByTransactionId(transactionId); }
 }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/Phase1AccountingDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/Phase1AccountingDaoUnitTest.java
@@ -1,0 +1,85 @@
+package io.legohunter.data.dao;
+
+import io.legohunter.data.dto.PartyExternalIdentity;
+import io.legohunter.data.dto.Shipment;
+import io.legohunter.data.dto.TransactionItemRevenue;
+import io.legohunter.data.dto.TransactionPartySnapshot;
+import io.legohunter.data.mybatis.mapper.PartyExternalIdentityMapper;
+import io.legohunter.data.mybatis.mapper.ShipmentMapper;
+import io.legohunter.data.mybatis.mapper.TransactionItemRevenueMapper;
+import io.legohunter.data.mybatis.mapper.TransactionPartySnapshotMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Phase1AccountingDaoUnitTest {
+    @Test
+    void partyExternalIdentityDaoDelegatesCrud() {
+        PartyExternalIdentityMapper mapper = mock(PartyExternalIdentityMapper.class);
+        PartyExternalIdentityDao dao = new PartyExternalIdentityDao(mapper);
+        PartyExternalIdentity value = PartyExternalIdentity.builder().partyExternalIdentityId(1L).build();
+        when(mapper.findAll()).thenReturn(List.of(value));
+        when(mapper.findByPartyExternalIdentityId(1L)).thenReturn(Optional.of(value));
+
+        assertThat(dao.insert(value)).isSameAs(value);
+        assertThat(dao.upsert(value)).isSameAs(value);
+        assertThat(dao.findAll()).containsExactly(value);
+        assertThat(dao.findByPartyExternalIdentityId(1L)).contains(value);
+        dao.delete(1L);
+        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).delete(1L);
+    }
+
+    @Test
+    void transactionPartySnapshotDaoDelegatesCrud() {
+        TransactionPartySnapshotMapper mapper = mock(TransactionPartySnapshotMapper.class);
+        TransactionPartySnapshotDao dao = new TransactionPartySnapshotDao(mapper);
+        TransactionPartySnapshot value = TransactionPartySnapshot.builder().transactionPartySnapshotId(1L).build();
+        when(mapper.findAll()).thenReturn(List.of(value));
+        when(mapper.findByTransactionPartySnapshotId(1L)).thenReturn(Optional.of(value));
+
+        assertThat(dao.insert(value)).isSameAs(value);
+        assertThat(dao.upsert(value)).isSameAs(value);
+        assertThat(dao.findAll()).containsExactly(value);
+        assertThat(dao.findByTransactionPartySnapshotId(1L)).contains(value);
+        dao.delete(1L);
+        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).delete(1L);
+    }
+
+    @Test
+    void transactionItemRevenueDaoDelegatesCrud() {
+        TransactionItemRevenueMapper mapper = mock(TransactionItemRevenueMapper.class);
+        TransactionItemRevenueDao dao = new TransactionItemRevenueDao(mapper);
+        TransactionItemRevenue value = TransactionItemRevenue.builder().transactionItemRevenueId(1L).build();
+        when(mapper.findAll()).thenReturn(List.of(value));
+        when(mapper.findByTransactionItemRevenueId(1L)).thenReturn(Optional.of(value));
+
+        assertThat(dao.insert(value)).isSameAs(value);
+        assertThat(dao.upsert(value)).isSameAs(value);
+        assertThat(dao.findAll()).containsExactly(value);
+        assertThat(dao.findByTransactionItemRevenueId(1L)).contains(value);
+        dao.delete(1L);
+        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).delete(1L);
+    }
+
+    @Test
+    void shipmentDaoDelegatesCrud() {
+        ShipmentMapper mapper = mock(ShipmentMapper.class);
+        ShipmentDao dao = new ShipmentDao(mapper);
+        Shipment value = Shipment.builder().shipmentId(1L).build();
+        when(mapper.findAll()).thenReturn(List.of(value));
+        when(mapper.findByShipmentId(1L)).thenReturn(Optional.of(value));
+
+        assertThat(dao.insert(value)).isSameAs(value);
+        assertThat(dao.upsert(value)).isSameAs(value);
+        assertThat(dao.findAll()).containsExactly(value);
+        assertThat(dao.findByShipmentId(1L)).contains(value);
+        dao.delete(1L);
+        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).delete(1L);
+    }
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/PartyExternalIdentity.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/PartyExternalIdentity.java
@@ -1,0 +1,16 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+public class PartyExternalIdentity {
+    private Long partyExternalIdentityId;
+    private Long partyId;
+    private Integer transactionPlatformId;
+    private String externalPartyId;
+    private ZonedDateTime createdAt;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/Shipment.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/Shipment.java
@@ -1,0 +1,22 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class Shipment {
+    private Long shipmentId;
+    private String externalShipmentId;
+    private LocalDate shipmentDate;
+    private String shipmentTrackingNumber;
+    private String carrierCode;
+    private String fulfillmentPlatformCode;
+    private String serviceCode;
+    private BigDecimal shipmentCost;
+    private BigDecimal insuranceCost;
+    private String currencyCode;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/Shipment.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/Shipment.java
@@ -16,7 +16,4 @@ public class Shipment {
     private String carrierCode;
     private String fulfillmentPlatformCode;
     private String serviceCode;
-    private BigDecimal shipmentCost;
-    private BigDecimal insuranceCost;
-    private String currencyCode;
 }

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/TransactionItemRevenue.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/TransactionItemRevenue.java
@@ -1,0 +1,17 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class TransactionItemRevenue {
+    private Long transactionItemRevenueId;
+    private Long transactionItemId;
+    private String currencyCode;
+    private BigDecimal unitAmount;
+    private Integer quantity;
+    private BigDecimal totalAmount;
+}

--- a/lego-data-model/src/main/java/io/legohunter/data/dto/TransactionPartySnapshot.java
+++ b/lego-data-model/src/main/java/io/legohunter/data/dto/TransactionPartySnapshot.java
@@ -1,0 +1,26 @@
+package io.legohunter.data.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Builder
+public class TransactionPartySnapshot {
+    private Long transactionPartySnapshotId;
+    private Long transactionId;
+    private Long partyId;
+    private String partyRoleCode;
+    private String displayName;
+    private String address1;
+    private String address2;
+    private String city;
+    private String state;
+    private String postalCode;
+    private String countryCode;
+    private String country;
+    private String phone;
+    private String email;
+    private ZonedDateTime capturedAt;
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
@@ -1,0 +1,13 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PartyExternalIdentity;
+import org.apache.ibatis.annotations.*;
+import java.util.Optional;
+
+public interface PartyExternalIdentityMapper {
+    String COLUMNS = "party_external_identity_id, party_id, transaction_platform_id, external_party_id, created_at";
+    @Select("SELECT " + COLUMNS + " FROM party_external_identity WHERE transaction_platform_id=#{transactionPlatformId} AND external_party_id=#{externalPartyId}")
+    @ResultMap("partyExternalIdentityResultMap") Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(@Param("transactionPlatformId") Integer transactionPlatformId, @Param("externalPartyId") String externalPartyId);
+    @Insert("INSERT INTO party_external_identity (party_id,transaction_platform_id,external_party_id) VALUES (#{partyId},#{transactionPlatformId},#{externalPartyId})")
+    @Options(useGeneratedKeys=true,keyProperty="partyExternalIdentityId") void insert(PartyExternalIdentity identity);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
@@ -2,12 +2,20 @@ package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.PartyExternalIdentity;
 import org.apache.ibatis.annotations.*;
+import java.util.List;
 import java.util.Optional;
 
 public interface PartyExternalIdentityMapper {
     String COLUMNS = "party_external_identity_id, party_id, transaction_platform_id, external_party_id, created_at";
+    @Select("SELECT " + COLUMNS + " FROM party_external_identity")
+    @ResultMap("partyExternalIdentityResultMap") List<PartyExternalIdentity> findAll();
+    @Select("SELECT " + COLUMNS + " FROM party_external_identity WHERE party_external_identity_id=#{partyExternalIdentityId}")
+    @ResultMap("partyExternalIdentityResultMap") Optional<PartyExternalIdentity> findByPartyExternalIdentityId(Long partyExternalIdentityId);
     @Select("SELECT " + COLUMNS + " FROM party_external_identity WHERE transaction_platform_id=#{transactionPlatformId} AND external_party_id=#{externalPartyId}")
     @ResultMap("partyExternalIdentityResultMap") Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(@Param("transactionPlatformId") Integer transactionPlatformId, @Param("externalPartyId") String externalPartyId);
     @Insert("INSERT INTO party_external_identity (party_id,transaction_platform_id,external_party_id) VALUES (#{partyId},#{transactionPlatformId},#{externalPartyId})")
     @Options(useGeneratedKeys=true,keyProperty="partyExternalIdentityId") void insert(PartyExternalIdentity identity);
+    @Insert("INSERT INTO party_external_identity (party_id,transaction_platform_id,external_party_id) VALUES (#{partyId},#{transactionPlatformId},#{externalPartyId}) ON DUPLICATE KEY UPDATE party_id=VALUES(party_id)")
+    @Options(useGeneratedKeys=true,keyProperty="partyExternalIdentityId") void upsert(PartyExternalIdentity identity);
+    @Delete("DELETE FROM party_external_identity WHERE party_external_identity_id=#{partyExternalIdentityId}") int delete(Long partyExternalIdentityId);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.java
@@ -1,21 +1,55 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.PartyExternalIdentity;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface PartyExternalIdentityMapper {
-    String COLUMNS = "party_external_identity_id, party_id, transaction_platform_id, external_party_id, created_at";
+    String COLUMNS = """
+            party_external_identity_id,
+            party_id,
+            transaction_platform_id,
+            external_party_id,
+            created_at
+            """;
+
     @Select("SELECT " + COLUMNS + " FROM party_external_identity")
-    @ResultMap("partyExternalIdentityResultMap") List<PartyExternalIdentity> findAll();
+    @ResultMap("partyExternalIdentityResultMap")
+    List<PartyExternalIdentity> findAll();
+
     @Select("SELECT " + COLUMNS + " FROM party_external_identity WHERE party_external_identity_id=#{partyExternalIdentityId}")
-    @ResultMap("partyExternalIdentityResultMap") Optional<PartyExternalIdentity> findByPartyExternalIdentityId(Long partyExternalIdentityId);
+    @ResultMap("partyExternalIdentityResultMap")
+    Optional<PartyExternalIdentity> findByPartyExternalIdentityId(Long partyExternalIdentityId);
+
     @Select("SELECT " + COLUMNS + " FROM party_external_identity WHERE transaction_platform_id=#{transactionPlatformId} AND external_party_id=#{externalPartyId}")
-    @ResultMap("partyExternalIdentityResultMap") Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(@Param("transactionPlatformId") Integer transactionPlatformId, @Param("externalPartyId") String externalPartyId);
-    @Insert("INSERT INTO party_external_identity (party_id,transaction_platform_id,external_party_id) VALUES (#{partyId},#{transactionPlatformId},#{externalPartyId})")
-    @Options(useGeneratedKeys=true,keyProperty="partyExternalIdentityId") void insert(PartyExternalIdentity identity);
-    @Insert("INSERT INTO party_external_identity (party_id,transaction_platform_id,external_party_id) VALUES (#{partyId},#{transactionPlatformId},#{externalPartyId}) ON DUPLICATE KEY UPDATE party_id=VALUES(party_id)")
-    @Options(useGeneratedKeys=true,keyProperty="partyExternalIdentityId") void upsert(PartyExternalIdentity identity);
-    @Delete("DELETE FROM party_external_identity WHERE party_external_identity_id=#{partyExternalIdentityId}") int delete(Long partyExternalIdentityId);
+    @ResultMap("partyExternalIdentityResultMap")
+    Optional<PartyExternalIdentity> findByPlatformAndExternalPartyId(
+            @Param("transactionPlatformId") Integer transactionPlatformId,
+            @Param("externalPartyId") String externalPartyId
+    );
+
+    @Insert("""
+            INSERT INTO party_external_identity (party_id, transaction_platform_id, external_party_id)
+            VALUES (#{partyId}, #{transactionPlatformId}, #{externalPartyId})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "partyExternalIdentityId")
+    void insert(PartyExternalIdentity identity);
+
+    @Insert("""
+            INSERT INTO party_external_identity (party_id, transaction_platform_id, external_party_id)
+            VALUES (#{partyId}, #{transactionPlatformId}, #{externalPartyId})
+            ON DUPLICATE KEY UPDATE party_id = VALUES(party_id)
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "partyExternalIdentityId")
+    void upsert(PartyExternalIdentity identity);
+
+    @Delete("DELETE FROM party_external_identity WHERE party_external_identity_id = #{partyExternalIdentityId}")
+    int delete(Long partyExternalIdentityId);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
@@ -1,22 +1,79 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.Shipment;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface ShipmentMapper {
-    String COLUMNS = "shipment_id,external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code";
+    String COLUMNS = """
+            shipment_id,
+            external_shipment_id,
+            shipment_date,
+            shipment_tracking_number,
+            carrier_code,
+            fulfillment_platform_code,
+            service_code
+            """;
+
     @Select("SELECT " + COLUMNS + " FROM shipment")
-    @ResultMap("shipmentResultMap") List<Shipment> findAll();
+    @ResultMap("shipmentResultMap")
+    List<Shipment> findAll();
+
     @Select("SELECT " + COLUMNS + " FROM shipment WHERE shipment_id=#{shipmentId}")
-    @ResultMap("shipmentResultMap") Optional<Shipment> findByShipmentId(Long shipmentId);
-    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode})")
-    @Options(useGeneratedKeys=true,keyProperty="shipmentId") void insert(Shipment shipment);
-    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode}) ON DUPLICATE KEY UPDATE shipment_date=VALUES(shipment_date),shipment_tracking_number=VALUES(shipment_tracking_number),carrier_code=VALUES(carrier_code),service_code=VALUES(service_code)")
-    @Options(useGeneratedKeys=true,keyProperty="shipmentId") void upsert(Shipment shipment);
-    @Delete("DELETE FROM shipment WHERE shipment_id=#{shipmentId}") int delete(Long shipmentId);
+    @ResultMap("shipmentResultMap")
+    Optional<Shipment> findByShipmentId(Long shipmentId);
+
+    @Insert("""
+            INSERT INTO shipment (
+                external_shipment_id, shipment_date, shipment_tracking_number, carrier_code,
+                fulfillment_platform_code, service_code
+            ) VALUES (
+                #{externalShipmentId}, #{shipmentDate,jdbcType=DATE}, #{shipmentTrackingNumber}, #{carrierCode},
+                #{fulfillmentPlatformCode}, #{serviceCode}
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "shipmentId")
+    void insert(Shipment shipment);
+
+    @Insert("""
+            INSERT INTO shipment (
+                external_shipment_id, shipment_date, shipment_tracking_number, carrier_code,
+                fulfillment_platform_code, service_code
+            ) VALUES (
+                #{externalShipmentId}, #{shipmentDate,jdbcType=DATE}, #{shipmentTrackingNumber}, #{carrierCode},
+                #{fulfillmentPlatformCode}, #{serviceCode}
+            ) ON DUPLICATE KEY UPDATE
+                shipment_date = VALUES(shipment_date),
+                shipment_tracking_number = VALUES(shipment_tracking_number),
+                carrier_code = VALUES(carrier_code),
+                service_code = VALUES(service_code)
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "shipmentId")
+    void upsert(Shipment shipment);
+
+    @Delete("DELETE FROM shipment WHERE shipment_id = #{shipmentId}")
+    int delete(Long shipmentId);
+
     @Select("SELECT " + COLUMNS + " FROM shipment WHERE fulfillment_platform_code=#{fulfillmentPlatformCode} AND external_shipment_id=#{externalShipmentId}")
-    @ResultMap("shipmentResultMap") Optional<Shipment> findByPlatformAndExternalShipmentId(@Param("fulfillmentPlatformCode") String fulfillmentPlatformCode, @Param("externalShipmentId") String externalShipmentId);
-    @Insert("INSERT INTO transaction_item_shipment (item_transaction_id,shipment_id) VALUES (#{transactionItemId},#{shipmentId})") void linkTransactionItem(@Param("transactionItemId") Long transactionItemId, @Param("shipmentId") Long shipmentId);
+    @ResultMap("shipmentResultMap")
+    Optional<Shipment> findByPlatformAndExternalShipmentId(
+            @Param("fulfillmentPlatformCode") String fulfillmentPlatformCode,
+            @Param("externalShipmentId") String externalShipmentId
+    );
+
+    @Insert("""
+            INSERT INTO transaction_item_shipment (item_transaction_id, shipment_id)
+            VALUES (#{transactionItemId}, #{shipmentId})
+            """)
+    void linkTransactionItem(
+            @Param("transactionItemId") Long transactionItemId,
+            @Param("shipmentId") Long shipmentId
+    );
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
@@ -1,0 +1,14 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.Shipment;
+import org.apache.ibatis.annotations.*;
+import java.util.Optional;
+
+public interface ShipmentMapper {
+    String COLUMNS = "shipment_id,external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code,shipment_cost,insurance_cost,currency_code";
+    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code,shipment_cost,insurance_cost,currency_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode},#{shipmentCost},#{insuranceCost},#{currencyCode})")
+    @Options(useGeneratedKeys=true,keyProperty="shipmentId") void insert(Shipment shipment);
+    @Select("SELECT " + COLUMNS + " FROM shipment WHERE fulfillment_platform_code=#{fulfillmentPlatformCode} AND external_shipment_id=#{externalShipmentId}")
+    @ResultMap("shipmentResultMap") Optional<Shipment> findByPlatformAndExternalShipmentId(@Param("fulfillmentPlatformCode") String fulfillmentPlatformCode, @Param("externalShipmentId") String externalShipmentId);
+    @Insert("INSERT INTO transaction_item_shipment (item_transaction_id,shipment_id) VALUES (#{transactionItemId},#{shipmentId})") void linkTransactionItem(@Param("transactionItemId") Long transactionItemId, @Param("shipmentId") Long shipmentId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
@@ -5,8 +5,8 @@ import org.apache.ibatis.annotations.*;
 import java.util.Optional;
 
 public interface ShipmentMapper {
-    String COLUMNS = "shipment_id,external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code,shipment_cost,insurance_cost,currency_code";
-    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code,shipment_cost,insurance_cost,currency_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode},#{shipmentCost},#{insuranceCost},#{currencyCode})")
+    String COLUMNS = "shipment_id,external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code";
+    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode})")
     @Options(useGeneratedKeys=true,keyProperty="shipmentId") void insert(Shipment shipment);
     @Select("SELECT " + COLUMNS + " FROM shipment WHERE fulfillment_platform_code=#{fulfillmentPlatformCode} AND external_shipment_id=#{externalShipmentId}")
     @ResultMap("shipmentResultMap") Optional<Shipment> findByPlatformAndExternalShipmentId(@Param("fulfillmentPlatformCode") String fulfillmentPlatformCode, @Param("externalShipmentId") String externalShipmentId);

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
@@ -2,12 +2,20 @@ package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.Shipment;
 import org.apache.ibatis.annotations.*;
+import java.util.List;
 import java.util.Optional;
 
 public interface ShipmentMapper {
     String COLUMNS = "shipment_id,external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code";
+    @Select("SELECT " + COLUMNS + " FROM shipment")
+    @ResultMap("shipmentResultMap") List<Shipment> findAll();
+    @Select("SELECT " + COLUMNS + " FROM shipment WHERE shipment_id=#{shipmentId}")
+    @ResultMap("shipmentResultMap") Optional<Shipment> findByShipmentId(Long shipmentId);
     @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode})")
     @Options(useGeneratedKeys=true,keyProperty="shipmentId") void insert(Shipment shipment);
+    @Insert("INSERT INTO shipment (external_shipment_id,shipment_date,shipment_tracking_number,carrier_code,fulfillment_platform_code,service_code) VALUES (#{externalShipmentId},#{shipmentDate,jdbcType=DATE},#{shipmentTrackingNumber},#{carrierCode},#{fulfillmentPlatformCode},#{serviceCode}) ON DUPLICATE KEY UPDATE shipment_date=VALUES(shipment_date),shipment_tracking_number=VALUES(shipment_tracking_number),carrier_code=VALUES(carrier_code),service_code=VALUES(service_code)")
+    @Options(useGeneratedKeys=true,keyProperty="shipmentId") void upsert(Shipment shipment);
+    @Delete("DELETE FROM shipment WHERE shipment_id=#{shipmentId}") int delete(Long shipmentId);
     @Select("SELECT " + COLUMNS + " FROM shipment WHERE fulfillment_platform_code=#{fulfillmentPlatformCode} AND external_shipment_id=#{externalShipmentId}")
     @ResultMap("shipmentResultMap") Optional<Shipment> findByPlatformAndExternalShipmentId(@Param("fulfillmentPlatformCode") String fulfillmentPlatformCode, @Param("externalShipmentId") String externalShipmentId);
     @Insert("INSERT INTO transaction_item_shipment (item_transaction_id,shipment_id) VALUES (#{transactionItemId},#{shipmentId})") void linkTransactionItem(@Param("transactionItemId") Long transactionItemId, @Param("shipmentId") Long shipmentId);

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
@@ -1,0 +1,13 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.TransactionItemRevenue;
+import org.apache.ibatis.annotations.*;
+import java.util.Optional;
+
+public interface TransactionItemRevenueMapper {
+    String COLUMNS = "transaction_item_revenue_id,transaction_item_id,currency_code,unit_amount,quantity,total_amount";
+    @Insert("INSERT INTO transaction_item_revenue (transaction_item_id,currency_code,unit_amount,quantity,total_amount) VALUES (#{transactionItemId},#{currencyCode},#{unitAmount},#{quantity},#{totalAmount})")
+    @Options(useGeneratedKeys=true,keyProperty="transactionItemRevenueId") void insert(TransactionItemRevenue revenue);
+    @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue WHERE transaction_item_id=#{transactionItemId}")
+    @ResultMap("transactionItemRevenueResultMap") Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
@@ -1,21 +1,56 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.TransactionItemRevenue;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface TransactionItemRevenueMapper {
-    String COLUMNS = "transaction_item_revenue_id,transaction_item_id,currency_code,unit_amount,quantity,total_amount";
+    String COLUMNS = """
+            transaction_item_revenue_id,
+            transaction_item_id,
+            currency_code,
+            unit_amount,
+            quantity,
+            total_amount
+            """;
+
     @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue")
-    @ResultMap("transactionItemRevenueResultMap") List<TransactionItemRevenue> findAll();
+    @ResultMap("transactionItemRevenueResultMap")
+    List<TransactionItemRevenue> findAll();
+
     @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue WHERE transaction_item_revenue_id=#{transactionItemRevenueId}")
-    @ResultMap("transactionItemRevenueResultMap") Optional<TransactionItemRevenue> findByTransactionItemRevenueId(Long transactionItemRevenueId);
-    @Insert("INSERT INTO transaction_item_revenue (transaction_item_id,currency_code,unit_amount,quantity,total_amount) VALUES (#{transactionItemId},#{currencyCode},#{unitAmount},#{quantity},#{totalAmount})")
-    @Options(useGeneratedKeys=true,keyProperty="transactionItemRevenueId") void insert(TransactionItemRevenue revenue);
-    @Insert("INSERT INTO transaction_item_revenue (transaction_item_id,currency_code,unit_amount,quantity,total_amount) VALUES (#{transactionItemId},#{currencyCode},#{unitAmount},#{quantity},#{totalAmount}) ON DUPLICATE KEY UPDATE currency_code=VALUES(currency_code),unit_amount=VALUES(unit_amount),quantity=VALUES(quantity),total_amount=VALUES(total_amount)")
-    @Options(useGeneratedKeys=true,keyProperty="transactionItemRevenueId") void upsert(TransactionItemRevenue revenue);
-    @Delete("DELETE FROM transaction_item_revenue WHERE transaction_item_revenue_id=#{transactionItemRevenueId}") int delete(Long transactionItemRevenueId);
+    @ResultMap("transactionItemRevenueResultMap")
+    Optional<TransactionItemRevenue> findByTransactionItemRevenueId(Long transactionItemRevenueId);
+
+    @Insert("""
+            INSERT INTO transaction_item_revenue (transaction_item_id, currency_code, unit_amount, quantity, total_amount)
+            VALUES (#{transactionItemId}, #{currencyCode}, #{unitAmount}, #{quantity}, #{totalAmount})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "transactionItemRevenueId")
+    void insert(TransactionItemRevenue revenue);
+
+    @Insert("""
+            INSERT INTO transaction_item_revenue (transaction_item_id, currency_code, unit_amount, quantity, total_amount)
+            VALUES (#{transactionItemId}, #{currencyCode}, #{unitAmount}, #{quantity}, #{totalAmount})
+            ON DUPLICATE KEY UPDATE
+                currency_code = VALUES(currency_code),
+                unit_amount = VALUES(unit_amount),
+                quantity = VALUES(quantity),
+                total_amount = VALUES(total_amount)
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "transactionItemRevenueId")
+    void upsert(TransactionItemRevenue revenue);
+
+    @Delete("DELETE FROM transaction_item_revenue WHERE transaction_item_revenue_id = #{transactionItemRevenueId}")
+    int delete(Long transactionItemRevenueId);
+
     @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue WHERE transaction_item_id=#{transactionItemId}")
-    @ResultMap("transactionItemRevenueResultMap") Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId);
+    @ResultMap("transactionItemRevenueResultMap")
+    Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.java
@@ -2,12 +2,20 @@ package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.TransactionItemRevenue;
 import org.apache.ibatis.annotations.*;
+import java.util.List;
 import java.util.Optional;
 
 public interface TransactionItemRevenueMapper {
     String COLUMNS = "transaction_item_revenue_id,transaction_item_id,currency_code,unit_amount,quantity,total_amount";
+    @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue")
+    @ResultMap("transactionItemRevenueResultMap") List<TransactionItemRevenue> findAll();
+    @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue WHERE transaction_item_revenue_id=#{transactionItemRevenueId}")
+    @ResultMap("transactionItemRevenueResultMap") Optional<TransactionItemRevenue> findByTransactionItemRevenueId(Long transactionItemRevenueId);
     @Insert("INSERT INTO transaction_item_revenue (transaction_item_id,currency_code,unit_amount,quantity,total_amount) VALUES (#{transactionItemId},#{currencyCode},#{unitAmount},#{quantity},#{totalAmount})")
     @Options(useGeneratedKeys=true,keyProperty="transactionItemRevenueId") void insert(TransactionItemRevenue revenue);
+    @Insert("INSERT INTO transaction_item_revenue (transaction_item_id,currency_code,unit_amount,quantity,total_amount) VALUES (#{transactionItemId},#{currencyCode},#{unitAmount},#{quantity},#{totalAmount}) ON DUPLICATE KEY UPDATE currency_code=VALUES(currency_code),unit_amount=VALUES(unit_amount),quantity=VALUES(quantity),total_amount=VALUES(total_amount)")
+    @Options(useGeneratedKeys=true,keyProperty="transactionItemRevenueId") void upsert(TransactionItemRevenue revenue);
+    @Delete("DELETE FROM transaction_item_revenue WHERE transaction_item_revenue_id=#{transactionItemRevenueId}") int delete(Long transactionItemRevenueId);
     @Select("SELECT " + COLUMNS + " FROM transaction_item_revenue WHERE transaction_item_id=#{transactionItemId}")
     @ResultMap("transactionItemRevenueResultMap") Optional<TransactionItemRevenue> findByTransactionItemId(Long transactionItemId);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
@@ -1,0 +1,13 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.TransactionPartySnapshot;
+import org.apache.ibatis.annotations.*;
+import java.util.List;
+
+public interface TransactionPartySnapshotMapper {
+    String COLUMNS = "transaction_party_snapshot_id,transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at";
+    @Insert("INSERT INTO transaction_party_snapshot (transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at) VALUES (#{transactionId},#{partyId},#{partyRoleCode},#{displayName},#{address1},#{address2},#{city},#{state},#{postalCode},#{countryCode},#{country},#{phone},#{email},#{capturedAt})")
+    @Options(useGeneratedKeys=true,keyProperty="transactionPartySnapshotId") void insert(TransactionPartySnapshot snapshot);
+    @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot WHERE transaction_id=#{transactionId} ORDER BY transaction_party_snapshot_id")
+    @ResultMap("transactionPartySnapshotResultMap") List<TransactionPartySnapshot> findByTransactionId(Long transactionId);
+}

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
@@ -1,21 +1,70 @@
 package io.legohunter.data.mybatis.mapper;
 
 import io.legohunter.data.dto.TransactionPartySnapshot;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface TransactionPartySnapshotMapper {
-    String COLUMNS = "transaction_party_snapshot_id,transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at";
+    String COLUMNS = """
+            transaction_party_snapshot_id,
+            transaction_id,
+            party_id,
+            party_role_code,
+            display_name,
+            address1,
+            address2,
+            city,
+            state,
+            postal_code,
+            country_code,
+            country,
+            phone,
+            email,
+            captured_at
+            """;
+
     @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot")
-    @ResultMap("transactionPartySnapshotResultMap") List<TransactionPartySnapshot> findAll();
+    @ResultMap("transactionPartySnapshotResultMap")
+    List<TransactionPartySnapshot> findAll();
+
     @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot WHERE transaction_party_snapshot_id=#{transactionPartySnapshotId}")
-    @ResultMap("transactionPartySnapshotResultMap") Optional<TransactionPartySnapshot> findByTransactionPartySnapshotId(Long transactionPartySnapshotId);
-    @Insert("INSERT INTO transaction_party_snapshot (transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at) VALUES (#{transactionId},#{partyId},#{partyRoleCode},#{displayName},#{address1},#{address2},#{city},#{state},#{postalCode},#{countryCode},#{country},#{phone},#{email},#{capturedAt})")
-    @Options(useGeneratedKeys=true,keyProperty="transactionPartySnapshotId") void insert(TransactionPartySnapshot snapshot);
-    @Insert("INSERT INTO transaction_party_snapshot (transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at) VALUES (#{transactionId},#{partyId},#{partyRoleCode},#{displayName},#{address1},#{address2},#{city},#{state},#{postalCode},#{countryCode},#{country},#{phone},#{email},#{capturedAt}) ON DUPLICATE KEY UPDATE transaction_party_snapshot_id=transaction_party_snapshot_id")
-    @Options(useGeneratedKeys=true,keyProperty="transactionPartySnapshotId") void upsert(TransactionPartySnapshot snapshot);
-    @Delete("DELETE FROM transaction_party_snapshot WHERE transaction_party_snapshot_id=#{transactionPartySnapshotId}") int delete(Long transactionPartySnapshotId);
+    @ResultMap("transactionPartySnapshotResultMap")
+    Optional<TransactionPartySnapshot> findByTransactionPartySnapshotId(Long transactionPartySnapshotId);
+
+    @Insert("""
+            INSERT INTO transaction_party_snapshot (
+                transaction_id, party_id, party_role_code, display_name, address1, address2, city,
+                state, postal_code, country_code, country, phone, email, captured_at
+            ) VALUES (
+                #{transactionId}, #{partyId}, #{partyRoleCode}, #{displayName}, #{address1}, #{address2}, #{city},
+                #{state}, #{postalCode}, #{countryCode}, #{country}, #{phone}, #{email}, #{capturedAt}
+            )
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "transactionPartySnapshotId")
+    void insert(TransactionPartySnapshot snapshot);
+
+    @Insert("""
+            INSERT INTO transaction_party_snapshot (
+                transaction_id, party_id, party_role_code, display_name, address1, address2, city,
+                state, postal_code, country_code, country, phone, email, captured_at
+            ) VALUES (
+                #{transactionId}, #{partyId}, #{partyRoleCode}, #{displayName}, #{address1}, #{address2}, #{city},
+                #{state}, #{postalCode}, #{countryCode}, #{country}, #{phone}, #{email}, #{capturedAt}
+            ) ON DUPLICATE KEY UPDATE transaction_party_snapshot_id = transaction_party_snapshot_id
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "transactionPartySnapshotId")
+    void upsert(TransactionPartySnapshot snapshot);
+
+    @Delete("DELETE FROM transaction_party_snapshot WHERE transaction_party_snapshot_id = #{transactionPartySnapshotId}")
+    int delete(Long transactionPartySnapshotId);
+
     @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot WHERE transaction_id=#{transactionId} ORDER BY transaction_party_snapshot_id")
-    @ResultMap("transactionPartySnapshotResultMap") List<TransactionPartySnapshot> findByTransactionId(Long transactionId);
+    @ResultMap("transactionPartySnapshotResultMap")
+    List<TransactionPartySnapshot> findByTransactionId(Long transactionId);
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.java
@@ -3,11 +3,19 @@ package io.legohunter.data.mybatis.mapper;
 import io.legohunter.data.dto.TransactionPartySnapshot;
 import org.apache.ibatis.annotations.*;
 import java.util.List;
+import java.util.Optional;
 
 public interface TransactionPartySnapshotMapper {
     String COLUMNS = "transaction_party_snapshot_id,transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at";
+    @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot")
+    @ResultMap("transactionPartySnapshotResultMap") List<TransactionPartySnapshot> findAll();
+    @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot WHERE transaction_party_snapshot_id=#{transactionPartySnapshotId}")
+    @ResultMap("transactionPartySnapshotResultMap") Optional<TransactionPartySnapshot> findByTransactionPartySnapshotId(Long transactionPartySnapshotId);
     @Insert("INSERT INTO transaction_party_snapshot (transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at) VALUES (#{transactionId},#{partyId},#{partyRoleCode},#{displayName},#{address1},#{address2},#{city},#{state},#{postalCode},#{countryCode},#{country},#{phone},#{email},#{capturedAt})")
     @Options(useGeneratedKeys=true,keyProperty="transactionPartySnapshotId") void insert(TransactionPartySnapshot snapshot);
+    @Insert("INSERT INTO transaction_party_snapshot (transaction_id,party_id,party_role_code,display_name,address1,address2,city,state,postal_code,country_code,country,phone,email,captured_at) VALUES (#{transactionId},#{partyId},#{partyRoleCode},#{displayName},#{address1},#{address2},#{city},#{state},#{postalCode},#{countryCode},#{country},#{phone},#{email},#{capturedAt}) ON DUPLICATE KEY UPDATE transaction_party_snapshot_id=transaction_party_snapshot_id")
+    @Options(useGeneratedKeys=true,keyProperty="transactionPartySnapshotId") void upsert(TransactionPartySnapshot snapshot);
+    @Delete("DELETE FROM transaction_party_snapshot WHERE transaction_party_snapshot_id=#{transactionPartySnapshotId}") int delete(Long transactionPartySnapshotId);
     @Select("SELECT " + COLUMNS + " FROM transaction_party_snapshot WHERE transaction_id=#{transactionId} ORDER BY transaction_party_snapshot_id")
     @ResultMap("transactionPartySnapshotResultMap") List<TransactionPartySnapshot> findByTransactionId(Long transactionId);
 }

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/PartyExternalIdentityMapper.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.PartyExternalIdentityMapper">
+  <resultMap id="partyExternalIdentityResultMap" type="io.legohunter.data.dto.PartyExternalIdentity">
+    <id column="party_external_identity_id" property="partyExternalIdentityId"/>
+    <result column="party_id" property="partyId"/>
+    <result column="transaction_platform_id" property="transactionPlatformId"/>
+    <result column="external_party_id" property="externalPartyId"/>
+    <result column="created_at" property="createdAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ShipmentMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ShipmentMapper.xml
@@ -4,7 +4,6 @@
     <id column="shipment_id" property="shipmentId"/><result column="external_shipment_id" property="externalShipmentId"/>
     <result column="shipment_date" property="shipmentDate"/><result column="shipment_tracking_number" property="shipmentTrackingNumber"/>
     <result column="carrier_code" property="carrierCode"/><result column="fulfillment_platform_code" property="fulfillmentPlatformCode"/>
-    <result column="service_code" property="serviceCode"/><result column="shipment_cost" property="shipmentCost"/>
-    <result column="insurance_cost" property="insuranceCost"/><result column="currency_code" property="currencyCode"/>
+    <result column="service_code" property="serviceCode"/>
   </resultMap>
 </mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ShipmentMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/ShipmentMapper.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.ShipmentMapper">
+  <resultMap id="shipmentResultMap" type="io.legohunter.data.dto.Shipment">
+    <id column="shipment_id" property="shipmentId"/><result column="external_shipment_id" property="externalShipmentId"/>
+    <result column="shipment_date" property="shipmentDate"/><result column="shipment_tracking_number" property="shipmentTrackingNumber"/>
+    <result column="carrier_code" property="carrierCode"/><result column="fulfillment_platform_code" property="fulfillmentPlatformCode"/>
+    <result column="service_code" property="serviceCode"/><result column="shipment_cost" property="shipmentCost"/>
+    <result column="insurance_cost" property="insuranceCost"/><result column="currency_code" property="currencyCode"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/TransactionItemRevenueMapper.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.TransactionItemRevenueMapper">
+  <resultMap id="transactionItemRevenueResultMap" type="io.legohunter.data.dto.TransactionItemRevenue">
+    <id column="transaction_item_revenue_id" property="transactionItemRevenueId"/>
+    <result column="transaction_item_id" property="transactionItemId"/><result column="currency_code" property="currencyCode"/>
+    <result column="unit_amount" property="unitAmount"/><result column="quantity" property="quantity"/>
+    <result column="total_amount" property="totalAmount"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.xml
+++ b/lego-data-mybatis/src/main/resources/io/legohunter/data/mybatis/mapper/TransactionPartySnapshotMapper.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.legohunter.data.mybatis.mapper.TransactionPartySnapshotMapper">
+  <resultMap id="transactionPartySnapshotResultMap" type="io.legohunter.data.dto.TransactionPartySnapshot">
+    <id column="transaction_party_snapshot_id" property="transactionPartySnapshotId"/>
+    <result column="transaction_id" property="transactionId"/>
+    <result column="party_id" property="partyId"/>
+    <result column="party_role_code" property="partyRoleCode"/>
+    <result column="display_name" property="displayName"/>
+    <result column="address1" property="address1"/><result column="address2" property="address2"/>
+    <result column="city" property="city"/><result column="state" property="state"/>
+    <result column="postal_code" property="postalCode"/><result column="country_code" property="countryCode"/>
+    <result column="country" property="country"/><result column="phone" property="phone"/>
+    <result column="email" property="email"/><result column="captured_at" property="capturedAt"/>
+  </resultMap>
+</mapper>

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/Phase1AccountingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/Phase1AccountingMapperTest.java
@@ -1,0 +1,104 @@
+package io.legohunter.data.mybatis.mapper;
+
+import io.legohunter.data.dto.PartyExternalIdentity;
+import io.legohunter.data.dto.Shipment;
+import io.legohunter.data.dto.TransactionItemRevenue;
+import io.legohunter.data.dto.TransactionPartySnapshot;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MapperIntegrationTest
+class Phase1AccountingMapperTest {
+    @Autowired PartyExternalIdentityMapper partyExternalIdentityMapper;
+    @Autowired TransactionPartySnapshotMapper transactionPartySnapshotMapper;
+    @Autowired TransactionItemRevenueMapper transactionItemRevenueMapper;
+    @Autowired ShipmentMapper shipmentMapper;
+
+    @Test
+    void partyExternalIdentitySupportsCrud() {
+        PartyExternalIdentity identity = PartyExternalIdentity.builder()
+                .partyId(1L).transactionPlatformId(1).externalPartyId("buyer-1").build();
+        partyExternalIdentityMapper.insert(identity);
+
+        assertThat(partyExternalIdentityMapper.findAll()).singleElement()
+                .satisfies(found -> assertThat(found.getPartyExternalIdentityId()).isEqualTo(identity.getPartyExternalIdentityId()));
+        assertThat(partyExternalIdentityMapper.findByPartyExternalIdentityId(identity.getPartyExternalIdentityId()))
+                .hasValueSatisfying(found -> assertThat(found.getExternalPartyId()).isEqualTo("buyer-1"));
+
+        identity.setPartyId(2L);
+        partyExternalIdentityMapper.upsert(identity);
+        assertThat(partyExternalIdentityMapper.findByPlatformAndExternalPartyId(1, "buyer-1"))
+                .hasValueSatisfying(found -> assertThat(found.getPartyId()).isEqualTo(2L));
+
+        assertThat(partyExternalIdentityMapper.delete(identity.getPartyExternalIdentityId())).isOne();
+        assertThat(partyExternalIdentityMapper.findByPartyExternalIdentityId(identity.getPartyExternalIdentityId())).isEmpty();
+    }
+
+    @Test
+    void transactionPartySnapshotSupportsCrudWithoutMutatingHistoricalSnapshot() {
+        TransactionPartySnapshot snapshot = TransactionPartySnapshot.builder()
+                .transactionId(1L).partyId(1L).partyRoleCode("BUYER").displayName("Original buyer")
+                .capturedAt(ZonedDateTime.parse("2026-08-28T12:00:00Z")).build();
+        transactionPartySnapshotMapper.insert(snapshot);
+
+        assertThat(transactionPartySnapshotMapper.findAll()).singleElement()
+                .satisfies(found -> assertThat(found.getTransactionPartySnapshotId()).isEqualTo(snapshot.getTransactionPartySnapshotId()));
+        assertThat(transactionPartySnapshotMapper.findByTransactionPartySnapshotId(snapshot.getTransactionPartySnapshotId()))
+                .hasValueSatisfying(found -> assertThat(found.getDisplayName()).isEqualTo("Original buyer"));
+
+        snapshot.setDisplayName("Changed buyer");
+        transactionPartySnapshotMapper.upsert(snapshot);
+        assertThat(transactionPartySnapshotMapper.findByTransactionPartySnapshotId(snapshot.getTransactionPartySnapshotId()))
+                .hasValueSatisfying(found -> assertThat(found.getDisplayName()).isEqualTo("Original buyer"));
+
+        assertThat(transactionPartySnapshotMapper.delete(snapshot.getTransactionPartySnapshotId())).isOne();
+        assertThat(transactionPartySnapshotMapper.findByTransactionPartySnapshotId(snapshot.getTransactionPartySnapshotId())).isEmpty();
+    }
+
+    @Test
+    void transactionItemRevenueSupportsCrud() {
+        TransactionItemRevenue revenue = TransactionItemRevenue.builder()
+                .transactionItemId(1L).currencyCode("USD").unitAmount(new BigDecimal("4.50"))
+                .quantity(2).totalAmount(new BigDecimal("9.00")).build();
+        transactionItemRevenueMapper.insert(revenue);
+
+        assertThat(transactionItemRevenueMapper.findAll()).singleElement()
+                .satisfies(found -> assertThat(found.getTransactionItemRevenueId()).isEqualTo(revenue.getTransactionItemRevenueId()));
+        assertThat(transactionItemRevenueMapper.findByTransactionItemRevenueId(revenue.getTransactionItemRevenueId()))
+                .hasValueSatisfying(found -> assertThat(found.getTotalAmount()).isEqualByComparingTo("9.00"));
+
+        revenue.setTotalAmount(new BigDecimal("10.00"));
+        transactionItemRevenueMapper.upsert(revenue);
+        assertThat(transactionItemRevenueMapper.findByTransactionItemId(1L))
+                .hasValueSatisfying(found -> assertThat(found.getTotalAmount()).isEqualByComparingTo("10.00"));
+
+        assertThat(transactionItemRevenueMapper.delete(revenue.getTransactionItemRevenueId())).isOne();
+        assertThat(transactionItemRevenueMapper.findByTransactionItemRevenueId(revenue.getTransactionItemRevenueId())).isEmpty();
+    }
+
+    @Test
+    void shipmentSupportsCrud() {
+        Shipment shipment = Shipment.builder()
+                .externalShipmentId("ss-1").shipmentDate(LocalDate.parse("2026-08-28"))
+                .shipmentTrackingNumber("TRACK-1").carrierCode("USPS")
+                .fulfillmentPlatformCode("SHIPSTATION").serviceCode("USPS_GROUND_ADVANTAGE").build();
+        shipmentMapper.insert(shipment);
+
+        assertThat(shipmentMapper.findAll()).containsExactly(shipment);
+        assertThat(shipmentMapper.findByShipmentId(shipment.getShipmentId())).contains(shipment);
+
+        shipment.setShipmentTrackingNumber("TRACK-2");
+        shipmentMapper.upsert(shipment);
+        assertThat(shipmentMapper.findByPlatformAndExternalShipmentId("SHIPSTATION", "ss-1"))
+                .hasValueSatisfying(found -> assertThat(found.getShipmentTrackingNumber()).isEqualTo("TRACK-2"));
+
+        assertThat(shipmentMapper.delete(shipment.getShipmentId())).isOne();
+        assertThat(shipmentMapper.findByShipmentId(shipment.getShipmentId())).isEmpty();
+    }
+}

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -705,9 +705,6 @@ CREATE TABLE shipment (
     carrier_code VARCHAR(10) NOT NULL,
     fulfillment_platform_code VARCHAR(30),
     service_code VARCHAR(100),
-    shipment_cost DECIMAL(12,4),
-    insurance_cost DECIMAL(12,4),
-    currency_code VARCHAR(8),
     CONSTRAINT uq_shipment_platform_external UNIQUE (fulfillment_platform_code, external_shipment_id)
 );
 

--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -1,4 +1,9 @@
 DROP TABLE IF EXISTS marketplace_order_transaction_link;
+DROP TABLE IF EXISTS transaction_item_shipment;
+DROP TABLE IF EXISTS transaction_item_revenue;
+DROP TABLE IF EXISTS transaction_party_snapshot;
+DROP TABLE IF EXISTS party_external_identity;
+DROP TABLE IF EXISTS shipment;
 DROP TABLE IF EXISTS marketplace_order_payload;
 DROP TABLE IF EXISTS marketplace_order_item;
 DROP TABLE IF EXISTS marketplace_order;
@@ -650,7 +655,8 @@ CREATE TABLE transactions (
     from_party_id BIGINT,
     to_party_id BIGINT,
     transaction_platform_id INT,
-    transaction_order_id VARCHAR(255)
+    transaction_order_id VARCHAR(255),
+    CONSTRAINT uq_transactions_platform_order UNIQUE (transaction_platform_id, transaction_order_id)
 );
 
 CREATE TABLE payment (
@@ -689,6 +695,64 @@ CREATE TABLE transaction_item_cost (
     currency_code VARCHAR(8),
     amount DOUBLE,
     notes VARCHAR(2048)
+);
+
+CREATE TABLE shipment (
+    shipment_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    external_shipment_id VARCHAR(100),
+    shipment_date DATE NOT NULL,
+    shipment_tracking_number VARCHAR(45),
+    carrier_code VARCHAR(10) NOT NULL,
+    fulfillment_platform_code VARCHAR(30),
+    service_code VARCHAR(100),
+    shipment_cost DECIMAL(12,4),
+    insurance_cost DECIMAL(12,4),
+    currency_code VARCHAR(8),
+    CONSTRAINT uq_shipment_platform_external UNIQUE (fulfillment_platform_code, external_shipment_id)
+);
+
+CREATE TABLE transaction_item_shipment (
+    item_transaction_id BIGINT NOT NULL,
+    shipment_id BIGINT NOT NULL,
+    PRIMARY KEY (item_transaction_id, shipment_id)
+);
+
+CREATE TABLE party_external_identity (
+    party_external_identity_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    party_id BIGINT NOT NULL,
+    transaction_platform_id INT NOT NULL,
+    external_party_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_party_external_identity_platform_party UNIQUE (transaction_platform_id, external_party_id)
+);
+
+CREATE TABLE transaction_party_snapshot (
+    transaction_party_snapshot_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    transaction_id BIGINT NOT NULL,
+    party_id BIGINT NOT NULL,
+    party_role_code VARCHAR(16) NOT NULL,
+    display_name VARCHAR(255),
+    address1 VARCHAR(255),
+    address2 VARCHAR(255),
+    city VARCHAR(255),
+    state VARCHAR(64),
+    postal_code VARCHAR(64),
+    country_code VARCHAR(8),
+    country VARCHAR(255),
+    phone VARCHAR(64),
+    email VARCHAR(255),
+    captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_transaction_party_snapshot_role UNIQUE (transaction_id, party_role_code)
+);
+
+CREATE TABLE transaction_item_revenue (
+    transaction_item_revenue_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    transaction_item_id BIGINT NOT NULL,
+    currency_code VARCHAR(8) NOT NULL,
+    unit_amount DECIMAL(12,4) NOT NULL,
+    quantity INT NOT NULL,
+    total_amount DECIMAL(12,4) NOT NULL,
+    CONSTRAINT uq_transaction_item_revenue_item UNIQUE (transaction_item_id)
 );
 
 ALTER TABLE external_service


### PR DESCRIPTION
## Summary

BrickLink Order Ingestion and Accounting ? Phase 1: Canonical sale-accounting foundation.

This repository supplies the shared Java/MyBatis persistence contract for the later ingress projection. The safe intermediate state is additive and unused by existing workflows; BrickLink polling and ShipStation fulfillment remain on their present path. Runtime projection and API work are deferred.

## Detailed Breakdown

- Aligns the Phase 1 H2 foreign-key columns with the existing SANDBOX INT canonical keys.

- Adds DTOs, MyBatis mappings, and DAOs for platform-scoped party identities and immutable transaction-party snapshots.
- Adds `TransactionItemRevenue` persistence using `BigDecimal`, separate from transaction and item costs.
- Adds shipment persistence for external ShipStation identity, fulfillment platform, carrier, and service metadata.
- Provides `findAll`, primary-key `findBy...`, `upsert`, and `delete` on every Phase 1 DAO/mapper pair: party external identity, transaction-party snapshot, transaction-item revenue, and shipment.
- Keeps transaction-party snapshots immutable: their upsert is idempotent on the transaction/role key and never overwrites historical data.
- Keeps shipping and insurance out of shipment persistence; optional amounts will be persisted as `transaction_cost` records.
- Extends the H2 schema with the same shipment shape and transaction platform/order unique constraint.

### Validation

- `mvn -pl lego-data-mybatis,lego-data-dao -am test -DskipTests=false`
- Result: passed; 66 mapper tests and 82 DAO tests passed, including CRUD integration coverage and DAO delegation coverage for all four Phase 1 persistence pairs.

## PR Review Roadmap

1. Review DTO semantics: item revenue, costs, and immutable party snapshots.
2. Review MyBatis mappings and the CRUD contract against the companion Phase 1 Liquibase migration.
3. Verify snapshot upsert is idempotent rather than mutating historical records.
4. Verify shipment is metadata-only and money remains in transaction accounting.
5. Review the H2 CRUD integration tests and DAO delegation tests.
6. Approve this shared contract after the database migration; Phase 2 projection remains intentionally absent.
