### PR TITLE
Phase 3: support canonical fulfillment shipment reconciliation

### DIFF
--- a/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
+++ b/lego-data-dao/src/main/java/io/legohunter/data/dao/ShipmentDao.java
@@ -17,4 +17,5 @@ public class ShipmentDao {
     public int delete(Long shipmentId) { return mapper.delete(shipmentId); }
     public Optional<Shipment> findByPlatformAndExternalShipmentId(String platformCode, String externalShipmentId) { return mapper.findByPlatformAndExternalShipmentId(platformCode, externalShipmentId); }
     public void linkTransactionItem(Long transactionItemId, Long shipmentId) { mapper.linkTransactionItem(transactionItemId, shipmentId); }
+    public List<Long> findTransactionItemIdsByShipmentId(Long shipmentId) { return mapper.findTransactionItemIdsByShipmentId(shipmentId); }
 }

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/MarketplaceOrderSyncDaoTest.java
@@ -94,10 +94,13 @@ class MarketplaceOrderSyncDaoTest {
     void marketplaceOrderDaoFindsFulfillmentCandidatesAcrossStatuses() {
         MarketplaceOrder pending = insertedOrder("DAO-BL-CANDIDATE-1");
         marketplaceOrderItemDao.insert(marketplaceOrderItem(pending.getMarketplaceOrderId()));
+        TransactionItem canonicalItem = insertedTransactionItem();
+        markInvoicedAndProjected(pending, canonicalItem.getTransactionId());
         MarketplaceOrder ready = insertedOrder("DAO-BL-CANDIDATE-2");
         ready.setExternalStatusCode("READY");
         marketplaceOrderDao.update(ready);
         marketplaceOrderItemDao.insert(marketplaceOrderItem(ready.getMarketplaceOrderId()));
+        markInvoicedAndProjected(ready, canonicalItem.getTransactionId());
         MarketplaceOrder withoutItems = insertedOrder("DAO-BL-CANDIDATE-3");
 
         assertThat(marketplaceOrderDao.findFulfillmentCandidates("BRICKLINK", List.of("PENDING", "READY"), 10))
@@ -258,6 +261,18 @@ class MarketplaceOrderSyncDaoTest {
                 .build();
         transactionItemDao.insert(transactionItem);
         return transactionItem;
+    }
+
+    private void markInvoicedAndProjected(MarketplaceOrder order, Long transactionId) {
+        order.setInvoiced(true);
+        marketplaceOrderDao.update(order);
+        marketplaceOrderTransactionLinkDao.insert(MarketplaceOrderTransactionLink.builder()
+                .marketplaceOrderId(order.getMarketplaceOrderId())
+                .transactionId(transactionId)
+                .linkTypeCode("ORDER")
+                .linkStatusCode("INVOICED")
+                .linkedAt(STARTED_AT.plusHours(1))
+                .build());
     }
 
     private Party party(String name) {

--- a/lego-data-dao/src/test/java/io/legohunter/data/dao/Phase1AccountingDaoUnitTest.java
+++ b/lego-data-dao/src/test/java/io/legohunter/data/dao/Phase1AccountingDaoUnitTest.java
@@ -79,7 +79,10 @@ class Phase1AccountingDaoUnitTest {
         assertThat(dao.upsert(value)).isSameAs(value);
         assertThat(dao.findAll()).containsExactly(value);
         assertThat(dao.findByShipmentId(1L)).contains(value);
+        when(mapper.findTransactionItemIdsByShipmentId(1L)).thenReturn(List.of(10L));
+        assertThat(dao.findTransactionItemIdsByShipmentId(1L)).containsExactly(10L);
+        dao.linkTransactionItem(10L, 1L);
         dao.delete(1L);
-        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).delete(1L);
+        verify(mapper).insert(value); verify(mapper).upsert(value); verify(mapper).linkTransactionItem(10L, 1L); verify(mapper).delete(1L);
     }
 }

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderMapper.java
@@ -68,10 +68,18 @@ public interface MarketplaceOrderMapper {
             @Param("marketplaceCode") String marketplaceCode,
             @Param("externalOrderId") String externalOrderId);
 
-    @Select("SELECT " + ALL_COLUMNS + """
-            FROM marketplace_order mo
+    @Select("""
+            SELECT mo.*
+            FROM transactions t
+            JOIN marketplace_order_transaction_link motl
+              ON motl.transaction_id = t.transaction_id
+             AND motl.link_type_code = 'ORDER'
+             AND motl.link_status_code = 'INVOICED'
+            JOIN marketplace_order mo
+              ON mo.marketplace_order_id = motl.marketplace_order_id
             WHERE mo.marketplace_code = #{marketplaceCode}
               AND mo.external_status_code = #{externalStatusCode}
+              AND mo.is_invoiced = TRUE
               AND EXISTS (
                   SELECT 1
                   FROM marketplace_order_item moi

--- a/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
+++ b/lego-data-mybatis/src/main/java/io/legohunter/data/mybatis/mapper/ShipmentMapper.java
@@ -70,10 +70,24 @@ public interface ShipmentMapper {
 
     @Insert("""
             INSERT INTO transaction_item_shipment (item_transaction_id, shipment_id)
-            VALUES (#{transactionItemId}, #{shipmentId})
+            SELECT #{transactionItemId}, #{shipmentId}
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM transaction_item_shipment
+                WHERE item_transaction_id = #{transactionItemId}
+                  AND shipment_id = #{shipmentId}
+            )
             """)
     void linkTransactionItem(
             @Param("transactionItemId") Long transactionItemId,
             @Param("shipmentId") Long shipmentId
     );
+
+    @Select("""
+            SELECT item_transaction_id
+            FROM transaction_item_shipment
+            WHERE shipment_id = #{shipmentId}
+            ORDER BY item_transaction_id
+            """)
+    List<Long> findTransactionItemIdsByShipmentId(@Param("shipmentId") Long shipmentId);
 }

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/MarketplaceOrderSyncMapperTest.java
@@ -77,11 +77,14 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
     void marketplaceOrderFindsFulfillmentCandidatesWithOrderItems() {
         MarketplaceOrder candidate = insertedOrder("BL-CANDIDATE-1");
         insertedOrderItem(candidate.getMarketplaceOrderId());
+        TransactionItem canonicalItem = insertedTransactionItem();
+        markInvoicedAndProjected(candidate, canonicalItem.getTransactionId());
         MarketplaceOrder withoutItems = insertedOrder("BL-CANDIDATE-2");
         MarketplaceOrder shipped = insertedOrder("BL-CANDIDATE-3");
         shipped.setExternalStatusCode("SHIPPED");
         marketplaceOrderMapper.update(shipped);
         insertedOrderItem(shipped.getMarketplaceOrderId());
+        markInvoicedAndProjected(shipped, canonicalItem.getTransactionId());
 
         assertThat(marketplaceOrderMapper.findFulfillmentCandidatesByStatus("BRICKLINK", "PENDING", 10))
                 .extracting(MarketplaceOrder::getMarketplaceOrderId)
@@ -244,6 +247,18 @@ class MarketplaceOrderSyncMapperTest extends MapperTestSupport {
                 .build();
         transactionItemMapper.insert(transactionItem);
         return transactionItem;
+    }
+
+    private void markInvoicedAndProjected(MarketplaceOrder order, Long transactionId) {
+        order.setInvoiced(true);
+        marketplaceOrderMapper.update(order);
+        marketplaceOrderTransactionLinkMapper.insert(MarketplaceOrderTransactionLink.builder()
+                .marketplaceOrderId(order.getMarketplaceOrderId())
+                .transactionId(transactionId)
+                .linkTypeCode("ORDER")
+                .linkStatusCode("INVOICED")
+                .linkedAt(STARTED_AT.plusHours(1))
+                .build());
     }
 
     private MarketplaceOrderSyncRun marketplaceOrderSyncRun() {

--- a/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/Phase1AccountingMapperTest.java
+++ b/lego-data-mybatis/src/test/java/io/legohunter/data/mybatis/mapper/Phase1AccountingMapperTest.java
@@ -101,4 +101,19 @@ class Phase1AccountingMapperTest {
         assertThat(shipmentMapper.delete(shipment.getShipmentId())).isOne();
         assertThat(shipmentMapper.findByShipmentId(shipment.getShipmentId())).isEmpty();
     }
+
+    @Test
+    void shipmentTransactionItemLinksAreIdempotent() {
+        Shipment shipment = Shipment.builder()
+                .externalShipmentId("ss-link-1").shipmentDate(LocalDate.parse("2026-08-28"))
+                .shipmentTrackingNumber("TRACK-LINK-1").carrierCode("USPS")
+                .fulfillmentPlatformCode("SHIPSTATION").serviceCode("USPS_GROUND_ADVANTAGE").build();
+        shipmentMapper.insert(shipment);
+
+        shipmentMapper.linkTransactionItem(101L, shipment.getShipmentId());
+        shipmentMapper.linkTransactionItem(101L, shipment.getShipmentId());
+
+        assertThat(shipmentMapper.findTransactionItemIdsByShipmentId(shipment.getShipmentId()))
+                .containsExactly(101L);
+    }
 }


### PR DESCRIPTION
## Summary

Phase 3 of BrickLink Order Ingestion and Accounting makes fulfillment eligibility follow the immutable canonical invoice projection and makes canonical transaction-item shipment links safely idempotent.

## Detailed Breakdown

- Limits fulfillment candidates to BrickLink marketplace orders that have a matching canonical `ORDER` link in `INVOICED` state, a staged invoiced flag, and at least one staged item.
- Makes `transaction_item_shipment` writes idempotent and exposes the linked transaction-item IDs for the shipment persistence contract.
- Updates mapper and DAO coverage to model the required canonical invoice projection.
- Uses the already deployed shipment association model; no Liquibase, H2 schema, or MySQL Workbench model change is required for this phase.

### Validation

- `mvn -pl lego-data-mybatis,lego-data-dao -am test` passed.
- `mvn install -DskipTests` passed to install the Phase 3 snapshot for the ingress reactor.
- `git diff --check` passed.

## PR Review Roadmap

1. Review the fulfillment-candidate query and its canonical invoice gate.
2. Review the portable idempotent shipment-item link and its mapper/DAO tests.
3. Confirm the existing schema is sufficient and that no migration/model change is expected in this Phase 3 slice.