### PR TITLE
Phase 2 — Add BrickLink order projection lookups

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderTransactionLinkDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/MarketplaceOrderTransactionLinkDao.java
@@ -21,6 +21,14 @@ public class MarketplaceOrderTransactionLinkDao {
         return marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(marketplaceOrderTransactionLinkId);
     }
 
+    public Set<MarketplaceOrderTransactionLink> findByMarketplaceOrderId(Integer marketplaceOrderId) {
+        return marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderId(marketplaceOrderId);
+    }
+
+    public Set<MarketplaceOrderTransactionLink> findByMarketplaceOrderItemId(Integer marketplaceOrderItemId) {
+        return marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderItemId(marketplaceOrderItemId);
+    }
+
     public MarketplaceOrderTransactionLink insert(MarketplaceOrderTransactionLink marketplaceOrderTransactionLink) {
         marketplaceOrderTransactionLinkMapper.insert(marketplaceOrderTransactionLink);
         return marketplaceOrderTransactionLink;

--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionsDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/TransactionsDao.java
@@ -28,4 +28,14 @@ public class TransactionsDao {
     public Optional<Transactions> findById(Long transactionId) {
         return transactionsMapper.findById(transactionId);
     }
+
+    public Optional<Transactions> findByTransactionPlatformIdAndTransactionOrderId(
+            Integer transactionPlatformId,
+            String transactionOrderId
+    ) {
+        return transactionsMapper.findByTransactionPlatformIdAndTransactionOrderId(
+                transactionPlatformId,
+                transactionOrderId
+        );
+    }
 }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
@@ -197,6 +197,12 @@ class MarketplaceOrderSyncDaoTest {
 
         assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
                 .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("UNLINKED"));
+        assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .extracting(MarketplaceOrderTransactionLink::getMarketplaceOrderTransactionLinkId)
+                .containsExactly(link.getMarketplaceOrderTransactionLinkId());
+        assertThat(marketplaceOrderTransactionLinkDao.findByMarketplaceOrderItemId(orderItem.getMarketplaceOrderItemId()))
+                .extracting(MarketplaceOrderTransactionLink::getMarketplaceOrderTransactionLinkId)
+                .containsExactly(link.getMarketplaceOrderTransactionLinkId());
         assertThat(marketplaceOrderTransactionLinkDao.findAll()).hasSize(1);
 
         link.setLinkStatusCode("ACTIVE");

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderTransactionLinkMapper.java
@@ -34,6 +34,14 @@ public interface MarketplaceOrderTransactionLinkMapper {
     @ResultMap("marketplaceOrderTransactionLinkResultMap")
     Optional<MarketplaceOrderTransactionLink> findByMarketplaceOrderTransactionLinkId(Integer marketplaceOrderTransactionLinkId);
 
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_transaction_link WHERE marketplace_order_id = #{marketplaceOrderId} ORDER BY marketplace_order_transaction_link_id")
+    @ResultMap("marketplaceOrderTransactionLinkResultMap")
+    Set<MarketplaceOrderTransactionLink> findByMarketplaceOrderId(Integer marketplaceOrderId);
+
+    @Select("SELECT " + ALL_COLUMNS + " FROM marketplace_order_transaction_link WHERE marketplace_order_item_id = #{marketplaceOrderItemId} ORDER BY marketplace_order_transaction_link_id")
+    @ResultMap("marketplaceOrderTransactionLinkResultMap")
+    Set<MarketplaceOrderTransactionLink> findByMarketplaceOrderItemId(Integer marketplaceOrderItemId);
+
     @Insert("""
             INSERT INTO marketplace_order_transaction_link (
                 marketplace_order_id,

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionsMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/TransactionsMapper.java
@@ -64,4 +64,22 @@ public interface TransactionsMapper {
             """)
     @ResultMap("transactionResultMap")
     Optional<Transactions> findById(Long transactionId);
+
+    @Select("""
+            select transaction_id,
+                   transaction_date,
+                   notes,
+                   from_party_id,
+                   to_party_id,
+                   transaction_platform_id,
+                   transaction_order_id
+            from transactions
+            where transaction_platform_id = #{transactionPlatformId}
+              and transaction_order_id = #{transactionOrderId}
+            """)
+    @ResultMap("transactionResultMap")
+    Optional<Transactions> findByTransactionPlatformIdAndTransactionOrderId(
+            @Param("transactionPlatformId") Integer transactionPlatformId,
+            @Param("transactionOrderId") String transactionOrderId
+    );
 }

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
@@ -193,6 +193,12 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
 
         assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderTransactionLinkId(link.getMarketplaceOrderTransactionLinkId()))
                 .hasValueSatisfying(found -> assertThat(found.getLinkStatusCode()).isEqualTo("UNLINKED"));
+        assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderId(order.getMarketplaceOrderId()))
+                .extracting(MarketplaceOrderTransactionLink::getMarketplaceOrderTransactionLinkId)
+                .containsExactly(link.getMarketplaceOrderTransactionLinkId());
+        assertThat(marketplaceOrderTransactionLinkMapper.findByMarketplaceOrderItemId(orderItem.getMarketplaceOrderItemId()))
+                .extracting(MarketplaceOrderTransactionLink::getMarketplaceOrderTransactionLinkId)
+                .containsExactly(link.getMarketplaceOrderTransactionLinkId());
         assertThat(marketplaceOrderTransactionLinkMapper.findAll()).hasSize(1);
 
         link.setLinkStatusCode("ACTIVE");

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/TransactionsMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/TransactionsMapperTest.java
@@ -18,6 +18,10 @@ class TransactionsMapperTest extends MapperTestSupport {
 
         assertThat(transactionsMapper.findById(transaction.getTransactionId()))
                 .hasValueSatisfying(found -> assertThat(found.getNotes()).isEqualTo("Updated transaction"));
+        assertThat(transactionsMapper.findByTransactionPlatformIdAndTransactionOrderId(
+                transaction.getTransactionPlatformId(),
+                transaction.getTransactionOrderId()
+        )).hasValueSatisfying(found -> assertThat(found.getTransactionId()).isEqualTo(transaction.getTransactionId()));
         assertThat(transactionsMapper.findAll()).hasSize(1);
 
         Transactions migratedTransaction = Transactions.builder()


### PR DESCRIPTION
## Summary

BrickLink Order Ingestion and Accounting — Phase 2: BrickLink order projection into canonical transactions.

This repository supplies the persistence lookups used by `lego-data-ingress` to make canonical transaction projection idempotent. The safe intermediate state is additive read support only: it consumes the Phase 1 unique transaction-order key and existing marketplace link table without a schema migration. ShipStation push/reconciliation and shipment persistence remain deferred to later phases.

## Detailed Breakdown

- Adds lookup of a canonical transaction by `(transaction_platform_id, transaction_order_id)`.
- Adds marketplace-order and marketplace-order-item link lookups.
- Covers each new mapper/DAO lookup with H2-backed integration tests.
- These APIs allow ingress to discover an existing open/invoiced projection rather than duplicate transactions or transaction items.

### Validation

- `mvn -pl lego-data-mybatis,lego-data-dao -am test -DskipTests=false` — passed (66 mapper tests, 82 DAO tests).
- The lookup contract relies on the Phase 1 `uq_transactions_platform_order` migration already merged and deployed to SANDBOX.

## PR Review Roadmap

1. Review `TransactionsMapper` and `TransactionsDao` for natural-key lookup semantics.
2. Review the marketplace link lookup additions and their mapper/DAO integration tests.
3. Confirm the additions are read-only and require no new migration or Workbench update.
4. Approve the persistence contract consumed by the companion Phase 2 ingress PR.

This phase depends on the merged Phase 1 accounting foundation. It intentionally excludes ShipStation lifecycle work and shipment reconciliation. Its exit gate is review and merge of this PR and the companion ingress PR before a later phase builds on the Phase 2 canonical projection behavior.