### PR TITLE
Phase 1 follow-up — Align accounting test foreign keys

### DIFF
--- a/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
+++ b/lego-data-mybatis/src/test/resources/scripts/db/h2/current_schema.ddl
@@ -716,7 +716,7 @@ CREATE TABLE transaction_item_shipment (
 
 CREATE TABLE party_external_identity (
     party_external_identity_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    party_id BIGINT NOT NULL,
+    party_id INT NOT NULL,
     transaction_platform_id INT NOT NULL,
     external_party_id VARCHAR(255) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -725,8 +725,8 @@ CREATE TABLE party_external_identity (
 
 CREATE TABLE transaction_party_snapshot (
     transaction_party_snapshot_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    transaction_id BIGINT NOT NULL,
-    party_id BIGINT NOT NULL,
+    transaction_id INT NOT NULL,
+    party_id INT NOT NULL,
     party_role_code VARCHAR(16) NOT NULL,
     display_name VARCHAR(255),
     address1 VARCHAR(255),
@@ -744,7 +744,7 @@ CREATE TABLE transaction_party_snapshot (
 
 CREATE TABLE transaction_item_revenue (
     transaction_item_revenue_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    transaction_item_id BIGINT NOT NULL,
+    transaction_item_id INT NOT NULL,
     currency_code VARCHAR(8) NOT NULL,
     unit_amount DECIMAL(12,4) NOT NULL,
     quantity INT NOT NULL,


### PR DESCRIPTION
## Summary

BrickLink Order Ingestion and Accounting ? Phase 1 compatibility follow-up.

The original Phase 1 persistence contract has merged. This follow-up keeps the H2 test schema aligned with the corrected SANDBOX-compatible migration. Runtime projection and API work remain deferred.

## Detailed Breakdown

- Changes the four Phase 1 H2 foreign-key columns to `INT`, matching the legacy canonical table keys.
- Preserves the Phase 1 DTO, mapper, DAO, and CRUD contracts.
- Ensures mapper integration tests exercise the same key widths as the corrected migration.

### Validation

- `mvn -pl lego-data-mybatis,lego-data-dao -am test -DskipTests=false` passed.
- Result: 66 mapper tests and 82 DAO tests passed.
- GitHub comparison against merged `develop` contains only the four H2 type corrections.

## PR Review Roadmap

1. Review the H2 schema changes alongside the database-deployer compatibility PR.
2. Confirm all four columns reference existing `INT` canonical keys.
3. Confirm no persistence API contract changes in this follow-up.
4. Review the successful mapper/DAO suite.
5. Phase 2 projection remains intentionally absent.
